### PR TITLE
[linalg] Add import for `_linalg_remove_unit` and update `__all__` definition

### DIFF
--- a/saiunit/linalg/__init__.py
+++ b/saiunit/linalg/__init__.py
@@ -17,9 +17,13 @@ from ._linalg_change_unit import *
 from ._linalg_change_unit import __all__ as _linalg_change_unit_all
 from ._linalg_keep_unit import *
 from ._linalg_keep_unit import __all__ as _linalg_keep_unit_all
+from ._linalg_remove_unit import *
+from ._linalg_remove_unit import __all__ as _linalg_remove_unit_all
 
 __all__ = (_linalg_change_unit_all +
-              _linalg_keep_unit_all)
+              _linalg_keep_unit_all +
+           _linalg_remove_unit_all)
 
 del (_linalg_change_unit_all,
-     _linalg_keep_unit_all)
+     _linalg_keep_unit_all,
+     _linalg_remove_unit_all)


### PR DESCRIPTION
This pull request introduces a new module, `_linalg_remove_unit`, to the `saiunit/linalg` package and updates the `__init__.py` file to integrate it. The changes ensure that the new module is imported and its symbols are included in the package's public API.

Updates to `saiunit/linalg/__init__.py`:

* Added imports for `_linalg_remove_unit` and its `__all__` definition. (`[saiunit/linalg/__init__.pyR20-R29](diffhunk://#diff-d881775d41827e6c87c377efe2141db98f453d25964dc5770bc6ab606f0c1a43R20-R29)`)
* Updated the `__all__` variable to include `_linalg_remove_unit_all`, ensuring the new module's symbols are part of the public API. (`[saiunit/linalg/__init__.pyR20-R29](diffhunk://#diff-d881775d41827e6c87c377efe2141db98f453d25964dc5770bc6ab606f0c1a43R20-R29)`)
* Added `_linalg_remove_unit_all` to the list of deleted variables at the end of the file to clean up the namespace. (`[saiunit/linalg/__init__.pyR20-R29](diffhunk://#diff-d881775d41827e6c87c377efe2141db98f453d25964dc5770bc6ab606f0c1a43R20-R29)`)

## Summary by Sourcery

Enhancements:
- Update package initialization to import and expose symbols from the new `_linalg_remove_unit` module