### PR TITLE
[doc] Gate brainx-sphinx-header injection on TARGET=brainunit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,10 +82,11 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'sphinx_thebe',
     'sphinx_design',
-    'brainx_sphinx_header',
 ]
 
-html_baseurl = 'https://brainx.chaobrain.com/brainunit/'
+if package == 'brainunit':
+    extensions.append('brainx_sphinx_header')
+    html_baseurl = 'https://brainx.chaobrain.com/brainunit/'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
## Summary
- `docs/conf.py` was unconditionally adding the `brainx_sphinx_header` extension and setting `html_baseurl` to brainunit's URL, polluting saiunit's own docs build (the default `TARGET=saiunit`).
- Both settings are now gated inside `if package == 'brainunit':` so saiunit's docs are unaffected.
- `brainx-sphinx-header>=0.4.0` stays in `docs/requirements.txt` since brainunit builds still need it.

## Test plan
- [ ] Build saiunit docs (default `TARGET`) and confirm the brainx header is absent.
- [ ] Build brainunit docs (`TARGET=brainunit`) and confirm the header still renders.

## Summary by Sourcery

Documentation:
- Restrict brainx_sphinx_header extension and brainunit html_baseurl configuration to brainunit docs builds only.