### PR TITLE
[jax] Add API compatibility layer and expand CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,42 @@ jobs:
           pytest saiunit/
 
 
+  test_jax_version:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.12" ]
+        jax-version: ["0.4.38", "0.5.2", "0.6.0"]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip cache purge
+          python -m pip install --upgrade pip setuptools --no-cache-dir
+          python -m pip install -r requirements-dev.txt  --no-cache-dir
+          if [ "${{ matrix.jax-version }}" == "" ]; then
+            python -m pip install jax || exit 1
+          else
+            python -m pip install jax==${{ matrix.jax-version }} || exit 1
+          fi
+          python -m pip install . || exit 1
+      - name: Test with pytest
+        run: |
+          pytest saiunit/
+
+
   test_windows:
     runs-on: windows-latest
     strategy:

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -15,18 +15,38 @@
 
 # -*- coding: utf-8 -*-
 
-from typing import TypeVar, Iterable
+from typing import TypeVar, Iterable, Callable
+
 import jax
 
 __all__ = [
     'safe_map',
     'unzip2',
+    'debug_info',
+    'wrap_init',
 ]
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+
+from jax.extend import linear_util
+
+if jax.__version_info__ < (0, 5, 0):
+    from jax._src.api_util import debug_info
+
+else:
+    from jax.api_util import debug_info
+
+
+def wrap_init(fun: Callable, args: tuple, kwargs: dict, name: str):
+    if jax.__version_info__ < (0, 5, 0):
+        f = linear_util.wrap_init(fun, kwargs)
+    else:
+        f = linear_util.wrap_init(fun, kwargs, debug_info=debug_info(name, fun, args, kwargs))
+    return f
+
 
 
 if jax.__version_info__ < (0, 6, 0):

--- a/saiunit/autograd/_jacobian.py
+++ b/saiunit/autograd/_jacobian.py
@@ -28,11 +28,11 @@ from jax._src.api import (
     _check_input_dtype_jacfwd,
     _check_output_dtype_jacfwd
 )
-from jax.api_util import argnums_partial, debug_info
+from jax.api_util import argnums_partial
 from jax.extend import linear_util
 
 from saiunit._base import Quantity, maybe_decimal, get_magnitude, get_unit
-from saiunit._compatible_import import safe_map
+from saiunit._compatible_import import safe_map, wrap_init
 from ._misc import _ensure_index, _check_callable
 
 __all__ = [
@@ -142,9 +142,7 @@ def jacrev(
 
     @wraps(fun)
     def jacfun(*args, **kwargs):
-        f = linear_util.wrap_init(
-            fun, kwargs, debug_info=debug_info('brainunit.autograd.jacrev', fun, args, kwargs)
-        )
+        f = wrap_init(fun, args, kwargs, 'brainunit.autograd.jacrev')
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         jax.tree.map(partial(_check_input_dtype_jacrev, holomorphic, allow_int), dyn_args)
         if not has_aux:
@@ -335,9 +333,7 @@ def jacfwd(
 
     @wraps(fun)
     def jacfun(*args, **kwargs):
-        f = linear_util.wrap_init(
-            fun, kwargs, debug_info=debug_info('brainunit.autograd.jacfwd', fun, args, kwargs)
-        )
+        f = wrap_init(fun, args, kwargs, 'brainunit.autograd.jacfwd')
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         jax.tree.map(partial(_check_input_dtype_jacfwd, holomorphic), dyn_args)
         if not has_aux:

--- a/saiunit/autograd/_vector_grad.py
+++ b/saiunit/autograd/_vector_grad.py
@@ -21,9 +21,10 @@ from typing import Callable, Sequence
 import jax
 from jax import numpy as jnp
 from jax._src.api import _vjp
-from jax.api_util import argnums_partial, debug_info
+from jax.api_util import argnums_partial
 from jax.extend import linear_util
 
+from saiunit._compatible_import import wrap_init
 from saiunit._base import get_unit, maybe_decimal, Quantity, get_mantissa
 from ._misc import _check_callable
 
@@ -77,9 +78,7 @@ def vector_grad(
 
     @wraps(func)
     def grad_fun(*args, **kwargs):
-        f = linear_util.wrap_init(
-            func, kwargs, debug_info=debug_info('vector_grad', func, args, kwargs)
-        )
+        f = wrap_init(func, args, kwargs, 'vector_grad')
         f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
         if has_aux:
             y, vjp_fn, aux = _vjp(f_partial, *dyn_args, has_aux=True)

--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -23,11 +23,11 @@ import numpy as np
 from jax.numpy import fft as jnpfft
 from jaxlib import xla_client
 
-from .. import _unit_common as uc
-from .._base import Quantity, Unit, get_or_create_dimension
-from .._misc import set_module_as
-from .._unit_common import second
-from ..math._fun_change_unit import _fun_change_unit_unary
+from saiunit import _unit_common as uc
+from saiunit._base import Quantity, Unit, get_or_create_dimension
+from saiunit._misc import set_module_as
+from saiunit._unit_common import second
+from saiunit.math._fun_change_unit import _fun_change_unit_unary
 
 __all__ = [
     # return original unit * time unit

--- a/saiunit/fft/_fft_keep_unit.py
+++ b/saiunit/fft/_fft_keep_unit.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import annotations
 
 from typing import Union, Sequence
 


### PR DESCRIPTION
## Summary by Sourcery

Add a compatibility layer for differing JAX APIs, refactor relevant modules to use it, and expand CI to validate against multiple JAX versions on macOS.

New Features:
- Add a macOS CI job to test against multiple JAX versions (0.4.38, 0.5.2, 0.6.0).

Enhancements:
- Introduce wrap_init and conditional debug_info imports to handle JAX API changes across versions.
- Refactor autograd modules (jacrev, jacfwd, vector_grad) to use the wrap_init compatibility layer.
- Convert FFT module imports to fully qualified saiunit paths for consistency.