### PR TITLE
Refactor debug_info import and update version check in wrap_init

### DIFF
--- a/docs/apis/saiunit.constants.rst
+++ b/docs/apis/saiunit.constants.rst
@@ -12,15 +12,15 @@ Physical constants
 ==================== ================== ======================= ==================================================================
 Constant             Symbol(s)          name                    Value
 ==================== ================== ======================= ==================================================================
-Avogadro constant    :math:`N_A, L`     ``avogadro_constant``   :math:`6.022140857\times 10^{23}\,\mathrm{mol}^{-1}`
-Boltzmann constant   :math:`k`          ``boltzmann_constant``  :math:`1.38064852\times 10^{-23}\,\mathrm{J}\,\mathrm{K}^{-1}`
-Electric constant    :math:`\epsilon_0` ``electric_constant``   :math:`8.854187817\times 10^{-12}\,\mathrm{F}\,\mathrm{m}^{-1}`
+Avogadro constant    :math:`N_A, L`     ``avogadro``            :math:`6.022140857\times 10^{23}\,\mathrm{mol}^{-1}`
+Boltzmann constant   :math:`k`          ``boltzmann``           :math:`1.38064852\times 10^{-23}\,\mathrm{J}\,\mathrm{K}^{-1}`
+Electric constant    :math:`\epsilon_0` ``electric``            :math:`8.854187817\times 10^{-12}\,\mathrm{F}\,\mathrm{m}^{-1}`
 Electron mass        :math:`m_e`        ``electron_mass``       :math:`9.10938356\times 10^{-31}\,\mathrm{kg}`
 Elementary charge    :math:`e`          ``elementary_charge``   :math:`1.6021766208\times 10^{-19}\,\mathrm{C}`
-Faraday constant     :math:`F`          ``faraday_constant``    :math:`96485.33289\,\mathrm{C}\,\mathrm{mol}^{-1}`
-Gas constant         :math:`R`          ``gas_constant``        :math:`8.3144598\,\mathrm{J}\,\mathrm{mol}^{-1}\,\mathrm{K}^{-1}`
-Magnetic constant    :math:`\mu_0`      ``magnetic_constant``   :math:`12.566370614\times 10^{-7}\,\mathrm{N}\,\mathrm{A}^{-2}`
-Molar mass constant  :math:`M_u`        ``molar_mass_constant`` :math:`1\times 10^{-3}\,\mathrm{kg}\,\mathrm{mol}^{-1}`
+Faraday constant     :math:`F`          ``faraday``             :math:`96485.33289\,\mathrm{C}\,\mathrm{mol}^{-1}`
+Gas constant         :math:`R`          ``gas``                 :math:`8.3144598\,\mathrm{J}\,\mathrm{mol}^{-1}\,\mathrm{K}^{-1}`
+Magnetic constant    :math:`\mu_0`      ``magnetic``            :math:`12.566370614\times 10^{-7}\,\mathrm{N}\,\mathrm{A}^{-2}`
+Molar mass constant  :math:`M_u`        ``molar_mass``          :math:`1\times 10^{-3}\,\mathrm{kg}\,\mathrm{mol}^{-1}`
 0°C                                     ``zero_celsius``        :math:`273.15\,\mathrm{K}`
 ==================== ================== ======================= ==================================================================
 

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -18,11 +18,11 @@
 from typing import TypeVar, Iterable, Callable
 
 import jax
+from jax.extend import linear_util
 
 __all__ = [
     'safe_map',
     'unzip2',
-    'debug_info',
     'wrap_init',
 ]
 
@@ -31,22 +31,14 @@ T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
 
-from jax.extend import linear_util
-
-if jax.__version_info__ < (0, 5, 0):
-    from jax._src.api_util import debug_info
-
-else:
-    from jax.api_util import debug_info
-
 
 def wrap_init(fun: Callable, args: tuple, kwargs: dict, name: str):
-    if jax.__version_info__ < (0, 5, 0):
+    if jax.__version_info__ < (0, 6, 0):
         f = linear_util.wrap_init(fun, kwargs)
     else:
+        from jax.api_util import debug_info
         f = linear_util.wrap_init(fun, kwargs, debug_info=debug_info(name, fun, args, kwargs))
     return f
-
 
 
 if jax.__version_info__ < (0, 6, 0):
@@ -62,8 +54,10 @@ else:
         return list(map(f, *args))
 
 
-    def unzip2(xys: Iterable[tuple[T1, T2]] ) -> tuple[tuple[T1, ...], tuple[T2, ...]]:
-        """Unzip sequence of length-2 tuples into two tuples."""
+    def unzip2(xys: Iterable[tuple[T1, T2]]) -> tuple[tuple[T1, ...], tuple[T2, ...]]:
+        """
+        Unzip sequence of length-2 tuples into two tuples.
+        """
         # Note: we deliberately don't use zip(*xys) because it is lazily evaluated,
         # is too permissive about inputs, and does not guarantee a length-2 output.
         xs: list[T1] = []
@@ -72,4 +66,3 @@ else:
             xs.append(x)
             ys.append(y)
         return tuple(xs), tuple(ys)
-


### PR DESCRIPTION
## Summary by Sourcery

Refactor compatibility layer to streamline debug_info handling and adjust version gating for wrap_init, and enhance docstring formatting for unzip2.

Enhancements:
- Refactor debug_info import by removing global conditional imports and importing it lazily within wrap_init
- Update wrap_init to apply linear_util.wrap_init behavior based on Jax version 0.6.0 instead of 0.5.0
- Reformat the unzip2 docstring to a multi-line style for improved readability