### PR TITLE
add `yw_to_w()` abstract method to `SparseMatrix`

### DIFF
--- a/saiunit/_base.py
+++ b/saiunit/_base.py
@@ -76,7 +76,6 @@ compat_with_equinox = False
 A = TypeVar('A')
 
 
-
 def compatible_with_equinox(mode: bool = True):
     """
     This function is developed to set the compatibility with equinox.

--- a/saiunit/_base_test.py
+++ b/saiunit/_base_test.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import itertools
 import os
 import pickle
-import sys
 import tempfile
 import unittest
 import warnings
@@ -30,7 +29,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from numpy.ma.core import indices
 from numpy.testing import assert_equal
 
 import saiunit as u

--- a/saiunit/_sparse_base.py
+++ b/saiunit/_sparse_base.py
@@ -15,8 +15,12 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+import numbers
+from abc import ABC
+from typing import Sequence, Union
 
+import jax
+import numpy as np
 from jax.experimental.sparse import JAXSparse
 
 __all__ = [
@@ -24,74 +28,121 @@ __all__ = [
 ]
 
 
-class SparseMatrix(JAXSparse):
+class SparseMatrix(JAXSparse, ABC):
+    """
+    Base class for sparse matrices in ``saiunit``.
 
-    # Not abstract methods because not all sparse classes implement them
+    This class is a subclass of ``jax.experimental.sparse.JAXSparse`` and adds some methods that are not implemented
+    in the original class.
+    """
 
-    def with_data(self, data):
+    def with_data(
+        self,
+        data: Union[jax.Array, np.ndarray, numbers.Number, 'Quantity']
+    ):
+        """
+        Create a new sparse matrix with the same structure but different data.
+
+        Args:
+            data: The new data.
+
+        Returns:
+
+        """
         raise NotImplementedError(f"{self.__class__}.assign_data")
 
-    def sum(self, axis: int | Sequence[int] = None):
+    def sum(self, axis: Union[int, Sequence[int]] = None):
+        """
+        Sum of the elements of the sparse matrix.
+
+        Args:
+            axis: Axis or axes along which the sum is computed. The default is to compute the sum of the flattened array.
+                Only None is supported.
+
+        Returns:
+            The sum of the elements of the sparse matrix.
+
+        """
         if axis is not None:
             raise NotImplementedError("CSR.sum with axis is not implemented.")
         return self.data.sum()
 
+    def yw_to_w(
+        self,
+        y_dim_arr: Union[jax.Array, np.ndarray, 'Quantity'],
+        w_dim_arr: Union[jax.Array, np.ndarray, 'Quantity']
+    ) -> Union[jax.Array, 'Quantity']:
+        """
+        The protocol method to convert the product of the sparse matrix and a vector to the sparse matrix data.
+
+        This protocol method is primarily used in `brainscale <https://github.com/chaobrain/brainscale>`_.
+
+        Args:
+            y_dim_arr: The first vector.
+            w_dim_arr: The second vector.
+
+        Returns:
+            The outer product of the two vectors.
+
+        """
+        raise NotImplementedError(f"{self.__class__}.yw_to_y is not implemented.")
+
     def __abs__(self):
-        raise NotImplementedError(f"{self.__class__}.__abs__")
+        raise NotImplementedError(f"{self.__class__}.__abs__ is not implemented.")
 
     def __neg__(self):
-        raise NotImplementedError(f"{self.__class__}.__neg__")
+        raise NotImplementedError(f"{self.__class__}.__neg__ is not implemented.")
 
     def __pos__(self):
-        raise NotImplementedError(f"{self.__class__}.__pos__")
+        raise NotImplementedError(f"{self.__class__}.__pos__ is not implemented.")
 
     def __matmul__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__matmul__")
+        raise NotImplementedError(f"{self.__class__}.__matmul__ is not implemented.")
 
     def __rmatmul__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rmatmul__")
+        raise NotImplementedError(f"{self.__class__}.__rmatmul__ is not implemented.")
 
     def __mul__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__mul__")
+        raise NotImplementedError(f"{self.__class__}.__mul__ is not implemented.")
 
     def __rmul__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rmul__")
+        raise NotImplementedError(f"{self.__class__}.__rmul__ is not implemented.")
 
     def __add__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__add__")
+        raise NotImplementedError(f"{self.__class__}.__add__ is not implemented.")
 
     def __radd__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__radd__")
+        raise NotImplementedError(f"{self.__class__}.__radd__ is not implemented.")
 
     def __sub__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__sub__")
+        raise NotImplementedError(f"{self.__class__}.__sub__ is not implemented.")
 
     def __rsub__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rsub__")
+        raise NotImplementedError(f"{self.__class__}.__rsub__ is not implemented.")
 
     def __div__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__div__")
+        raise NotImplementedError(f"{self.__class__}.__div__ is not implemented.")
 
     def __rdiv__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rdiv__")
+        raise NotImplementedError(f"{self.__class__}.__rdiv__ is not implemented.")
 
     def __truediv__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__truediv__")
+        raise NotImplementedError(f"{self.__class__}.__truediv__ is not implemented.")
 
     def __rtruediv__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rtruediv__")
+        raise NotImplementedError(f"{self.__class__}.__rtruediv__ is not implemented.")
 
     def __floordiv__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__floordiv__")
+        raise NotImplementedError(f"{self.__class__}.__floordiv__ is not implemented.")
 
     def __rfloordiv__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rfloordiv__")
+        raise NotImplementedError(f"{self.__class__}.__rfloordiv__ is not implemented.")
 
     def __mod__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__mod__")
+        raise NotImplementedError(f"{self.__class__}.__mod__ is not implemented.")
 
     def __rmod__(self, other):
-        raise NotImplementedError(f"{self.__class__}.__rmod__")
+        raise NotImplementedError(f"{self.__class__}.__rmod__ is not implemented.")
 
     def __getitem__(self, item):
-        raise NotImplementedError(f"{self.__class__}.__getitem__")
+        raise NotImplementedError(f"{self.__class__}.__getitem__ is not implemented.")


### PR DESCRIPTION
This pull request includes several changes to the `saiunit` package, focusing on improving compatibility, simplifying imports, and enhancing the `SparseMatrix` class. The most important changes include adding docstrings to methods, importing necessary modules, and modifying the `SparseMatrix` class to include additional methods and implement the `ABC` class.

### Improvements to compatibility and imports:

* [`saiunit/_base.py`](diffhunk://#diff-6a3c21b25892a5da301e4574209ebeebec9759dd7e28ac8505dc84999ecb6c7aL79): Removed an extraneous newline.
* [`saiunit/_base_test.py`](diffhunk://#diff-06a71ecedb3f6336c9a741c3cb759c98ef503cba1c8d62dbf72e7114a5bda44fL21): Removed unused imports `sys` and `indices` from `numpy.ma.core`. [[1]](diffhunk://#diff-06a71ecedb3f6336c9a741c3cb759c98ef503cba1c8d62dbf72e7114a5bda44fL21) [[2]](diffhunk://#diff-06a71ecedb3f6336c9a741c3cb759c98ef503cba1c8d62dbf72e7114a5bda44fL33)

### Enhancements to `SparseMatrix` class:

* [`saiunit/_sparse_base.py`](diffhunk://#diff-dce8ed45b7b42aba5ad0383a32dd03bc43672d5c423f7a76c15b0cc782ed9607L18-R148): Imported `numbers`, `abc`, `jax`, and `numpy` modules.
* [`saiunit/_sparse_base.py`](diffhunk://#diff-dce8ed45b7b42aba5ad0383a32dd03bc43672d5c423f7a76c15b0cc782ed9607L18-R148): Modified `SparseMatrix` class to inherit from `ABC` and added docstrings to methods.
* [`saiunit/_sparse_base.py`](diffhunk://#diff-dce8ed45b7b42aba5ad0383a32dd03bc43672d5c423f7a76c15b0cc782ed9607L18-R148): Added `yw_to_w` method to `SparseMatrix` class for converting the product of the sparse matrix and a vector to the sparse matrix data.

## Summary by Sourcery

New Features:
- Added `yw_to_w` method to `SparseMatrix` class for converting the product of the sparse matrix and a vector to the sparse matrix data.