### PR TITLE
Refactor interp to propagate fp unit and update tests

### DIFF
--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -28,6 +28,7 @@ from .._base import (
     Quantity,
     fail_for_dimension_mismatch,
     get_unit,
+    split_mantissa_unit,
     UNITLESS,
     unit_scale_align_to_first,
     maybe_decimal
@@ -2959,18 +2960,17 @@ def interp(
       Union[jax.Array, Quantity]: Quantity if `x`, `xp`, and `fp` are Quantities that have the same unit, else an array.
     """
     x_unit = get_unit(x)
+    fp, y_unit = split_mantissa_unit(fp)
     x, xp, fp, left, right, period = (
         x.mantissa if isinstance(x, Quantity) else x,
         Quantity(xp).in_unit(x_unit).mantissa,
-        Quantity(fp).in_unit(x_unit).mantissa,
+        fp,
         Quantity(left).in_unit(x_unit).mantissa if left is not None else left,
         Quantity(right).in_unit(x_unit).mantissa if right is not None else right,
         Quantity(period).in_unit(x_unit).mantissa if period is not None else period
     )
     r = jnp.interp(x, xp=xp, fp=fp, left=left, right=right, period=period)
-    if x_unit.is_unitless:
-        return r
-    return Quantity(r, unit=x_unit)
+    return maybe_decimal(Quantity(r, unit=y_unit))
 
 
 @set_module_as('saiunit.math')

--- a/saiunit/math/_fun_keep_unit_test.py
+++ b/saiunit/math/_fun_keep_unit_test.py
@@ -584,10 +584,11 @@ class TestFunKeepUnitOther(parameterized.TestCase):
 
         x = [1, 2, 3] * u.second
         xp = [0, 1, 2, 3, 4] * u.second
-        fp = [0, 1, 2, 3, 4] * u.second
+        fp = [0, 1, 2, 3, 4] * u.mvolt
         result_q = u.math.interp(x, xp, fp)
-        expected_q = jnp.interp(jnp.array([1, 2, 3]), jnp.array([0, 1, 2, 3, 4]),
-                                jnp.array([0, 1, 2, 3, 4])) * u.second
+        expected_q = jnp.interp(jnp.array([1, 2, 3]),
+                                jnp.array([0, 1, 2, 3, 4]),
+                                jnp.array([0, 1, 2, 3, 4])) * u.mvolt
         assert u.math.allclose(result_q, expected_q)
 
     def test_clip(self):


### PR DESCRIPTION
## Summary by Sourcery

Refactor interp to correctly split mantissa and unit and propagate the fp unit in the result, with updated tests reflecting the new unit behavior

Enhancements:
- Refactor interp to use split_mantissa_unit for separating mantissa and unit
- Propagate output unit based on the unit of the fp parameter and wrap result with maybe_decimal

Tests:
- Update interp tests to interpolate millivolt inputs and expect millivolt outputs