### PR TITLE
[jax] Add safe_map compatibility layer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The official documentation is hosted on Read the Docs: [https://saiunit.readthed
   journal={Nature Communications},
   year={2025},
   volume={16},
-  url={https://api.semanticscholar.org/CorpusID:277853734}
+  url={https://doi.org/10.1038/s41467-025-58626-4}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     'Intended Audience :: Developers',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -1,0 +1,36 @@
+# Copyright 2025 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+import jax
+
+__all__ = [
+    'safe_map',
+]
+
+
+if jax.__version_info__ < (0, 6, 0):
+    from jax.util import safe_map, safe_zip, unzip2, unzip3, wraps
+
+else:
+
+    def safe_map(f, *args):
+        args = list(map(list, args))
+        n = len(args[0])
+        for arg in args[1:]:
+            assert len(arg) == n, f'length mismatch: {list(map(len, args))}'
+        return list(map(f, *args))
+

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -21,9 +21,8 @@ __all__ = [
     'safe_map',
 ]
 
-
 if jax.__version_info__ < (0, 6, 0):
-    from jax.util import safe_map, safe_zip, unzip2, unzip3, wraps
+    from jax.util import safe_map
 
 else:
 
@@ -33,4 +32,3 @@ else:
         for arg in args[1:]:
             assert len(arg) == n, f'length mismatch: {list(map(len, args))}'
         return list(map(f, *args))
-

--- a/saiunit/autograd/_jacobian.py
+++ b/saiunit/autograd/_jacobian.py
@@ -20,16 +20,19 @@ from typing import (Sequence, Callable, Any)
 
 import jax
 import numpy as np
-from jax._src.api import (_jvp,
-                          _vjp,
-                          _check_input_dtype_jacrev,
-                          _check_output_dtype_jacrev,
-                          _check_input_dtype_jacfwd,
-                          _check_output_dtype_jacfwd)
+from jax._src.api import (
+    _jvp,
+    _vjp,
+    _check_input_dtype_jacrev,
+    _check_output_dtype_jacrev,
+    _check_input_dtype_jacfwd,
+    _check_output_dtype_jacfwd
+)
 from jax.api_util import argnums_partial
 from jax.extend import linear_util
 
 from saiunit._base import Quantity, maybe_decimal, get_magnitude, get_unit
+from saiunit._compatible_import import safe_map
 from ._misc import _ensure_index, _check_callable
 
 __all__ = [
@@ -354,7 +357,7 @@ def jacfwd(
 
 def _std_basis(pytree):
     leaves, _ = jax.tree.flatten(pytree)
-    ndim = sum(jax.util.safe_map(np.size, leaves))
+    ndim = sum(safe_map(np.size, leaves))
     dtype = jax.dtypes.result_type(*leaves)
     flat_basis = jax.numpy.eye(ndim, dtype=dtype)
     return _unravel_array_into_pytree(pytree, 1, flat_basis)
@@ -372,7 +375,7 @@ def _jacfwd_unravel(input_pytree, arr, is_leaf=None):
     leaves, treedef = jax.tree.flatten(input_pytree, is_leaf=is_leaf)
     axis = axis % arr.ndim
     shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis + 1:] for l in leaves]
-    parts = _split(arr, np.cumsum(jax.util.safe_map(np.size, leaves[:-1])), axis)
+    parts = _split(arr, np.cumsum(safe_map(np.size, leaves[:-1])), axis)
     reshaped_parts = [x.reshape(shape) for x, shape in zip(parts, shapes)]
     unit_reshaped_parts = [
         maybe_decimal(
@@ -403,7 +406,7 @@ def _unravel_array_into_pytree(pytree, axis, arr, is_leaf=None):
     leaves, treedef = jax.tree.flatten(pytree, is_leaf=is_leaf)
     axis = axis % arr.ndim
     shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis + 1:] for l in leaves]
-    parts = _split(arr, np.cumsum(jax.util.safe_map(np.size, leaves[:-1])), axis)
+    parts = _split(arr, np.cumsum(safe_map(np.size, leaves[:-1])), axis)
     reshaped_parts = [x.reshape(shape) for x, shape in zip(parts, shapes)]
     return jax.tree.unflatten(treedef, reshaped_parts)
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
## Summary by Sourcery

Introduce a compatibility layer for JAX version handling, specifically for `safe_map`, and update its usage internally.

Enhancements:
- Add a compatibility module to handle `safe_map` import/definition based on JAX version.
- Refactor internal code to use the new compatibility `safe_map` function.

Documentation:
- Update the citation URL in the README.