### PR TITLE
[doc] Detailed docstring for functions in _celsius.py

### DIFF
--- a/saiunit/_celsius.py
+++ b/saiunit/_celsius.py
@@ -82,6 +82,6 @@ def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
     25.0
 
     """
-    if not isinstance(value, Quantity) and value.unit != kelvin:
+    if not (isinstance(value, Quantity) and value.unit == kelvin):
         raise TypeError("The input value should be a Quantity with kelvin.")
     return value.mantissa - 273.15

--- a/saiunit/_celsius.py
+++ b/saiunit/_celsius.py
@@ -38,6 +38,18 @@ def celsius2kelvin(celsius: jax.typing.ArrayLike) -> Quantity:
     -------
       Quantity: The converted value.
 
+    Raises
+    ------
+    TypeError
+      If the input value is a Quantity.
+
+    Examples
+    --------
+    >>> from saiunit import kelvin, celsius2kelvin
+    >>> celsius = 25.0
+    >>> celsius2kelvin(celsius)
+    298.15 * kelvin
+
     """
     if isinstance(celsius, Quantity):
         raise TypeError("The input value should be not be a Quantity.")
@@ -56,6 +68,18 @@ def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
     Returns
     -------
       Quantity: The converted value.
+
+    Raises
+    ------
+    TypeError
+      If the input value is not a Quantity with kelvin unit.
+
+    Examples
+    --------
+    >>> from saiunit import kelvin, kelvin2celsius
+    >>> value = 298.15 * kelvin
+    >>> kelvin2celsius(value)
+    25.0
 
     """
     if not isinstance(value, Quantity) and value.unit != kelvin:


### PR DESCRIPTION
Closes #21 

This pull request improves the documentation and error handling for temperature conversion functions in the `saiunit/_celsius.py` file. The changes include adding detailed `Raises` and `Examples` sections to the docstrings of the `celsius2kelvin` and `kelvin2celsius` functions, as well as refining the error messages for invalid input types.

### Documentation improvements:

* `saiunit/_celsius.py` (`celsius2kelvin` function): Added `Raises` section to specify that a `TypeError` is raised if the input is a `Quantity`. Included an `Examples` section demonstrating usage with a sample input.
* `saiunit/_celsius.py` (`kelvin2celsius` function): Added `Raises` section to specify that a `TypeError` is raised if the input is not a `Quantity` with the `kelvin` unit. Included an `Examples` section demonstrating usage with a sample input.

## Summary by Sourcery

Documentation:
- Added detailed docstrings for celsius2kelvin and kelvin2celsius functions, including Raises and Examples sections to clarify function usage and error conditions