### PR TITLE
[doc] Detailed docstring for functions in fft module

### DIFF
--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -23,7 +23,7 @@ import numpy as np
 from jax.numpy import fft as jnpfft
 from jaxlib import xla_client
 
-from .. import _unit_common as u
+from .. import _unit_common as uc
 from .._base import Quantity, Unit, get_or_create_dimension
 from .._misc import set_module_as
 from .._unit_common import second
@@ -77,7 +77,7 @@ def fft(
     saiunit implementation of :func:`numpy.fft.fft`.
 
     Args:
-        a: input array
+        a: input quantity or array.
         n: int. Specifies the dimension of the result along ``axis``. If not specified,
             it will default to the dimension of ``a`` along ``axis``.
         axis: int, default=-1. Specifies the axis along which the transform is computed.
@@ -86,7 +86,7 @@ def fft(
             supported.
 
     Returns:
-        An array containing the one-dimensional discrete Fourier transform of ``a``.
+        A quantity containing the one-dimensional discrete Fourier transform of ``a``.
 
     See also:
         - :func:`saiunit.fft.ifft`: Computes a one-dimensional inverse discrete
@@ -99,34 +99,48 @@ def fft(
     Examples:
         ``saiunit.fft.fft`` computes the transform along ``axis -1`` by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[1, 2, 4, 7],
-        ...                [5, 3, 1, 9]])
-        >>> saiunit.fft.fft(x)
-        Array([[14.+0.j, -3.+5.j, -4.+0.j, -3.-5.j],
-               [18.+0.j,  4.+6.j, -6.+0.j,  4.-6.j]], dtype=complex64)
+        ...                [5, 3, 1, 9]]) * u.meter
+        >>> u.fft.fft(x)
+        ArrayImpl([[14.+0.j, -3.+5.j, -4.+0.j, -3.-5.j],
+                   [18.+0.j,  4.+6.j, -6.+0.j,  4.-6.j]], dtype=complex64) * meter * second
+        The units have changed here, transitioning from meters in the spatial domain
+        to meter * second in the frequency domain.
+        This is because the Fourier transform converts between the time domain
+        and the frequency domain:
+
+        - Time-domain signal (unit: second) → Frequency-domain signal (unit: hertz = 1/second)
+        - Spatial-domain signal (unit: meter) → Wavenumber-domain signal (unit: 1/meter)
+        In this case, the original signal B is in the spatial domain,
+        but the FFT operation inherently assumes a time-domain input,
+        resulting in output units of meter * second.
+        This unit conversion reflects the physical meaning of the Fourier transform.
 
         When ``n=3``, dimension of the transform along axis -1 will be ``3`` and
         dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.fft(x, n=3))
-        [[ 7.+0.j   -2.+1.73j -2.-1.73j]
-         [ 9.+0.j    3.-1.73j  3.+1.73j]]
+        ...   print(u.fft.fft(x, n=3))
+        ArrayImpl([[ 7.+0.j  , -2.+1.73j, -2.-1.73j],
+                   [ 9.+0.j  ,  3.-1.73j,  3.+1.73j]], dtype=complex64) * meter * second
 
         When ``n=3`` and ``axis=0``, dimension of the transform along ``axis 0`` will
         be ``3`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.fft(x, n=3, axis=0))
-        [[ 6. +0.j    5. +0.j    5. +0.j   16. +0.j  ]
-         [-1.5-4.33j  0.5-2.6j   3.5-0.87j  2.5-7.79j]
-         [-1.5+4.33j  0.5+2.6j   3.5+0.87j  2.5+7.79j]]
+        ...   print(u.fft.fft(x, n=3, axis=0))
+        ArrayImpl([[ 6. +0.j  ,  5. +0.j  ,  5. +0.j  , 16. +0.j  ],
+                   [-1.5-4.33j,  0.5-2.6j ,  3.5-0.87j,  2.5-7.79j],
+                   [-1.5+4.33j,  0.5+2.6j ,  3.5+0.87j,  2.5+7.79j]],
+                  dtype=complex64) * meter * second
 
         ``jnp.fft.ifft`` can be used to reconstruct ``x`` from the result of
         ``jnp.fft.fft``.
 
-        >>> x_fft = jnp.fft.fft(x)
-        >>> jnp.allclose(x, saiunit.fft.ifft(x_fft))
+        >>> x_fft = u.fft.fft(x)
+        >>> u.math.allclose(x, u.fft.ifft(x_fft))
         Array(True, dtype=bool)
     """
     # check target_time_unit.dim == second.dim
@@ -147,7 +161,7 @@ def rfft(
     saiunit implementation of :func:`numpy.fft.rfft`.
 
     Args:
-        a: real-valued input array.
+        a: real-valued input quantity or array.
         n: int. Specifies the effective dimension of the input along ``axis``. If not
             specified, it will default to the dimension of input along ``axis``.
         axis: int, default=-1. Specifies the axis along which the transform is computed.
@@ -156,7 +170,7 @@ def rfft(
             supported.
 
     Returns:
-        An array containing the one-dimensional discrete Fourier transform of ``a``.
+        A quantity containing the one-dimensional discrete Fourier transform of ``a``.
         The dimension of the array along ``axis`` is ``(n/2)+1``, if ``n`` is even and
         ``(n+1)/2``, if ``n`` is odd.
 
@@ -173,29 +187,31 @@ def rfft(
     Examples:
         ``saiunit.fft.rfft`` computes the transform along ``axis -1`` by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[1, 3, 5],
-        ...                [2, 4, 6]])
+        ...                [2, 4, 6]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft(x)
-        Array([[ 9.+0.j  , -3.+1.73j],
-               [12.+0.j  , -3.+1.73j]], dtype=complex64)
+        ...   u.fft.rfft(x)
+        ArrayImpl([[ 9.+0.j  , -3.+1.73j],
+                   [12.+0.j  , -3.+1.73j]], dtype=complex64) * meter * second
 
         When ``n=5``, dimension of the transform along axis -1 will be ``(5+1)/2 =3``
         and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft(x, n=5)
-        Array([[ 9.  +0.j  , -2.12-5.79j,  0.12+2.99j],
-               [12.  +0.j  , -1.62-7.33j,  0.62+3.36j]], dtype=complex64)
+        ...   u.fft.rfft(x, n=5)
+        ArrayImpl([[ 9.  +0.j  , -2.12-5.79j,  0.12+2.99j],
+                   [12.  +0.j  , -1.62-7.33j,  0.62+3.36j]], dtype=complex64) * meter * second
 
         When ``n=4`` and ``axis=0``, dimension of the transform along ``axis 0`` will
         be ``(4/2)+1 =3`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft(x, n=4, axis=0)
-        Array([[ 3.+0.j,  7.+0.j, 11.+0.j],
-               [ 1.-2.j,  3.-4.j,  5.-6.j],
-               [-1.+0.j, -1.+0.j, -1.+0.j]], dtype=complex64)
+        ...   u.fft.rfft(x, n=4, axis=0)
+        ArrayImpl([[ 3.+0.j,  7.+0.j, 11.+0.j],
+                   [ 1.-2.j,  3.-4.j,  5.-6.j],
+                   [-1.+0.j, -1.+0.j, -1.+0.j]], dtype=complex64) * meter * second
     """
     return _fun_change_unit_unary(
         jnpfft.rfft,
@@ -223,7 +239,7 @@ def ifft(
     saiunit implementation of :func:`numpy.fft.ifft`.
 
     Args:
-        a: input array
+        a: input quantity or array.
         n: int. Specifies the dimension of the result along ``axis``. If not specified,
             it will default to the dimension of ``a`` along ``axis``.
         axis: int, default=-1. Specifies the axis along which the transform is computed.
@@ -232,7 +248,7 @@ def ifft(
             supported.
 
     Returns:
-        An array containing the one-dimensional discrete Fourier transform of ``a``.
+        A quantity containing the one-dimensional discrete Fourier transform of ``a``.
 
     See also:
         - :func:`saiunit.fft.fft`: Computes a one-dimensional discrete Fourier
@@ -245,28 +261,34 @@ def ifft(
     Examples:
         ``saiunit.fft.ifft`` computes the transform along ``axis -1`` by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[3, 1, 4, 6],
-        ...                [2, 5, 7, 1]])
-        >>> saiunit.fft.ifft(x)
-        Array([[ 3.5 +0.j  , -0.25-1.25j,  0.  +0.j  , -0.25+1.25j],
-              [ 3.75+0.j  , -1.25+1.j  ,  0.75+0.j  , -1.25-1.j  ]],      dtype=complex64)
+        ...                [2, 5, 7, 1]]) * u.meter
+        >>> u.fft.ifft(x)
+        ArrayImpl([[ 3.5 +0.j  , -0.25-1.25j,  0.  +0.j  , -0.25+1.25j],
+                   [ 3.75+0.j  , -1.25+1.j  ,  0.75+0.j  , -1.25-1.j  ]],
+                  dtype=complex64) * meter / second
 
         When ``n=5``, dimension of the transform along axis -1 will be ``5`` and
         dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifft(x, n=5))
-        [[ 2.8 +0.j   -0.96-0.04j  1.06+0.5j   1.06-0.5j  -0.96+0.04j]
-         [ 3.  +0.j   -0.59+1.66j  0.09-0.55j  0.09+0.55j -0.59-1.66j]]
+        ...   print(u.fft.ifft(x, n=5))
+        ArrayImpl([[ 2.8 +0.j  , -0.96-0.04j,  1.06+0.5j ,  1.06-0.5j ,
+                    -0.96+0.04j],
+                   [ 3.  +0.j  , -0.59+1.66j,  0.09-0.55j,  0.09+0.55j,
+                    -0.59-1.66j]], dtype=complex64) * meter / second
 
         When ``n=3`` and ``axis=0``, dimension of the transform along ``axis 0`` will
         be ``3`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifft(x, n=3, axis=0))
-        [[ 1.67+0.j    2.  +0.j    3.67+0.j    2.33+0.j  ]
-         [ 0.67+0.58j -0.5 +1.44j  0.17+2.02j  1.83+0.29j]
-         [ 0.67-0.58j -0.5 -1.44j  0.17-2.02j  1.83-0.29j]]
+        ...   print(u.fft.ifft(x, n=3, axis=0))
+        ArrayImpl([[ 1.67+0.j  ,  2.  +0.j  ,  3.67+0.j  ,  2.33+0.j  ],
+                   [ 0.67+0.58j, -0.5 +1.44j,  0.17+2.02j,  1.83+0.29j],
+                   [ 0.67-0.58j, -0.5 -1.44j,  0.17-2.02j,  1.83-0.29j]],
+                  dtype=complex64) * meter / second
     """
     return _fun_change_unit_unary(
         jnpfft.ifft,
@@ -290,7 +312,7 @@ def irfft(
     saiunit implementation of :func:`numpy.fft.irfft`.
 
     Args:
-        a: input array.
+        a: input quantity or array.
         n: int. Specifies the dimension of the result along ``axis``. If not specified,
             ``n = 2*(m-1)``, where ``m`` is the dimension of ``a`` along ``axis``.
         axis: int, default=-1. Specifies the axis along which the transform is computed.
@@ -299,7 +321,7 @@ def irfft(
             supported.
 
     Returns:
-        A real-valued array containing the one-dimensional inverse discrete Fourier
+        A real-valued quantity containing the one-dimensional inverse discrete Fourier
         transform of ``a``, with a dimension of ``n`` along ``axis``.
 
     See also:
@@ -315,29 +337,31 @@ def irfft(
     Examples:
         ``saiunit.fft.rfft`` computes the transform along ``axis -1`` by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[1, 3, 5],
-        ...                [2, 4, 6]])
-        >>> saiunit.fft.irfft(x)
-        Array([[ 3., -1.,  0., -1.],
-               [ 4., -1.,  0., -1.]], dtype=float32)
+        ...                [2, 4, 6]]) * u.meter
+        >>> u.fft.irfft(x)
+        ArrayImpl([[ 3., -1.,  0., -1.],
+                   [ 4., -1.,  0., -1.]], dtype=float32) * meter / second
 
         When ``n=3``, dimension of the transform along axis -1 will be ``3`` and
         dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfft(x, n=3)
-        Array([[ 2.33, -0.67, -0.67],
-               [ 3.33, -0.67, -0.67]], dtype=float32)
+        ...   print(u.fft.irfft(x, n=3))
+        ArrayImpl([[ 2.33, -0.67, -0.67],
+                   [ 3.33, -0.67, -0.67]], dtype=float32) * meter / second
 
         When ``n=4`` and ``axis=0``, dimension of the transform along ``axis 0`` will
         be ``4`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfft(x, n=4, axis=0)
-        Array([[ 1.25,  2.75,  4.25],
-               [ 0.25,  0.75,  1.25],
-               [-0.75, -1.25, -1.75],
-               [ 0.25,  0.75,  1.25]], dtype=float32)
+        ...   print(u.fft.irfft(x, n=4, axis=0))
+        ArrayImpl([[ 1.25,  2.75,  4.25],
+                   [ 0.25,  0.75,  1.25],
+                   [-0.75, -1.25, -1.75],
+                   [ 0.25,  0.75,  1.25]], dtype=float32) * meter / second
     """
     return _fun_change_unit_unary(jnpfft.irfft,
                                   lambda u: u / second,
@@ -359,7 +383,7 @@ def fft2(
     saiunit implementation of :func:`numpy.fft.fft2`.
 
     Args:
-        a: input array. Must have ``a.ndim >= 2``.
+        a: input quantity or array. Must have ``a.ndim >= 2``.
         s: optional length-2 sequence of integers. Specifies the size of the output
             along each specified axis. If not specified, it will default to the size
             of ``a`` along the specified ``axes``.
@@ -369,7 +393,7 @@ def fft2(
             and "forward" are supported.
 
     Returns:
-        An array containing the two-dimensional discrete Fourier transform of ``a``
+        A quantity containing the two-dimensional discrete Fourier transform of ``a``
         along given ``axes``.
 
     See also:
@@ -383,48 +407,51 @@ def fft2(
     Examples:
         ``saiunit.fft.fft2`` computes the transform along the last two axes by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3],
         ...                 [2, 4]],
         ...                [[5, 7],
-        ...                 [6, 8]]])
+        ...                 [6, 8]]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.fft2(x)
-        Array([[[10.+0.j, -4.+0.j],
-                [-2.+0.j,  0.+0.j]],
+        ...   print(u.fft.fft2(x))
+        ArrayImpl([[[10.+0.j, -4.+0.j],
+                  [-2.+0.j,  0.+0.j]],
         <BLANKLINE>
-               [[26.+0.j, -4.+0.j],
-                [-2.+0.j,  0.+0.j]]], dtype=complex64)
+                 [[26.+0.j, -4.+0.j],
+                  [-2.+0.j,  0.+0.j]]], dtype=complex64) * meter * second2
 
         When ``s=[2, 3]``, dimension of the transform along ``axes (-2, -1)`` will be
         ``(2, 3)`` and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.fft2(x, s=[2, 3])
-        Array([[[10.  +0.j  , -0.5 -6.06j, -0.5 +6.06j],
-                [-2.  +0.j  , -0.5 +0.87j, -0.5 -0.87j]],
+        ...   print(u.fft.fft2(x, s=[2, 3]))
+        ArrayImpl([[[10.  +0.j  , -0.5 -6.06j, -0.5 +6.06j],
+                    [-2.  +0.j  , -0.5 +0.87j, -0.5 -0.87j]],
         <BLANKLINE>
-               [[26.  +0.j  ,  3.5-12.99j,  3.5+12.99j],
-                [-2.  +0.j  , -0.5 +0.87j, -0.5 -0.87j]]], dtype=complex64)
+                   [[26.  +0.j  ,  3.5-12.99j,  3.5+12.99j],
+                    [-2.  +0.j  , -0.5 +0.87j, -0.5 -0.87j]]], dtype=complex64) * meter * second2
+
 
         When ``s=[2, 3]`` and ``axes=(0, 1)``, shape of the transform along
         ``axes (0, 1)`` will be ``(2, 3)`` and dimension along other axes will be
         same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.fft2(x, s=[2, 3], axes=(0, 1))
-        Array([[[14. +0.j  , 22. +0.j  ],
-                [ 2. -6.93j,  4.-10.39j],
-                [ 2. +6.93j,  4.+10.39j]],
+        ...   print(u.fft.fft2(x, s=[2, 3], axes=(0, 1)))
+        ArrayImpl([[[14. +0.j  , 22. +0.j  ],
+                    [ 2. -6.93j,  4.-10.39j],
+                    [ 2. +6.93j,  4.+10.39j]],
         <BLANKLINE>
-               [[-8. +0.j  , -8. +0.j  ],
-                [-2. +3.46j, -2. +3.46j],
-                [-2. -3.46j, -2. -3.46j]]], dtype=complex64)
+                   [[-8. +0.j  , -8. +0.j  ],
+                    [-2. +3.46j, -2. +3.46j],
+                    [-2. -3.46j, -2. -3.46j]]], dtype=complex64) * meter * second2
 
         ``jnp.fft.ifft2`` can be used to reconstruct ``x`` from the result of
         ``jnp.fft.fft2``.
 
-        >>> x_fft2 = saiunit.fft.fft2(x)
-        >>> jnp.allclose(x, saiunit.fft.ifft2(x_fft2))
+        >>> x_fft2 = u.fft.fft2(x)
+        >>> u.math.allclose(x, u.fft.ifft2(x_fft2))
         Array(True, dtype=bool)
     """
     return _fun_change_unit_unary(jnpfft.fft2,
@@ -444,7 +471,7 @@ def rfft2(
     saiunit implementation of :func:`numpy.fft.rfft2`.
 
     Args:
-        a: real-valued input array. Must have ``a.ndim >= 2``.
+        a: real-valued input quantity or array. Must have ``a.ndim >= 2``.
         s: optional length-2 sequence of integers. Specifies the effective size of the
             output along each specified axis. If not specified, it will default to the
             dimension of input along ``axes``.
@@ -454,7 +481,7 @@ def rfft2(
             and "forward" are supported.
 
     Returns:
-        An array containing the two-dimensional discrete Fourier transform of ``a``.
+        A quantity containing the two-dimensional discrete Fourier transform of ``a``.
         The size of the output along the axis ``axes[1]`` is ``(s[1]/2)+1``, if ``s[1]``
         is even and ``(s[1]+1)/2``, if ``s[1]`` is odd. The size of the output along
         the axis ``axes[0]`` is ``s[0]``.
@@ -470,47 +497,50 @@ def rfft2(
     Examples:
         ``saiunit.fft.rfft2`` computes the transform along the last two axes by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3, 5],
         ...                 [2, 4, 6]],
         ...                [[7, 9, 11],
-        ...                 [8, 10, 12]]])
+        ...                 [8, 10, 12]]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft2(x)
-        Array([[[21.+0.j  , -6.+3.46j],
-                [-3.+0.j  ,  0.+0.j  ]],
+        ...   print(u.fft.rfft2(x))
+        ArrayImpl([[[21.+0.j  , -6.+3.46j],
+                    [-3.+0.j  ,  0.+0.j  ]],
         <BLANKLINE>
-               [[57.+0.j  , -6.+3.46j],
-                [-3.+0.j  ,  0.+0.j  ]]], dtype=complex64)
+                   [[57.+0.j  , -6.+3.46j],
+                    [-3.+0.j  ,  0.+0.j  ]]], dtype=complex64) * meter * second2
 
         When ``s=[2, 4]``, dimension of the transform along ``axis -2`` will be
         ``2``, along ``axis -1`` will be ``(4/2)+1) = 3`` and dimension along other
         axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft2(x, s=[2, 4])
-        Array([[[21. +0.j, -8. -7.j,  7. +0.j],
-                [-3. +0.j,  0. +1.j, -1. +0.j]],
+        ...   print(u.fft.rfft2(x, s=[2, 4]))
+        ArrayImpl([[[21. +0.j, -8. -7.j,  7. +0.j],
+                    [-3. +0.j,  0. +1.j, -1. +0.j]],
         <BLANKLINE>
-               [[57. +0.j, -8.-19.j, 19. +0.j],
-                [-3. +0.j,  0. +1.j, -1. +0.j]]], dtype=complex64)
+                   [[57. +0.j, -8.-19.j, 19. +0.j],
+                    [-3. +0.j,  0. +1.j, -1. +0.j]]], dtype=complex64) * meter * second2
 
         When ``s=[3, 5]`` and ``axes=(0, 1)``, shape of the transform along ``axis 0``
         will be ``3``, along ``axis 1`` will be ``(5+1)/2 = 3`` and dimension along
         other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfft2(x, s=[3, 5], axes=(0, 1))
-        Array([[[ 18.   +0.j  ,  26.   +0.j  ,  34.   +0.j  ],
-                [ 11.09 -9.51j,  16.33-13.31j,  21.56-17.12j],
-                [ -0.09 -5.88j,   0.67 -8.23j,   1.44-10.58j]],
+        ...   print(u.fft.rfft2(x, s=[3, 5], axes=(0, 1)))
+        ArrayImpl([[[ 18.   +0.j  ,  26.   +0.j  ,  34.   +0.j  ],
+                    [ 11.09 -9.51j,  16.33-13.31j,  21.56-17.12j],
+                    [ -0.09 -5.88j,   0.67 -8.23j,   1.44-10.58j]],
         <BLANKLINE>
-              [[ -4.5 -12.99j,  -2.5 -16.45j,  -0.5 -19.92j],
-                [ -9.71 -6.3j , -10.05 -9.52j, -10.38-12.74j],
-                [ -4.95 +0.72j,  -5.78 -0.2j ,  -6.61 -1.12j]],
+                   [[ -4.5 -12.99j,  -2.5 -16.45j,  -0.5 -19.92j],
+                    [ -9.71 -6.3j , -10.05 -9.52j, -10.38-12.74j],
+                    [ -4.95 +0.72j,  -5.78 -0.2j ,  -6.61 -1.12j]],
         <BLANKLINE>
-              [[ -4.5 +12.99j,  -2.5 +16.45j,  -0.5 +19.92j],
-                [  3.47+10.11j,   6.43+11.42j,   9.38+12.74j],
-                [  3.19 +1.63j,   4.4  +1.38j,   5.61 +1.12j]]], dtype=complex64)
+                   [[ -4.5 +12.99j,  -2.5 +16.45j,  -0.5 +19.92j],
+                    [  3.47+10.11j,   6.43+11.42j,   9.38+12.74j],
+                    [  3.19 +1.63j,   4.4  +1.38j,   5.61 +1.12j]]],
+                  dtype=complex64) * meter * second2
     """
     return _fun_change_unit_unary(jnpfft.rfft2,
                                   lambda u: u * (second ** 2),
@@ -529,7 +559,7 @@ def fftn(
     saiunit implementation of :func:`numpy.fft.fftn`.
 
     Args:
-        a: input array
+        a: input quantity or array..
         s: sequence of integers. Specifies the shape of the result. If not specified,
             it will default to the shape of ``a`` along the specified ``axes``.
         axes: sequence of integers, default=None. Specifies the axes along which the
@@ -538,7 +568,7 @@ def fftn(
             supported.
 
     Returns:
-        An array containing the multidimensional discrete Fourier transform of ``a``.
+        A quantity containing the multidimensional discrete Fourier transform of ``a``.
 
     See also:
         - :func:`saiunit.fft.fft`: Computes a one-dimensional discrete Fourier
@@ -552,44 +582,47 @@ def fftn(
         ``saiunit.fft.fftn`` computes the transform along all the axes by default when
         ``axes`` argument is ``None``.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[1, 2, 5, 6],
         ...                [4, 1, 3, 7],
-        ...                [5, 9, 2, 1]])
+        ...                [5, 9, 2, 1]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.fftn(x)
-        Array([[ 46.  +0.j  ,   0.  +2.j  ,  -6.  +0.j  ,   0.  -2.j  ],
-               [ -2.  +1.73j,   6.12+6.73j,   0.  -1.73j, -18.12-3.27j],
-               [ -2.  -1.73j, -18.12+3.27j,   0.  +1.73j,   6.12-6.73j]],      dtype=complex64)
+        ...   print(u.fft.fftn(x))
+        ArrayImpl([[ 46.  +0.j  ,   0.  +2.j  ,  -6.  +0.j  ,   0.  -2.j  ],
+                   [ -2.  +1.73j,   6.12+6.73j,   0.  -1.73j, -18.12-3.27j],
+                   [ -2.  -1.73j, -18.12+3.27j,   0.  +1.73j,   6.12-6.73j]],
+                  dtype=complex64) * meter * second2
 
         When ``s=[2]``, dimension of the transform along ``axis -1`` will be ``2``
         and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.fftn(x, s=[2]))
-        [[ 3.+0.j -1.+0.j]
-         [ 5.+0.j  3.+0.j]
-         [14.+0.j -4.+0.j]]
+        ...   print(u.fft.fftn(x, s=[2]))
+        ArrayImpl([[ 3.+0.j, -1.+0.j],
+                   [ 5.+0.j,  3.+0.j],
+                   [14.+0.j, -4.+0.j]], dtype=complex64) * meter * second2
 
         When ``s=[2]`` and ``axes=[0]``, dimension of the transform along ``axis 0``
         will be ``2`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.fftn(x, s=[2], axes=[0]))
-        [[ 5.+0.j  3.+0.j  8.+0.j 13.+0.j]
-         [-3.+0.j  1.+0.j  2.+0.j -1.+0.j]]
+        ...   print(u.fft.fftn(x, s=[2], axes=[0]))
+        ArrayImpl([[ 5.+0.j,  3.+0.j,  8.+0.j, 13.+0.j],
+                   [-3.+0.j,  1.+0.j,  2.+0.j, -1.+0.j]], dtype=complex64) * meter * second
 
         When ``s=[2, 3]``, shape of the transform will be ``(2, 3)``.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.fftn(x, s=[2, 3]))
-        [[16. +0.j   -0.5+4.33j -0.5-4.33j]
-         [ 0. +0.j   -4.5+0.87j -4.5-0.87j]]
+        ...   print(u.fft.fftn(x, s=[2, 3]))
+        ArrayImpl([[16. +0.j  , -0.5+4.33j, -0.5-4.33j],
+                   [ 0. +0.j  , -4.5+0.87j, -4.5-0.87j]], dtype=complex64) * meter * second2
 
         ``saiunit.fft.ifftn`` can be used to reconstruct ``x`` from the result of
         ``saiunit.fft.fftn``.
 
-        >>> x_fftn = saiunit.fft.fftn(x)
-        >>> jnp.allclose(x, saiunit.fft.ifftn(x_fftn))
+        >>> x_fftn = u.fft.fftn(x)
+        >>> u.math.allclose(x, u.fft.ifftn(x_fftn))
         Array(True, dtype=bool)
     """
     n = _calculate_fftn_dimension(a.ndim, axes)
@@ -613,7 +646,7 @@ def rfftn(
     JAX implementation of :func:`numpy.fft.rfftn`.
 
     Args:
-        a: real-valued input array.
+        a: real-valued input quantity or array.
         s: optional sequence of integers. Controls the effective size of the input
             along each specified axis. If not specified, it will default to the
             dimension of input along ``axes``.
@@ -625,7 +658,7 @@ def rfftn(
             and "forward" are supported.
 
     Returns:
-        An array containing the multidimensional discrete Fourier transform of ``a``
+        A quantity containing the multidimensional discrete Fourier transform of ``a``
         having size specified in ``s`` along the axes ``axes`` except along the axis
         ``axes[-1]``. The size of the output along the axis ``axes[-1]`` is
         ``s[-1]//2+1``.
@@ -639,59 +672,63 @@ def rfftn(
             discrete Fourier transform.
 
     Examples:
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3, 5],
         ...                 [2, 4, 6]],
         ...                [[7, 9, 11],
-        ...                 [8, 10, 12]]])
+        ...                 [8, 10, 12]]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfftn(x)
-        Array([[[ 78.+0.j  , -12.+6.93j],
-                [ -6.+0.j  ,   0.+0.j  ]],
+        ...   print(u.fft.rfftn(x))
+        ArrayImpl([[[ 78.+0.j  , -12.+6.93j],
+                    [ -6.+0.j  ,   0.+0.j  ]],
         <BLANKLINE>
-               [[-36.+0.j  ,   0.+0.j  ],
-                [  0.+0.j  ,   0.+0.j  ]]], dtype=complex64)
+                   [[-36.+0.j  ,   0.+0.j  ],
+                    [  0.+0.j  ,   0.+0.j  ]]], dtype=complex64) * meter * second3
 
         When ``s=[3, 3, 4]``,  size of the transform along ``axes (-3, -2)`` will
         be (3, 3), and along ``axis -1`` will be ``4//2+1 = 3`` and size along
         other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfftn(x, s=[3, 3, 4])
-        Array([[[ 78.   +0.j  , -16.  -26.j  ,  26.   +0.j  ],
-                [ 15.  -36.37j, -16.12 +1.93j,   5.  -12.12j],
-                [ 15.  +36.37j,   8.12-11.93j,   5.  +12.12j]],
+        ...   print(u.fft.rfftn(x, s=[3, 3, 4]))
+        ArrayImpl([[[ 78.   +0.j  , -16.  -26.j  ,  26.   +0.j  ],
+                    [ 15.  -36.37j, -16.12 +1.93j,   5.  -12.12j],
+                    [ 15.  +36.37j,   8.12-11.93j,   5.  +12.12j]],
         <BLANKLINE>
-               [[ -7.5 -49.36j, -20.45 +9.43j,  -2.5 -16.45j],
-                [-25.5  -7.79j,  -0.6 +11.96j,  -8.5  -2.6j ],
-                [ 19.5 -12.99j,  -8.33 -6.5j ,   6.5  -4.33j]],
+                   [[ -7.5 -49.36j, -20.45 +9.43j,  -2.5 -16.45j],
+                    [-25.5  -7.79j,  -0.6 +11.96j,  -8.5  -2.6j ],
+                    [ 19.5 -12.99j,  -8.33 -6.5j ,   6.5  -4.33j]],
         <BLANKLINE>
-               [[ -7.5 +49.36j,  12.45 -4.43j,  -2.5 +16.45j],
-                [ 19.5 +12.99j,   0.33 -6.5j ,   6.5  +4.33j],
-                [-25.5  +7.79j,   4.6  +5.04j,  -8.5  +2.6j ]]], dtype=complex64)
+                   [[ -7.5 +49.36j,  12.45 -4.43j,  -2.5 +16.45j],
+                    [ 19.5 +12.99j,   0.33 -6.5j ,   6.5  +4.33j],
+                    [-25.5  +7.79j,   4.6  +5.04j,  -8.5  +2.6j ]]],
+                  dtype=complex64) * meter * second3
 
         When ``s=[3, 5]`` and ``axes=(0, 1)``, size of the transform along ``axis 0``
         will be ``3``, along ``axis 1`` will be ``5//2+1 = 3`` and dimension along
         other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.rfftn(x, s=[3, 5], axes=[0, 1])
-        Array([[[ 18.   +0.j  ,  26.   +0.j  ,  34.   +0.j  ],
-                [ 11.09 -9.51j,  16.33-13.31j,  21.56-17.12j],
-                [ -0.09 -5.88j,   0.67 -8.23j,   1.44-10.58j]],
+        ...   print(u.fft.rfftn(x, s=[3, 5], axes=[0, 1]))
+        ArrayImpl([[[ 18.   +0.j  ,  26.   +0.j  ,  34.   +0.j  ],
+                    [ 11.09 -9.51j,  16.33-13.31j,  21.56-17.12j],
+                    [ -0.09 -5.88j,   0.67 -8.23j,   1.44-10.58j]],
         <BLANKLINE>
-               [[ -4.5 -12.99j,  -2.5 -16.45j,  -0.5 -19.92j],
-                [ -9.71 -6.3j , -10.05 -9.52j, -10.38-12.74j],
-                [ -4.95 +0.72j,  -5.78 -0.2j ,  -6.61 -1.12j]],
+                   [[ -4.5 -12.99j,  -2.5 -16.45j,  -0.5 -19.92j],
+                    [ -9.71 -6.3j , -10.05 -9.52j, -10.38-12.74j],
+                    [ -4.95 +0.72j,  -5.78 -0.2j ,  -6.61 -1.12j]],
         <BLANKLINE>
-               [[ -4.5 +12.99j,  -2.5 +16.45j,  -0.5 +19.92j],
-                [  3.47+10.11j,   6.43+11.42j,   9.38+12.74j],
-                [  3.19 +1.63j,   4.4  +1.38j,   5.61 +1.12j]]], dtype=complex64)
+                   [[ -4.5 +12.99j,  -2.5 +16.45j,  -0.5 +19.92j],
+                    [  3.47+10.11j,   6.43+11.42j,   9.38+12.74j],
+                    [  3.19 +1.63j,   4.4  +1.38j,   5.61 +1.12j]]],
+                  dtype=complex64) * meter * second2
 
         For 1-D input:
 
-        >>> x1 = jnp.array([1, 2, 3, 4])
-        >>> saiunit.fft.rfftn(x1)
-        Array([10.+0.j, -2.+2.j, -2.+0.j], dtype=complex64)
+        >>> x1 = jnp.array([1, 2, 3, 4]) * u.meter
+        >>> u.fft.rfftn(x1)
+        ArrayImpl([10.+0.j, -2.+2.j, -2.+0.j], dtype=complex64) * meter * second
     """
     n = _calculate_fftn_dimension(a.ndim, axes)
     _unit_change_fun = lambda u: u * (second ** n)
@@ -717,7 +754,7 @@ def ifft2(
     saiunit implementation of :func:`numpy.fft.ifft2`.
 
     Args:
-        a: input array. Must have ``a.ndim >= 2``.
+        a: input quantity or array. Must have ``a.ndim >= 2``.
         s: optional length-2 sequence of integers. Specifies the size of the output
           in each specified axis. If not specified, it will default to the size of
           ``a`` along the specified ``axes``.
@@ -727,7 +764,7 @@ def ifft2(
           and "forward" are supported.
 
     Returns:
-        An array containing the two-dimensional inverse discrete Fourier transform
+        A quantity containing the two-dimensional inverse discrete Fourier transform
         of ``a`` along given ``axes``.
 
     See also:
@@ -741,42 +778,44 @@ def ifft2(
     Examples:
         ``saiunit.fft.ifft2`` computes the transform along the last two axes by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3],
         ...                 [2, 4]],
         ...                [[5, 7],
-        ...                 [6, 8]]])
+        ...                 [6, 8]]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.ifft2(x)
-        Array([[[ 2.5+0.j, -1. +0.j],
-                [-0.5+0.j,  0. +0.j]],
+        ...   print(u.fft.ifft2(x))
+        ArrayImpl([[[ 2.5+0.j, -1. +0.j],
+                    [-0.5+0.j,  0. +0.j]],
         <BLANKLINE>
-               [[ 6.5+0.j, -1. +0.j],
-                [-0.5+0.j,  0. +0.j]]], dtype=complex64)
+                   [[ 6.5+0.j, -1. +0.j],
+                    [-0.5+0.j,  0. +0.j]]], dtype=complex64) * meter / second2
 
         When ``s=[2, 3]``, dimension of the transform along ``axes (-2, -1)`` will be
         ``(2, 3)`` and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.ifft2(x, s=[2, 3])
-        Array([[[ 1.67+0.j  , -0.08+1.01j, -0.08-1.01j],
-                [-0.33+0.j  , -0.08-0.14j, -0.08+0.14j]],
+        ...   print(u.fft.ifft2(x, s=[2, 3]))
+        ArrayImpl([[[ 1.67+0.j  , -0.08+1.01j, -0.08-1.01j],
+                    [-0.33+0.j  , -0.08-0.14j, -0.08+0.14j]],
         <BLANKLINE>
-               [[ 4.33+0.j  ,  0.58+2.17j,  0.58-2.17j],
-                [-0.33+0.j  , -0.08-0.14j, -0.08+0.14j]]], dtype=complex64)
+                   [[ 4.33+0.j  ,  0.58+2.17j,  0.58-2.17j],
+                    [-0.33+0.j  , -0.08-0.14j, -0.08+0.14j]]], dtype=complex64) * meter / second2
 
         When ``s=[2, 3]`` and ``axes=(0, 1)``, shape of the transform along
         ``axes (0, 1)`` will be ``(2, 3)`` and dimension along other axes will be
         same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.ifft2(x, s=[2, 3], axes=(0, 1))
-        Array([[[ 2.33+0.j  ,  3.67+0.j  ],
-                [ 0.33+1.15j,  0.67+1.73j],
-                [ 0.33-1.15j,  0.67-1.73j]],
+        ...   print(u.fft.ifft2(x, s=[2, 3], axes=(0, 1)))
+        ArrayImpl([[[ 2.33+0.j  ,  3.67+0.j  ],
+                    [ 0.33+1.15j,  0.67+1.73j],
+                    [ 0.33-1.15j,  0.67-1.73j]],
         <BLANKLINE>
-               [[-1.33+0.j  , -1.33+0.j  ],
-                [-0.33-0.58j, -0.33-0.58j],
-                [-0.33+0.58j, -0.33+0.58j]]], dtype=complex64)
+                   [[-1.33+0.j  , -1.33+0.j  ],
+                    [-0.33-0.58j, -0.33-0.58j],
+                    [-0.33+0.58j, -0.33+0.58j]]], dtype=complex64) * meter / second2
     """
     return _fun_change_unit_unary(jnpfft.ifft2,
                                   lambda u: u / (second ** 2),
@@ -795,7 +834,7 @@ def irfft2(
     saiunit implementation of :func:`numpy.fft.irfft2`.
 
     Args:
-        a: input array. Must have ``a.ndim >= 2``.
+        a: input quantity or array. Must have ``a.ndim >= 2``.
         s: optional length-2 sequence of integers. Specifies the size of the output
             in each specified axis. If not specified, the dimension of output along
             axis ``axes[1]`` is ``2*(m-1)``, ``m`` is the size of input along axis
@@ -807,7 +846,7 @@ def irfft2(
             and "forward" are supported.
 
     Returns:
-        A real-valued array containing the two-dimensional inverse discrete Fourier
+        A real-valued quantity containing the two-dimensional inverse discrete Fourier
         transform of ``a``.
 
     See also:
@@ -821,43 +860,46 @@ def irfft2(
     Examples:
         ``saiunit.fft.irfft2`` computes the transform along the last two axes by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3, 5],
         ...                 [2, 4, 6]],
         ...                [[7, 9, 11],
-        ...                 [8, 10, 12]]])
-        >>> saiunit.fft.irfft2(x)
-        Array([[[ 3.5, -1. ,  0. , -1. ],
-                [-0.5,  0. ,  0. ,  0. ]],
+        ...                 [8, 10, 12]]]) * u.meter
+        >>> print(u.fft.irfft2(x))
+        ArrayImpl([[[ 3.5, -1. ,  0. , -1. ],
+                    [-0.5,  0. ,  0. ,  0. ]],
         <BLANKLINE>
-               [[ 9.5, -1. ,  0. , -1. ],
-                [-0.5,  0. ,  0. ,  0. ]]], dtype=float32)
+                   [[ 9.5, -1. ,  0. , -1. ],
+                    [-0.5,  0. ,  0. ,  0. ]]], dtype=float32) * meter / second2
 
         When ``s=[3, 3]``, dimension of the transform along ``axes (-2, -1)`` will be
         ``(3, 3)`` and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfft2(x, s=[3, 3])
-        Array([[[ 1.89, -0.44, -0.44],
-                [ 0.22, -0.78,  0.56],
-                [ 0.22,  0.56, -0.78]],
+        ...   print(u.fft.irfft2(x, s=[3, 3]))
+        ArrayImpl([[[ 1.89, -0.44, -0.44],
+                    [ 0.22, -0.78,  0.56],
+                    [ 0.22,  0.56, -0.78]],
         <BLANKLINE>
-               [[ 5.89, -0.44, -0.44],
-                [ 1.22, -1.78,  1.56],
-                [ 1.22,  1.56, -1.78]]], dtype=float32)
+                   [[ 5.89, -0.44, -0.44],
+                    [ 1.22, -1.78,  1.56],
+                    [ 1.22,  1.56, -1.78]]], dtype=float32) * meter / second2
 
         When ``s=[2, 3]`` and ``axes=(0, 1)``, shape of the transform along
         ``axes (0, 1)`` will be ``(2, 3)`` and dimension along other axes will be
         same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfft2(x, s=[2, 3], axes=(0, 1))
-        Array([[[ 4.67,  6.67,  8.67],
-                [-0.33, -0.33, -0.33],
-                [-0.33, -0.33, -0.33]],
+        ...   print(u.fft.irfft2(x, s=[2, 3], axes=(0, 1)))
+        ArrayImpl([[[ 4.67,  6.67,  8.67],
+                    [-0.33, -0.33, -0.33],
+                    [-0.33, -0.33, -0.33]],
         <BLANKLINE>
-               [[-3.  , -3.  , -3.  ],
-                [ 0.  ,  0.  ,  0.  ],
-                [ 0.  ,  0.  ,  0.  ]]], dtype=float32)
+                   [[-3.  , -3.  , -3.  ],
+                    [ 0.  ,  0.  ,  0.  ],
+                    [ 0.  ,  0.  ,  0.  ]]], dtype=float32) * meter / second2
+
     """
     return _fun_change_unit_unary(jnpfft.irfft2,
                                   lambda u: u / (second ** 2),
@@ -876,7 +918,7 @@ def ifftn(
     saiunit implementation of :func:`numpy.fft.ifftn`.
 
     Args:
-        a: input array
+        a: input quantity or array.
         s: sequence of integers. Specifies the shape of the result. If not specified,
             it will default to the shape of ``a`` along the specified ``axes``.
         axes: sequence of integers, default=None. Specifies the axes along which the
@@ -885,7 +927,7 @@ def ifftn(
             supported.
 
     Returns:
-        An array containing the multidimensional inverse discrete Fourier transform
+        A quantity containing the multidimensional inverse discrete Fourier transform
         of ``a``.
 
     See also:
@@ -900,38 +942,41 @@ def ifftn(
         ``saiunit.fft.ifftn`` computes the transform along all the axes by default when
         ``axes`` argument is ``None``.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[1, 2, 5, 3],
         ...                [4, 1, 2, 6],
-        ...                [5, 3, 2, 1]])
+        ...                [5, 3, 2, 1]]) * u.meter
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifftn(x))
-        [[ 2.92+0.j    0.08-0.33j  0.25+0.j    0.08+0.33j]
-         [-0.08+0.14j -0.04-0.03j  0.  -0.29j -1.05-0.11j]
-         [-0.08-0.14j -1.05+0.11j  0.  +0.29j -0.04+0.03j]]
+        ...   print(u.fft.ifftn(x))
+        ArrayImpl([[ 2.92+0.j  ,  0.08-0.33j,  0.25+0.j  ,  0.08+0.33j],
+                   [-0.08+0.14j, -0.04-0.03j,  0.  -0.29j, -1.05-0.11j],
+                   [-0.08-0.14j, -1.05+0.11j,  0.  +0.29j, -0.04+0.03j]],
+                   dtype=complex64) * meter / second2
 
         When ``s=[3]``, dimension of the transform along ``axis -1`` will be ``3``
         and dimension along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifftn(x, s=[3]))
-        [[ 2.67+0.j   -0.83-0.87j -0.83+0.87j]
-         [ 2.33+0.j    0.83-0.29j  0.83+0.29j]
-         [ 3.33+0.j    0.83+0.29j  0.83-0.29j]]
+        ...   print(u.fft.ifftn(x, s=[3]))
+        ArrayImpl([[ 2.67+0.j  , -0.83-0.87j, -0.83+0.87j],
+                   [ 2.33+0.j  ,  0.83-0.29j,  0.83+0.29j],
+                   [ 3.33+0.j  ,  0.83+0.29j,  0.83-0.29j]], dtype=complex64) * meter / second2
 
         When ``s=[2]`` and ``axes=[0]``, dimension of the transform along ``axis 0``
         will be ``2`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifftn(x, s=[2], axes=[0]))
-        [[ 2.5+0.j  1.5+0.j  3.5+0.j  4.5+0.j]
-         [-1.5+0.j  0.5+0.j  1.5+0.j -1.5+0.j]]
+        ...   print(u.fft.ifftn(x, s=[2], axes=[0]))
+        ArrayImpl([[ 2.5+0.j,  1.5+0.j,  3.5+0.j,  4.5+0.j],
+                   [-1.5+0.j,  0.5+0.j,  1.5+0.j, -1.5+0.j]], dtype=complex64) * meter / second
 
         When ``s=[2, 3]``, shape of the transform will be ``(2, 3)``.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   print(saiunit.fft.ifftn(x, s=[2, 3]))
-        [[ 2.5 +0.j    0.  -0.58j  0.  +0.58j]
-         [ 0.17+0.j   -0.83-0.29j -0.83+0.29j]]
+        ...   print(u.fft.ifftn(x, s=[2, 3]))
+        ArrayImpl([[ 2.5 +0.j  ,  0.  -0.58j,  0.  +0.58j],
+                   [ 0.17+0.j  , -0.83-0.29j, -0.83+0.29j]], dtype=complex64) * meter / second2
     """
     n = _calculate_fftn_dimension(a.ndim, axes)
     _unit_change_fun = lambda u: u / (second ** n)
@@ -954,7 +999,7 @@ def irfftn(
     saiunit implementation of :func:`numpy.fft.irfftn`.
 
     Args:
-        a: input array.
+        a: input quantity or array.
         s: optional sequence of integers. Specifies the size of the output in each
             specified axis. If not specified, the dimension of output along axis
             ``axes[-1]`` is ``2*(m-1)``, ``m`` is the size of input along axis ``axes[-1]``
@@ -967,7 +1012,7 @@ def irfftn(
             and "forward" are supported.
 
     Returns:
-        A real-valued array containing the multidimensional inverse discrete Fourier
+        A real-valued quantity containing the multidimensional inverse discrete Fourier
         transform of ``a`` with size ``s`` along specified ``axes``, and the same as
         the input along other axes.
 
@@ -982,43 +1027,45 @@ def irfftn(
     Examples:
         ``saiunit.fft.irfftn`` computes the transform along all the axes by default.
 
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
         >>> x = jnp.array([[[1, 3, 5],
         ...                 [2, 4, 6]],
         ...                [[7, 9, 11],
-        ...                 [8, 10, 12]]])
-        >>> saiunit.fft.irfftn(x)
-        Array([[[ 6.5, -1. ,  0. , -1. ],
-                [-0.5,  0. ,  0. ,  0. ]],
+        ...                 [8, 10, 12]]]) * u.meter
+        >>> u.fft.irfftn(x)
+        ArrayImpl([[[ 6.5, -1. ,  0. , -1. ],
+                    [-0.5,  0. ,  0. ,  0. ]],
         <BLANKLINE>
-               [[-3. ,  0. ,  0. ,  0. ],
-                [ 0. ,  0. ,  0. ,  0. ]]], dtype=float32)
+                   [[-3. ,  0. ,  0. ,  0. ],
+                    [ 0. ,  0. ,  0. ,  0. ]]], dtype=float32) * meter / second3
 
         When ``s=[3, 4]``, size of the transform along ``axes (-2, -1)`` will be
         ``(3, 4)`` and size along other axes will be the same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfftn(x, s=[3, 4])
-        Array([[[ 2.33, -0.67,  0.  , -0.67],
-                [ 0.33, -0.74,  0.  ,  0.41],
-                [ 0.33,  0.41,  0.  , -0.74]],
+        ...   print(u.fft.irfftn(x, s=[3, 4]))
+        ArrayImpl([[[ 2.33, -0.67,  0.  , -0.67],
+                    [ 0.33, -0.74,  0.  ,  0.41],
+                    [ 0.33,  0.41,  0.  , -0.74]],
         <BLANKLINE>
-               [[ 6.33, -0.67,  0.  , -0.67],
-                [ 1.33, -1.61,  0.  ,  1.28],
-                [ 1.33,  1.28,  0.  , -1.61]]], dtype=float32)
+                   [[ 6.33, -0.67,  0.  , -0.67],
+                    [ 1.33, -1.61,  0.  ,  1.28],
+                    [ 1.33,  1.28,  0.  , -1.61]]], dtype=float32) * meter / second3
 
         When ``s=[3]`` and ``axes=[0]``, size of the transform along ``axes 0`` will
         be ``3`` and dimension along other axes will be same as that of input.
 
         >>> with jnp.printoptions(precision=2, suppress=True):
-        ...   saiunit.fft.irfftn(x, s=[3], axes=[0])
-        Array([[[ 5.,  7.,  9.],
-                [ 6.,  8., 10.]],
+        ...   print(u.fft.irfftn(x, s=[3], axes=[0]))
+        ArrayImpl([[[ 5.,  7.,  9.],
+                    [ 6.,  8., 10.]],
         <BLANKLINE>
-               [[-2., -2., -2.],
-                [-2., -2., -2.]],
+                   [[-2., -2., -2.],
+                    [-2., -2., -2.]],
         <BLANKLINE>
-               [[-2., -2., -2.],
-                [-2., -2., -2.]]], dtype=float32)
+                   [[-2., -2., -2.],
+                    [-2., -2., -2.]]], dtype=float32) * meter / second
     """
     n = _calculate_fftn_dimension(a.ndim, axes)
     _unit_change_fun = lambda u: u / (second ** n)
@@ -1033,27 +1080,27 @@ def irfftn(
 # ---------------------
 
 _time_freq_map = {
-    0: (u.second, u.hertz),
-    -24: (u.ysecond, u.Yhertz),
-    -21: (u.zsecond, u.Zhertz),
-    -18: (u.asecond, u.Ehertz),
-    -15: (u.fsecond, u.Phertz),
-    -12: (u.psecond, u.Thertz),
-    -9: (u.nsecond, u.Ghertz),
-    -6: (u.usecond, u.Mhertz),
-    -3: (u.msecond, u.khertz),
-    -2: (u.csecond, u.hhertz),
-    -1: (u.dsecond, u.dahertz),
-    1: (u.dasecond, u.dhertz),
-    2: (u.hsecond, u.chertz),
-    3: (u.ksecond, u.mhertz),
-    6: (u.Msecond, u.uhertz),
-    9: (u.Gsecond, u.nhertz),
-    12: (u.Tsecond, u.phertz),
-    15: (u.Psecond, u.fhertz),
-    18: (u.Esecond, u.ahertz),
-    21: (u.Zsecond, u.zhertz),
-    24: (u.Ysecond, u.yhertz),
+    0: (uc.second, uc.hertz),
+    -24: (uc.ysecond, uc.Yhertz),
+    -21: (uc.zsecond, uc.Zhertz),
+    -18: (uc.asecond, uc.Ehertz),
+    -15: (uc.fsecond, uc.Phertz),
+    -12: (uc.psecond, uc.Thertz),
+    -9: (uc.nsecond, uc.Ghertz),
+    -6: (uc.usecond, uc.Mhertz),
+    -3: (uc.msecond, uc.khertz),
+    -2: (uc.csecond, uc.hhertz),
+    -1: (uc.dsecond, uc.dahertz),
+    1: (uc.dasecond, uc.dhertz),
+    2: (uc.hsecond, uc.chertz),
+    3: (uc.ksecond, uc.mhertz),
+    6: (uc.Msecond, uc.uhertz),
+    9: (uc.Gsecond, uc.nhertz),
+    12: (uc.Tsecond, uc.phertz),
+    15: (uc.Psecond, uc.fhertz),
+    18: (uc.Esecond, uc.ahertz),
+    21: (uc.Zsecond, uc.zhertz),
+    24: (uc.Ysecond, uc.yhertz),
 }
 
 
@@ -1094,11 +1141,18 @@ def fftfreq(
             to which the created array will be committed.
 
     Returns:
-        Array of sample frequencies, length ``n``.
+        Quantity of sample frequencies, length ``n``.
 
     See also:
     - :func:`saiunit.fft.rfftfreq`: frequencies for use with
       :func:`~saiunit.fft.rfft` and :func:`~saiunit.fft.irfft`.
+
+    Example:
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
+        >>> x = 1 * u.second
+        >>> u.fft.fftfreq(4, x)
+        ArrayImpl([ 0.  ,  0.25, -0.5 , -0.25], dtype=float32) * hertz
     """
     if isinstance(d, Quantity):
         assert d.dim == second.dim, f"Expected time unit, got {d.unit}"
@@ -1147,11 +1201,18 @@ def rfftfreq(
             to which the created array will be committed.
 
     Returns:
-        Array of sample frequencies, length ``n // 2 + 1``.
+        Quantity of sample frequencies, length ``n // 2 + 1``.
 
     See also:
     - :func:`saiunit.fft.fftfreq`: frequencies for use with
       :func:`~saiunit.fft.fft` and :func:`~saiunit.fft.ifft`.
+
+    Example:
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
+        >>> x = jnp.array([1, 2, 3, 4]) * u.second
+        >>> u.fft.rfftfreq(4, x)
+        ArrayImpl([0.  , 0.25, 0.5 ], dtype=float32) * hertz
     """
     if isinstance(d, Quantity):
         assert d.dim == second.dim, f"Expected time unit, got {d.unit}"

--- a/saiunit/fft/_fft_keep_unit.py
+++ b/saiunit/fft/_fft_keep_unit.py
@@ -42,7 +42,7 @@ def fftshift(
     saiunit implementation of :func:`numpy.fft.fftshift`.
 
     Args:
-        x: N-dimensional array array of frequencies.
+        x: N-dimensional quantity or array of frequencies.
         axes: optional integer or sequence of integers specifying which axes to
             shift. If None (default), then shift all axes.
 
@@ -56,20 +56,21 @@ def fftshift(
     Examples:
         Generate FFT frequencies with :func:`~saiunit.fft.fftfreq`:
 
-        >>> freq = saiunit.fft.fftfreq(5)
+        >>> import saiunit as u
+        >>> freq = u.fft.fftfreq(5, 1 * u.second)
         >>> freq
-        Array([ 0. ,  0.2,  0.4, -0.4, -0.2], dtype=float32)
+        ArrayImpl([ 0.  ,  0.25, -0.5 , -0.25], dtype=float32) * hertz
 
         Use ``fftshift`` to shift the zero-frequency entry to the middle of the array:
 
-        >>> shifted_freq = saiunit.fft.fftshift(freq)
+        >>> shifted_freq = u.fft.fftshift(freq)
         >>> shifted_freq
-        Array([-0.4, -0.2,  0. ,  0.2,  0.4], dtype=float32)
+        ArrayImpl([-0.5 , -0.25,  0.  ,  0.25], dtype=float32) * hertz
 
         Unshift with :func:`~saiunit.fft.ifftshift` to recover the original frequencies:
 
-        >>> saiunit.fft.ifftshift(shifted_freq)
-        Array([ 0. ,  0.2,  0.4, -0.4, -0.2], dtype=float32)
+        >>> u.fft.ifftshift(shifted_freq)
+        ArrayImpl([ 0.  ,  0.25, -0.5 , -0.25], dtype=float32) * hertz
     """
     return _fun_keep_unit_unary(jnpfft.fftshift, x, axes=axes)
 
@@ -98,20 +99,21 @@ def ifftshift(
     Examples:
         Generate FFT frequencies with :func:`~saiunit.fft.fftfreq`:
 
-        >>> freq = saiunit.fft.fftfreq(5)
+        >>> import saiunit as u
+        >>> freq = u.fft.fftfreq(4, 1 * u.second)
         >>> freq
-        Array([ 0. ,  0.2,  0.4, -0.4, -0.2], dtype=float32)
+        ArrayImpl([ 0.  ,  0.25, -0.5 , -0.25], dtype=float32) * hertz
 
         Use :func:`~saiunit.fft.fftshift` to shift the zero-frequency entry
         to the middle of the array:
 
-        >>> shifted_freq = saiunit.fft.fftshift(freq)
+        >>> shifted_freq = u.fft.fftshift(freq)
         >>> shifted_freq
-        Array([-0.4, -0.2,  0. ,  0.2,  0.4], dtype=float32)
+        ArrayImpl([-0.5 , -0.25,  0.  ,  0.25], dtype=float32) * hertz
 
         Unshift with ``ifftshift`` to recover the original frequencies:
 
-        >>> saiunit.fft.ifftshift(shifted_freq)
-        Array([ 0. ,  0.2,  0.4, -0.4, -0.2], dtype=float32)
+        >>> u.fft.ifftshift(shifted_freq)
+        ArrayImpl([ 0.  ,  0.25, -0.5 , -0.25], dtype=float32) * hertz
     """
     return _fun_keep_unit_unary(jnpfft.ifftshift, x, axes=axes)

--- a/saiunit/fft/_fft_keep_unit.py
+++ b/saiunit/fft/_fft_keep_unit.py
@@ -85,7 +85,7 @@ def ifftshift(
     saiunit implementation of :func:`numpy.fft.ifftshift`.
 
     Args:
-        x: N-dimensional array array of frequencies.
+        x: N-dimensional quantity or array of frequencies.
         axes: optional integer or sequence of integers specifying which axes to
             shift. If None (default), then shift all axes.
 


### PR DESCRIPTION
Closes #23

## Summary by Sourcery

Improve documentation for the `fft` module functions.

Documentation:
- Clarify that FFT functions accept and return `Quantity` objects.
- Update examples to use `Quantity` objects and demonstrate unit handling.
- Explain unit transformations (e.g., spatial to frequency domain) in examples.
- Add usage examples for `fftfreq` and `rfftfreq`.