### PR TITLE
[doc] Update documentation links and improve content in notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
 	<a href="https://pypi.org/project/saiunit/"><img alt="Supported Python Version" src="https://img.shields.io/pypi/pyversions/saiunit"></a>
 	<a href="https://github.com/chaobrain/saiunit/blob/main/LICENSE"><img alt="LICENSE" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
-    <a href='https://saiunit.readthedocs.io/en/latest/?badge=latest'>
+    <a href='https://saiunit.readthedocs.io/?badge=latest'>
         <img src='https://readthedocs.org/projects/saiunit/badge/?version=latest' alt='Documentation Status' />
     </a>  	
     <a href="https://badge.fury.io/py/saiunit"><img alt="PyPI version" src="https://badge.fury.io/py/saiunit.svg"></a>

--- a/brainunit/README.md
+++ b/brainunit/README.md
@@ -10,7 +10,7 @@
 <p align="center">
 	<a href="https://pypi.org/project/brainunit/"><img alt="Supported Python Version" src="https://img.shields.io/pypi/pyversions/brainunit"></a>
 	<a href="https://github.com/chaobrain/brainunit/blob/main/LICENSE"><img alt="LICENSE" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
-    <a href='https://brainunit.readthedocs.io/en/latest/?badge=latest'>
+    <a href='https://brainunit.readthedocs.io/?badge=latest'>
         <img src='https://readthedocs.org/projects/brainunit/badge/?version=latest' alt='Documentation Status' />
     </a>  	
     <a href="https://badge.fury.io/py/brainunit"><img alt="PyPI version" src="https://badge.fury.io/py/brainunit.svg"></a>

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -92,6 +92,6 @@ Please refer to the [JAX installation guide](https://jax.readthedocs.io/en/lates
 ### How do I create a Quantity in ``saiunit``?
 
 
-Please refer to the documentation on https://brainunit.readthedocs.io/en/latest/physical_units/quantity.html.
+Please refer to the documentation on [https://saiunit.readthedocs.io/physical_units/quantity.html](https://saiunit.readthedocs.io/physical_units/quantity.html).
 
 

--- a/docs/advanced_tutorials/mechanism.ipynb
+++ b/docs/advanced_tutorials/mechanism.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "Scaling in the `Unit` class is handled through the `_scale` attribute and the use of standard SI prefixes. The `create_scaled_unit` method is used to create a new unit that is a scaled version of an existing base unit. This method takes a `baseunit` and a `scalefactor` (the prefix like \"m\" for milli) and adjusts the `scale` attribute accordingly. For example, if the `baseunit` is metre and the `scalefactor` is \"k\" (for kilo), the `scale` would be increased by 3 (since kilo represents 10^3).\n",
     "\n",
-    "See more details of creating units at [link](https://saiunit.readthedocs.io/en/latest/physical_units/combining_defining.html)."
+    "See more details of creating units at [link](https://saiunit.readthedocs.io/advanced_tutorials/combining_and_defining.html)."
    ]
   },
   {

--- a/docs/mathematical_functions/fft_functions.ipynb
+++ b/docs/mathematical_functions/fft_functions.ipynb
@@ -17,8 +17,8 @@
     "In `saiunit.fft` we reimplemented Fast Fourier Transform functions compatible with both `Quantity` and arrays.\n",
     "For compatible with `Quantity`, we categorized the functions into two groups.\n",
     "\n",
-    "- [FFT Changing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.fft.html#functions-that-changing-unit)\n",
-    "- [FFT Keeping Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.fft.html#functions-that-keeping-unit)"
+    "- [FFT Changing Unit](https://saiunit.readthedocs.io/apis/saiunit.fft.html#functions-that-changing-unit)\n",
+    "- [FFT Keeping Unit](https://saiunit.readthedocs.io/apis/saiunit.fft.html#functions-that-keeping-unit)"
    ]
   }
  ],

--- a/docs/mathematical_functions/lax_functions.ipynb
+++ b/docs/mathematical_functions/lax_functions.ipynb
@@ -17,13 +17,13 @@
     "In `saiunit.lax` we reimplemented almost all important Jax Lax functions compatible with both `Quantity` and arrays.\n",
     "For compatible with `Quantity`, we categorized the functions into serveral groups.\n",
     "\n",
-    "- [Lax Array Creation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#array-creation-functions)\n",
-    "- [Lax Accept Unitless](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#functions-that-accepting-unitless)\n",
-    "- [Lax Changing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#functions-that-changing-unit)\n",
-    "- [Lax Keeping Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#functions-that-keeping-unit)\n",
-    "- [Lax Removing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#functions-that-removing-unit)\n",
-    "- [Lax Linear Algebra Functions](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#linalg-functions)\n",
-    "- [More Functions](https://saiunit.readthedocs.io/en/latest/apis/saiunit.lax.html#other-functions)"
+    "- [Lax Array Creation](https://saiunit.readthedocs.io/apis/saiunit.lax.html#array-creation-functions)\n",
+    "- [Lax Accept Unitless](https://saiunit.readthedocs.io/apis/saiunit.lax.html#functions-that-accepting-unitless)\n",
+    "- [Lax Changing Unit](https://saiunit.readthedocs.io/apis/saiunit.lax.html#functions-that-changing-unit)\n",
+    "- [Lax Keeping Unit](https://saiunit.readthedocs.io/apis/saiunit.lax.html#functions-that-keeping-unit)\n",
+    "- [Lax Removing Unit](https://saiunit.readthedocs.io/apis/saiunit.lax.html#functions-that-removing-unit)\n",
+    "- [Lax Linear Algebra Functions](https://saiunit.readthedocs.io/apis/saiunit.lax.html#linalg-functions)\n",
+    "- [More Functions](https://saiunit.readthedocs.io/apis/saiunit.lax.html#other-functions)"
    ]
   }
  ],

--- a/docs/mathematical_functions/linalg_functions.ipynb
+++ b/docs/mathematical_functions/linalg_functions.ipynb
@@ -17,8 +17,8 @@
     "In `saiunit.linalg` we reimplemented almost all important Linear Algebra functions compatible with both `Quantity` and arrays.\n",
     "For compatible with `Quantity`, we categorized the functions into two groups.\n",
     "\n",
-    "- [Linear Algebra Changing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.linalg.html#functions-that-changing-unit)\n",
-    "- [Linear Algebra Keeping Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.linalg.html#functions-that-keeping-unit)"
+    "- [Linear Algebra Changing Unit](https://saiunit.readthedocs.io/apis/saiunit.linalg.html#functions-that-changing-unit)\n",
+    "- [Linear Algebra Keeping Unit](https://saiunit.readthedocs.io/apis/saiunit.linalg.html#functions-that-keeping-unit)"
    ]
   }
  ],

--- a/docs/mathematical_functions/numpy_functions.ipynb
+++ b/docs/mathematical_functions/numpy_functions.ipynb
@@ -17,13 +17,13 @@
     "In `saiunit.math` we reimplemented almost all important NumPy functions compatible with both `Quantity` and arrays.\n",
     "For compatible with `Quantity`, we categorized the functions into serveral groups.\n",
     "\n",
-    "- [Array Creation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#array-creation-functions)\n",
-    "- [Functions Accept Unitless](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-accepting-unitless)\n",
-    "- [Functions Changing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-changing-unit)\n",
-    "- [Functions Keeping Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-keeping-unit)\n",
-    "- [Functions Removing Unit](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-removing-unit)\n",
-    "- [Activation Functions](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#activation-functions)\n",
-    "- [More Functions](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#other-functions)"
+    "- [Array Creation](https://saiunit.readthedocs.io/apis/saiunit.math.html#array-creation-functions)\n",
+    "- [Functions Accept Unitless](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-accepting-unitless)\n",
+    "- [Functions Changing Unit](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-changing-unit)\n",
+    "- [Functions Keeping Unit](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-keeping-unit)\n",
+    "- [Functions Removing Unit](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-removing-unit)\n",
+    "- [Activation Functions](https://saiunit.readthedocs.io/apis/saiunit.math.html#activation-functions)\n",
+    "- [More Functions](https://saiunit.readthedocs.io/apis/saiunit.math.html#other-functions)"
    ]
   },
   {
@@ -67,7 +67,7 @@
     "- tree_ones_like\n",
     "- tree_zeros_like\n",
     "\n",
-    "Detailed information can be found in the [Array Creation documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#array-creation-functions)."
+    "Detailed information can be found in the [Array Creation documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#array-creation-functions)."
    ]
   },
   {
@@ -131,7 +131,7 @@
     "- left_shift\n",
     "- right_shift\n",
     "\n",
-    "Detailed information can be found in the [Functions Accept Unitless documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-accepting-unitless)."
+    "Detailed information can be found in the [Functions Accept Unitless documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-accepting-unitless)."
    ]
   },
   {
@@ -175,7 +175,7 @@
     "- tensordot\n",
     "- matrix_power\n",
     "\n",
-    "Detailed information can be found in the [Functions Changing Unit documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-changing-unit)."
+    "Detailed information can be found in the [Functions Changing Unit documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-changing-unit)."
    ]
   },
   {
@@ -286,7 +286,7 @@
     "- where\n",
     "- unique\n",
     "\n",
-    "Detailed information can be found in the [Functions Keeping Unit documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-keeping-unit)."
+    "Detailed information can be found in the [Functions Keeping Unit documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-keeping-unit)."
    ]
   },
   {
@@ -331,7 +331,7 @@
     "- searchsorted\n",
     "- count_nonzero\n",
     "\n",
-    "Detailed information can be found in the [Functions Removing Unit documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#functions-that-removing-unit)."
+    "Detailed information can be found in the [Functions Removing Unit documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#functions-that-removing-unit)."
    ]
   },
   {
@@ -367,7 +367,7 @@
     "- squareplus\n",
     "- mish\n",
     "\n",
-    "Detailed information can be found in the [More Functions documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#activation-functions)."
+    "Detailed information can be found in the [More Functions documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#activation-functions)."
    ]
   },
   {
@@ -406,7 +406,7 @@
     "- nan\n",
     "- euler_gamma\n",
     "\n",
-    "Detailed information can be found in the [More Functions documentation](https://saiunit.readthedocs.io/en/latest/apis/saiunit.math.html#other-functions)."
+    "Detailed information can be found in the [More Functions documentation](https://saiunit.readthedocs.io/apis/saiunit.math.html#other-functions)."
    ]
   }
  ],

--- a/docs/physical_units/math_operations_with_quantity.ipynb
+++ b/docs/physical_units/math_operations_with_quantity.ipynb
@@ -211,7 +211,7 @@
     "    - clamp\n",
     "    - sort\n",
     "\n",
-    "For more details on these functions, refer to the [documentation](https://saiunit.readthedocs.io/en/latest/apis/generated/saiunit.Quantity.html)."
+    "For more details on these functions, refer to the [documentation](https://saiunit.readthedocs.io/apis/generated/saiunit.Quantity.html)."
    ]
   },
   {

--- a/docs/physical_units/quantity.ipynb
+++ b/docs/physical_units/quantity.ipynb
@@ -420,7 +420,7 @@
     "  - `saiunit.math.tril`\n",
     "  - `saiunit.math.triu`\n",
     "\n",
-    "See the [Array Creation Documentation](https://saiunit.readthedocs.io/en/latest/mathematical_functions/array_creation.html) for more information."
+    "See the [Array Creation Documentation](https://saiunit.readthedocs.io/mathematical_functions/array_creation.html) for more information."
    ]
   },
   {
@@ -717,7 +717,7 @@
     "    - clamp\n",
     "    - sort\n",
     "\n",
-    "For more details on these functions, refer to the [documentation](https://saiunit.readthedocs.io/en/latest/saiunit/apis/generated/saiunit.Quantity.html)."
+    "For more details on these functions, refer to the [documentation](https://saiunit.readthedocs.io/saiunit/apis/generated/saiunit.Quantity.html)."
    ]
   },
   {

--- a/saiunit/math/_activation.py
+++ b/saiunit/math/_activation.py
@@ -57,7 +57,7 @@ def relu(
         An array.
 
     Examples:
-        >>> jax.nn.relu(jax.numpy.array([-2., -1., -0.5, 0, 0.5, 1., 2.]))
+        >>> saiunit.math.relu(jax.numpy.array([-2., -1., -0.5, 0, 0.5, 1., 2.]))
         Array([0. , 0. , 0. , 0. , 0.5, 1. , 2. ], dtype=float32)
     """
     return _fun_keep_unit_unary(nn.relu, x)


### PR DESCRIPTION
This pull request updates various documentation files to fix outdated or incorrect URLs, ensuring they point to the correct locations in the `saiunit` documentation. The changes primarily involve removing `/en/latest` from the URLs and updating paths to match the current structure of the documentation.

### Updates to Documentation URLs:

* **General Documentation Links:**
  - Updated the `saiunit` and `brainunit` README files to remove `/en/latest` from the ReadTheDocs links for documentation badges. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) `brainunit/README.md`: [[2]](diffhunk://#diff-2ecf837a0141d7e6660953425408b046030df3eefdf4e96b8f26e6820118891aL13-R13)

* **Physical Units Documentation:**
  - Fixed the link to the Quantity documentation in the FAQs to point to the correct path. (`docs/FAQs.md`: [docs/FAQs.mdL95-R95](diffhunk://#diff-cc908ca4b57d59e44123c8b13deee7af64523aa40e21f69f11d4c604af276ff6L95-R95))
  - Updated links in the `math_operations_with_quantity` and `quantity` notebooks to remove `/en/latest` and reflect the updated documentation structure. (`docs/physical_units/math_operations_with_quantity.ipynb`: [[1]](diffhunk://#diff-ad00208ebf9909596b009773906e98c10fa0683913d74851912bd69e6a868ca2L214-R214) `docs/physical_units/quantity.ipynb`: [[2]](diffhunk://#diff-7c34b5d4e66f65ba4e8a9ab2715e1f833b5bd055bc20251155a69be8221b1014L423-R423) [[3]](diffhunk://#diff-7c34b5d4e66f65ba4e8a9ab2715e1f833b5bd055bc20251155a69be8221b1014L720-R720)

* **Mathematical Functions Documentation:**
  - Updated links in the `fft_functions`, `lax_functions`, `linalg_functions`, and `numpy_functions` notebooks to remove `/en/latest` and ensure paths align with the updated documentation structure. (`docs/mathematical_functions/fft_functions.ipynb`: [[1]](diffhunk://#diff-7945c8e29356fe8daef648fb615f652f392664a4237e75f15fd526c9194d680fL20-R21) `docs/mathematical_functions/lax_functions.ipynb`: [[2]](diffhunk://#diff-cece04870ae51c631ec3e881165bc53f4f8cefa0e3089263a1fe1b623b19623aL20-R26) `docs/mathematical_functions/linalg_functions.ipynb`: [[3]](diffhunk://#diff-e39cc0aff727299265e2275078984511d6d4703f1b51253a1d7169ead273b262L20-R21) `docs/mathematical_functions/numpy_functions.ipynb`: [[4]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L20-R26) [[5]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L70-R70) [[6]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L134-R134) [[7]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L178-R178) [[8]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L289-R289) [[9]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L334-R334) [[10]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L370-R370) [[11]](diffhunk://#diff-dfabc5e7ec4fdc1e043849cb397ac0e7dd7d882ca34c2f444e471562570e3610L409-R409)

* **Advanced Tutorials:**
  - Corrected the link to the advanced tutorial on combining and defining units. (`docs/advanced_tutorials/mechanism.ipynb`: [docs/advanced_tutorials/mechanism.ipynbL66-R66](diffhunk://#diff-bf1ec911fed4b71017ff8cc1ab41977a91edb47fc58832c99d5919d40387a4ebL66-R66)) 

These changes improve the accuracy and usability of the documentation by ensuring all links are functional and up-to-date.