### PR TITLE
[autograd] Add debug_info to wrap_init

### DIFF
--- a/brainunit/pyproject.toml.template
+++ b/brainunit/pyproject.toml.template
@@ -49,8 +49,6 @@ classifiers = [
 keywords = ['physical unit', 'physical quantity', 'brain modeling']
 
 dependencies = [
-    'jax',
-    'jaxlib',
     'numpy',
     'typing_extensions',
     'saiunit==',

--- a/brainunit/setup.py.template
+++ b/brainunit/setup.py.template
@@ -58,7 +58,6 @@ setup(
   python_requires='>=3.10',
   install_requires=[
     'numpy>=1.15',
-    'jax',
     'typing_extensions',
     'saiunit=='
   ],
@@ -69,9 +68,9 @@ setup(
     "Source Code": "https://github.com/chaobrain/brainunit",
   },
   extras_require={
-    'cpu': ['jaxlib'],
-    'cuda12': ['jaxlib[cuda12]', ],
-    'tpu': ['jaxlib[tpu]'],
+    'cpu': ['jax[cpu]'],
+    'cuda12': ['jax[cuda12]', ],
+    'tpu': ['jax[tpu]'],
   },
   keywords=('physical unit, '
             'physical quantity, '

--- a/saiunit/_base_test.py
+++ b/saiunit/_base_test.py
@@ -546,7 +546,7 @@ class TestQuantity(unittest.TestCase):
             set_to_value((slice(2), slice(3)), np.ones((2, 3)))
 
         quantity = Quantity(brainstate.random.rand(10))
-        quantity[0] = 1
+        quantity[0] = 1.0
 
     def test_multiplication_division(self):
         u = mV

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -15,14 +15,22 @@
 
 # -*- coding: utf-8 -*-
 
+from typing import TypeVar, Iterable
 import jax
 
 __all__ = [
     'safe_map',
+    'unzip2',
 ]
 
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+
+
 if jax.__version_info__ < (0, 6, 0):
-    from jax.util import safe_map
+    from jax.util import safe_map, unzip2
 
 else:
 
@@ -32,3 +40,16 @@ else:
         for arg in args[1:]:
             assert len(arg) == n, f'length mismatch: {list(map(len, args))}'
         return list(map(f, *args))
+
+
+    def unzip2(xys: Iterable[tuple[T1, T2]] ) -> tuple[tuple[T1, ...], tuple[T2, ...]]:
+        """Unzip sequence of length-2 tuples into two tuples."""
+        # Note: we deliberately don't use zip(*xys) because it is lazily evaluated,
+        # is too permissive about inputs, and does not guarantee a length-2 output.
+        xs: list[T1] = []
+        ys: list[T2] = []
+        for x, y in xys:
+            xs.append(x)
+            ys.append(y)
+        return tuple(xs), tuple(ys)
+

--- a/saiunit/autograd/_jacobian.py
+++ b/saiunit/autograd/_jacobian.py
@@ -28,7 +28,7 @@ from jax._src.api import (
     _check_input_dtype_jacfwd,
     _check_output_dtype_jacfwd
 )
-from jax.api_util import argnums_partial
+from jax.api_util import argnums_partial, debug_info
 from jax.extend import linear_util
 
 from saiunit._base import Quantity, maybe_decimal, get_magnitude, get_unit
@@ -142,7 +142,9 @@ def jacrev(
 
     @wraps(fun)
     def jacfun(*args, **kwargs):
-        f = linear_util.wrap_init(fun, kwargs)
+        f = linear_util.wrap_init(
+            fun, kwargs, debug_info=debug_info('brainunit.autograd.jacrev', fun, args, kwargs)
+        )
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         jax.tree.map(partial(_check_input_dtype_jacrev, holomorphic, allow_int), dyn_args)
         if not has_aux:
@@ -333,7 +335,9 @@ def jacfwd(
 
     @wraps(fun)
     def jacfun(*args, **kwargs):
-        f = linear_util.wrap_init(fun, kwargs)
+        f = linear_util.wrap_init(
+            fun, kwargs, debug_info=debug_info('brainunit.autograd.jacfwd', fun, args, kwargs)
+        )
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         jax.tree.map(partial(_check_input_dtype_jacfwd, holomorphic), dyn_args)
         if not has_aux:

--- a/saiunit/autograd/_vector_grad.py
+++ b/saiunit/autograd/_vector_grad.py
@@ -21,7 +21,7 @@ from typing import Callable, Sequence
 import jax
 from jax import numpy as jnp
 from jax._src.api import _vjp
-from jax.api_util import argnums_partial
+from jax.api_util import argnums_partial, debug_info
 from jax.extend import linear_util
 
 from saiunit._base import get_unit, maybe_decimal, Quantity, get_mantissa
@@ -77,7 +77,9 @@ def vector_grad(
 
     @wraps(func)
     def grad_fun(*args, **kwargs):
-        f = linear_util.wrap_init(func, kwargs)
+        f = linear_util.wrap_init(
+            func, kwargs, debug_info=debug_info('vector_grad', func, args, kwargs)
+        )
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         if has_aux:
             y, vjp_fn, aux = _vjp(f_partial, *dyn_args, has_aux=True)

--- a/saiunit/math/_einops.py
+++ b/saiunit/math/_einops.py
@@ -496,7 +496,7 @@ def _get_shape(x) -> Tuple[int, ...]:
     if isinstance(x, Quantity):
         shape = x.shape
     else:
-        shape = jnp.shape(x)
+        shape = asarray(x).shape
     return shape
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     author_email='chao.brain@qq.com',
     packages=packages,
     python_requires='>=3.10',
-    install_requires=['numpy>=1.15', 'jax', 'typing_extensions'],
+    install_requires=['numpy>=1.15', 'typing_extensions'],
     url='https://github.com/chaobrain/saiunit',
     project_urls={
         "Bug Tracker": "https://github.com/chaobrain/saiunit/issues",
@@ -65,9 +65,9 @@ setup(
         "Source Code": "https://github.com/chaobrain/saiunit",
     },
     extras_require={
-        'cpu': ['jaxlib'],
-        'cuda12': ['jaxlib[cuda12]', ],
-        'tpu': ['jaxlib[tpu]'],
+        'cpu': ['jax[cpu]'],
+        'cuda12': ['jax[cuda12]', ],
+        'tpu': ['jax[tpu]'],
     },
     keywords=(
         'physical unit, '


### PR DESCRIPTION
## Summary by Sourcery

Add debug_info to linear_util.wrap_init in jacrev, jacfwd, and vector_grad for improved error tracing, and update setup.py to remove direct jax dependency and configure JAX extras via extras_require.

Enhancements:
- Include debug_info in wrap_init calls for jacrev, jacfwd, and vector_grad functions to improve debugging.

Build:
- Remove direct jax dependency and update extras_require to specify JAX CPU, CUDA, and TPU variants.