### PR TITLE
Enable Quantity hashing, add JIT tests, and restore setup generation

### DIFF
--- a/brainunit/setup.py.template
+++ b/brainunit/setup.py.template
@@ -21,18 +21,13 @@ import re
 
 from setuptools import setup
 
-# version
-here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, '../saiunit/', '__init__.py'), 'r') as f:
-  init_py = f.read()
-version = re.search('__version__ = "(.*)"', init_py).groups()[0]
-
 # obtain long description from README
+here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.md'), 'r', encoding='utf-8') as f:
     README = f.read()
 
 # setup
 setup(
-  version=version,
+  version=,
   long_description=README,
 )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Installation
 
        .. code-block:: bash
 
-          pip install -U saiunit[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+          pip install -U saiunit[tpu]
 
 ----
 

--- a/make_brainunit_setup.py
+++ b/make_brainunit_setup.py
@@ -37,10 +37,10 @@ def make(root_dir):
         f.write(pyproject.replace('saiunit==', f'saiunit=={saiunit.__version__}'))
 
     # setup
-    # with open(os.path.join(brainunit_dir, 'setup.py.template'), 'r') as f:
-    #     setup = f.read()
-    # with open(os.path.join(brainunit_dir, 'setup.py'), 'w') as f:
-    #     f.write(setup.replace('saiunit==', f'saiunit=={saiunit.__version__}'))
+    with open(os.path.join(brainunit_dir, 'setup.py.template'), 'r') as f:
+        setup = f.read()
+    with open(os.path.join(brainunit_dir, 'setup.py'), 'w') as f:
+        f.write(setup.replace('version=,', f'version="{saiunit.__version__}",'))
 
 
 if __name__ == '__main__':

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/saiunit/_base.py
+++ b/saiunit/_base.py
@@ -3063,6 +3063,15 @@ class Quantity(Generic[A]):
     # Python inherent methods #
     # ----------------------- #
 
+    def __hash__(self):
+        """
+        Hash the Quantity object.
+
+        Returns:
+          int: The hash value of the Quantity object.
+        """
+        return hash((self.mantissa, self.unit))
+
     def __repr__(self) -> str:
         return self.repr_in_unit(python_code=True)
 

--- a/saiunit/_base_test.py
+++ b/saiunit/_base_test.py
@@ -32,16 +32,12 @@ import pytest
 from numpy.testing import assert_equal
 
 import saiunit as u
+from saiunit import get_dim, Unit, Quantity, DIMENSIONLESS, get_or_create_dimension
 from saiunit._base import (
-    DIMENSIONLESS,
     UNITLESS,
     DimensionMismatchError,
-    Quantity,
-    Unit,
     check_units,
     fail_for_dimension_mismatch,
-    get_or_create_dimension,
-    get_dim,
     have_same_dim,
     display_in_unit,
     is_scalar_type,
@@ -49,12 +45,6 @@ from saiunit._base import (
 )
 from saiunit._unit_common import *
 from saiunit._unit_shortcuts import kHz, ms, mV, nS
-
-import jax.numpy as jnp
-import numpy as np
-
-import saiunit as u
-from saiunit import get_dim, Unit, Quantity, DIMENSIONLESS, get_or_create_dimension
 
 
 class Test_get_dim:
@@ -1749,3 +1739,37 @@ class TestGetMethod(unittest.TestCase):
             assert f"{q2:.2f}" == "ArrayImpl([1.23, 1.23]) * mvolt"
             assert f"{q2:.3f}" == "ArrayImpl([1.235, 1.235]) * mvolt"
             assert f"{q2:.4f}" == "ArrayImpl([1.2346, 1.2346]) * mvolt"
+
+
+class TestJit:
+    def test1(self):
+        @jax.jit
+        def f(a):
+            return a * 2
+
+        f(3 * u.mV)
+        f(brainstate.random.rand(10) * u.mV)
+
+    def test2(self):
+        @brainstate.transform.jit
+        def f(a):
+            return a * 2
+
+        f(3 * u.mV)
+        f(brainstate.random.rand(10) * u.mV)
+
+    def test3(self):
+        @jax.jit
+        def f(**kwargs):
+            return kwargs['a'] * 2
+
+        f(a=3 * u.mV)
+        f(a=brainstate.random.rand(10) * u.mV)
+
+    def test4(self):
+        @brainstate.transform.jit
+        def f(**kwargs):
+            return kwargs['a'] * 2
+
+        f(a=3 * u.mV)
+        f(a=brainstate.random.rand(10) * u.mV)


### PR DESCRIPTION
## Summary by Sourcery

Enable Quantity hashing, add JIT compatibility tests, and restore automated setup.py generation

Enhancements:
- Implement __hash__ for Quantity objects to enable hashing based on mantissa and unit
- Restore generation of setup.py in make_brainunit_setup.py with correct version formatting

Tests:
- Add TestJit suite to validate jax.jit and brainstate.transform.jit compatibility with Quantity inputs

Chores:
- Remove unused imports from saiunit/_base_test.py