### PR TITLE
Fix matplotlib convert for zero-sized inputs

### DIFF
--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/saiunit/_matplotlib_compat.py
+++ b/saiunit/_matplotlib_compat.py
@@ -38,10 +38,13 @@ if matplotlib_installed:
         @staticmethod
         def convert(val, unit, axis):
             val = Quantity(val)
-            # check dimension
-            fail_for_dimension_mismatch(val.unit, unit)
-            # check unit
-            return val.to(unit).mantissa
+            if val.size > 0:
+                # check dimension
+                fail_for_dimension_mismatch(val.unit, unit)
+                # check unit
+                return val.to(unit).mantissa
+            else:
+                return []
 
         @staticmethod
         def default_units(x, axis):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Return an empty list for zero-sized inputs in convert to prevent dimension and unit mismatch errors.