### PR TITLE
fix unit rdiv operation

### DIFF
--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/saiunit/_base.py
+++ b/saiunit/_base.py
@@ -284,7 +284,7 @@ _siprefixes = {
 
 
 def _is_tracer(x):
-    return isinstance(x, (jax.ShapeDtypeStruct, jax.core.ShapedArray, DynamicJaxprTracer))
+    return isinstance(x, (jax.ShapeDtypeStruct, jax.core.ShapedArray, DynamicJaxprTracer, jax.core.Tracer))
 
 
 class Dimension:
@@ -1883,7 +1883,7 @@ class Unit:
 
     def __rdiv__(self, other) -> 'Unit' | Quantity:
         # other / self
-        if is_scalar_type(other) and other == 1:
+        if is_scalar_type(other) and not _is_tracer(other) and other == 1:
             dim = self.dim ** -1
             scale = -self.scale
             factor = 1. / self.factor


### PR DESCRIPTION
This pull request includes updates to the `saiunit` package, focusing on version increment, compatibility improvements, and bug fixes. The most important changes are listed below:

### Version Update:
* [`saiunit/__init__.py`](diffhunk://#diff-957801b3aa463b0f6bab7995ad37a24ca4ffc318812bda550a8ec2bf9d51b3daL16-R16): Updated the version from `0.0.7` to `0.0.8`.

### Compatibility Improvements:
* [`saiunit/_base.py`](diffhunk://#diff-6a3c21b25892a5da301e4574209ebeebec9759dd7e28ac8505dc84999ecb6c7aL287-R287): Modified the `_is_tracer` function to include `jax.core.Tracer` in the list of types it checks for.

### Bug Fixes:
* [`saiunit/_base.py`](diffhunk://#diff-6a3c21b25892a5da301e4574209ebeebec9759dd7e28ac8505dc84999ecb6c7aL1886-R1886): Updated the `__div__` method to ensure it correctly handles cases where `other` is a tracer.

## Summary by Sourcery

This pull request updates the `saiunit` package to improve JAX tracer compatibility and fix a bug in the `__rdiv__` method. It also increments the package version.

Bug Fixes:
- Fixes a bug in the `__rdiv__` method to correctly handle cases where `other` is a tracer, ensuring proper unit division.

Enhancements:
- Improves compatibility by including `jax.core.Tracer` in the list of types checked by the `_is_tracer` function.

Chores:
- Increments the package version from 0.0.7 to 0.0.8.