### PR TITLE
fix: address review findings across Quantity, Unit, and backend layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ cython_debug/
 docs/_brand/
 docs/_static/css/brainx-header.css
 docs/_static/js/brainx-header.js
+/AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,4 @@ docs/_brand/
 docs/_static/css/brainx-header.css
 docs/_static/js/brainx-header.js
 /AGENTS.md
+/CLAUDE.md

--- a/brainunit/brainunit/__init__.py
+++ b/brainunit/brainunit/__init__.py
@@ -18,6 +18,7 @@ __version__ = saiunit.__version__
 __version_info__ = saiunit.__version_info__
 
 from . import autograd
+from saiunit._matplotlib_compat import enable_matplotlib_support
 from . import constants
 from . import fft
 from . import lax
@@ -34,6 +35,18 @@ from ._base_dimension import (
     get_dim_for_display,
     get_or_create_dimension,
 )
+from ._backend import (
+    get_default_backend,
+    is_cupy_array,
+    is_dask_array,
+    is_jax_array,
+    is_ndonnx_array,
+    is_numpy_array,
+    is_torch_array,
+    set_default_backend,
+    using_backend,
+)
+from ._exceptions import BackendError
 from ._base_getters import (
     array_with_unit,
     assert_quantity,
@@ -48,6 +61,7 @@ from ._base_getters import (
     have_same_dim,
     is_dimensionless,
     is_scalar_type,
+    is_unit_equal_math,
     is_unitless,
     maybe_decimal,
     split_mantissa_unit,
@@ -55,7 +69,7 @@ from ._base_getters import (
 )
 from ._base_quantity import Quantity, compatible_with_equinox
 from ._base_unit import UNITLESS, Unit, add_standard_unit, parse_unit
-from ._celsius import celsius2kelvin, kelvin2celsius
+from ._celsius import celsius2kelvin, kelvin2celsius, fahrenheit2kelvin, kelvin2fahrenheit
 from ._misc import maybe_custom_array, maybe_custom_array_tree
 from ._unit_common import *
 from ._unit_common import __all__ as _common_all
@@ -100,6 +114,18 @@ __all__ = [
               'DIMENSIONLESS',
               'DimensionMismatchError',
               'UnitMismatchError',
+              'BackendError',
+
+              # _backend
+              'get_default_backend',
+              'set_default_backend',
+              'using_backend',
+              'is_jax_array',
+              'is_numpy_array',
+              'is_cupy_array',
+              'is_torch_array',
+              'is_dask_array',
+              'is_ndonnx_array',
               'get_or_create_dimension',
               'get_dim_for_display',
 
@@ -125,6 +151,7 @@ __all__ = [
               'assert_quantity',
               'have_same_dim',
               'has_same_unit',
+              'is_unit_equal_math',
               'unit_scale_align_to_first',
               'array_with_unit',
 
@@ -140,6 +167,11 @@ __all__ = [
               # _celsius
               'celsius2kelvin',
               'kelvin2celsius',
+              'fahrenheit2kelvin',
+              'kelvin2fahrenheit',
+
+              # _matplotlib_compat
+              'enable_matplotlib_support',
 
               # old version compatibility
               'avogadro_constant',

--- a/brainunit/brainunit/_backend.py
+++ b/brainunit/brainunit/_backend.py
@@ -1,0 +1,17 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from saiunit._backend import *
+from saiunit._backend import __all__

--- a/brainunit/brainunit/_exceptions.py
+++ b/brainunit/brainunit/_exceptions.py
@@ -1,0 +1,17 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from saiunit._exceptions import *
+from saiunit._exceptions import __all__

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ jaxlib
 typing_extensions
 matplotlib
 brainstate
+array_api_compat
 
 # document requirements
 pandoc

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -54,8 +54,8 @@ Examples
     True
 """
 
-from . import _matplotlib_compat
 from . import autograd
+from ._matplotlib_compat import enable_matplotlib_support
 from . import constants
 from . import fft
 from . import lax
@@ -105,7 +105,7 @@ from ._base_getters import (
 )
 from ._base_quantity import Quantity, compatible_with_equinox
 from ._base_unit import UNITLESS, Unit, add_standard_unit, parse_unit
-from ._celsius import celsius2kelvin, kelvin2celsius
+from ._celsius import celsius2kelvin, kelvin2celsius, fahrenheit2kelvin, kelvin2fahrenheit
 from ._misc import maybe_custom_array, maybe_custom_array_tree
 from ._unit_common import *
 from ._unit_common import __all__ as _common_all
@@ -203,6 +203,11 @@ __all__ = [
               # _celsius
               'celsius2kelvin',
               'kelvin2celsius',
+              'fahrenheit2kelvin',
+              'kelvin2fahrenheit',
+
+              # _matplotlib_compat
+              'enable_matplotlib_support',
 
               # old version compatibility
               'avogadro_constant',
@@ -215,4 +220,4 @@ __all__ = [
               'magnetic_constant',
               'molar_mass_constant',
           ] + _common_all + _std_units_all + _constants_all
-del _common_all, _std_units_all, _matplotlib_compat, _constants_all
+del _common_all, _std_units_all, _constants_all

--- a/saiunit/_base_dimension.py
+++ b/saiunit/_base_dimension.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import numbers
+import threading
 
 import jax
 import numpy as np
@@ -545,8 +546,8 @@ class Dimension:
         Compare this Dimension object with another for equality.
 
         This method implements the equality comparison (==) for Dimension objects.
-        Two Dimension objects are considered equal if they have the same dimensional
-        exponents (within a small numerical tolerance).
+        Two Dimension objects are considered equal if their seven SI exponent
+        vectors are bit-for-bit identical (no floating-point tolerance).
 
         Parameters
         ----------
@@ -561,9 +562,10 @@ class Dimension:
 
         Notes
         -----
-        The comparison uses numpy's allclose() function to handle potential
-        floating-point precision issues in the dimension exponents.
-        If value is not a Dimension object, returns False without attempting comparison.
+        The comparison uses ``numpy.array_equal``. Equal Dimensions are
+        produced by ``get_or_create_dimension`` from the same exponent tuple,
+        so callers that round their exponents identically observe equal
+        instances. If value is not a Dimension object, returns False.
         """
         if not isinstance(value, Dimension):
             return False
@@ -676,8 +678,12 @@ class Dimension:
         return self.hash
 
 
-# Cache for get_or_create_dimension — maps tuple(dims) -> Dimension
+# Cache for get_or_create_dimension — maps tuple(dims) -> Dimension.
+# The lock guards the get/insert window so concurrent callers always
+# observe the same Dimension instance for a given key (identity is
+# load-bearing throughout the library).
 _dimension_cache: dict[tuple, 'Dimension'] = {}
+_dimension_cache_lock = threading.Lock()
 
 
 @set_module_as('saiunit')
@@ -758,9 +764,13 @@ def get_or_create_dimension(*args, **kwds) -> Dimension:
     cached = _dimension_cache.get(key)
     if cached is not None:
         return cached
-    new_dim = Dimension(dims)
-    _dimension_cache[key] = new_dim
-    return new_dim
+    with _dimension_cache_lock:
+        cached = _dimension_cache.get(key)
+        if cached is not None:
+            return cached
+        new_dim = Dimension(dims)
+        _dimension_cache[key] = new_dim
+        return new_dim
 
 
 DIMENSIONLESS = get_or_create_dimension([0, 0, 0, 0, 0, 0, 0])

--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -44,6 +44,7 @@ __all__ = [
     'assert_quantity',
     'have_same_dim',
     'has_same_unit',
+    'is_unit_equal_math',
     'unit_scale_align_to_first',
     'array_with_unit',
     'is_scalar_type',
@@ -334,13 +335,63 @@ def have_same_dim(obj1, obj2) -> bool:
 
 
 @set_module_as('saiunit')
+def is_unit_equal_math(u1, u2) -> bool:
+    """
+    Check whether two units are mathematically equivalent.
+
+    Two units are mathematically equivalent when they have the same
+    ``dim``, ``scale``, ``base``, and ``factor`` — i.e. they convert
+    quantities the same way. The display ``name`` and ``dispname`` are
+    ignored, so e.g. ``metre`` and ``meter`` (different aliases of the
+    SI meter) are equivalent, and a freshly-composed ``A * ohm`` is
+    equivalent to ``volt``.
+
+    This is distinct from ``Unit.__eq__``, which also requires
+    ``name``/``dispname`` to match — that operator treats two aliases as
+    different units. Use ``is_unit_equal_math`` when you only care that
+    two units convert the same way.
+
+    Parameters
+    ----------
+    u1, u2 : Unit
+        The units to compare.
+
+    Returns
+    -------
+    bool
+        ``True`` if `u1` and `u2` are mathematically equivalent.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import saiunit as u
+        >>> u.is_unit_equal_math(u.metre, u.meter)
+        True
+        >>> u.is_unit_equal_math(u.amp * u.ohm, u.volt)
+        True
+        >>> u.is_unit_equal_math(u.mV, u.volt)
+        False
+    """
+    if not isinstance(u1, Unit) or not isinstance(u2, Unit):
+        return False
+    return (
+        (u1.dim == u2.dim)
+        and (u1.scale == u2.scale)
+        and (u1.base == u2.base)
+        and (u1.factor == u2.factor)
+    )
+
+
+@set_module_as('saiunit')
 def has_same_unit(obj1, obj2) -> bool:
     """
     Check whether two objects have the same unit.
 
-    Unlike `have_same_dim`, this function also checks that the *scale*
-    matches (e.g. ``mV`` and ``V`` have the same dimension but different
-    units).
+    Compares the underlying units mathematically (``dim``, ``scale``,
+    ``base``, ``factor``) — alias spellings and display-name differences
+    are ignored. For strict identity-level equality use ``Unit.__eq__``
+    directly.
 
     Parameters
     ----------
@@ -357,6 +408,7 @@ def has_same_unit(obj1, obj2) -> bool:
     See Also
     --------
     have_same_dim : Check whether two objects share the same dimension.
+    is_unit_equal_math : Same-math comparison for Unit objects directly.
 
     Examples
     --------
@@ -374,7 +426,7 @@ def has_same_unit(obj1, obj2) -> bool:
     obj2 = maybe_custom_array(obj2)
     unit1 = get_unit(obj1)
     unit2 = get_unit(obj2)
-    return unit1 == unit2
+    return is_unit_equal_math(unit1, unit2)
 
 
 @set_module_as('saiunit')

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -250,6 +250,45 @@ def _element_not_quantity(x):
     return x
 
 
+def _reduction_count_from_shape(shape, axis) -> int:
+    """Number of elements reduced over ``axis`` for an array of static ``shape``.
+
+    JIT-safe: depends only on the static shape, never on values.
+    """
+    if axis is None:
+        n = 1
+        for d in shape:
+            n *= int(d)
+        return n
+    if isinstance(axis, (int, np.integer)):
+        return int(shape[int(axis)])
+    n = 1
+    for a in axis:
+        n *= int(shape[int(a)])
+    return n
+
+
+def _is_concrete_zero(mantissa) -> bool:
+    """Return True iff ``mantissa`` is a concrete (non-traced) numeric zero.
+
+    Used to honour the physics convention that ``0`` is compatible with any
+    dimension. Returns False under JIT tracing or for any non-zero value.
+    """
+    if _is_tracer(mantissa):
+        return False
+    if isinstance(mantissa, (int, float, complex)):
+        return mantissa == 0
+    if isinstance(mantissa, (np.ndarray, jax.Array, np.generic)):
+        try:
+            arr = np.asarray(mantissa)
+        except Exception:
+            return False
+        if arr.size == 0:
+            return False
+        return bool(np.all(arr == 0))
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Pickle helper
 # ---------------------------------------------------------------------------
@@ -481,7 +520,11 @@ class Quantity:
         dtype: jax.typing.DTypeLike | None = None,
     ):
 
-        with jax.ensure_compile_time_eval():  # inside JIT, this can avoid to trace the constant mantissa value
+        # ``ensure_compile_time_eval`` is a no-op outside tracing; inside a
+        # JIT trace it forces constant mantissas (lists, scalars, parse_unit
+        # output) through eager evaluation so they are baked into the
+        # traced graph rather than promoted to tracers.
+        with jax.ensure_compile_time_eval():
 
             # String-based unit: Quantity(1.0, "mV")
             if isinstance(unit, str):
@@ -709,6 +752,12 @@ class Quantity:
             Quantity([4. 5. 6.], "mV")
         """
         self_value = self.mantissa
+        if _is_tracer(self_value):
+            raise RuntimeError(
+                "update_mantissa() cannot mutate a Quantity whose mantissa is a "
+                "JAX tracer (e.g., inside jit/vmap/grad). Construct a new Quantity "
+                "instead, e.g. Quantity(new_mantissa, unit=q.unit)."
+            )
         if isinstance(mantissa, Quantity):
             raise ValueError("Cannot set the mantissa of a Quantity to another Quantity.")
         if is_numpy_array(self_value):
@@ -1382,18 +1431,11 @@ class Quantity:
     # Python inherent methods #
     # ----------------------- #
 
-    def __hash__(self):
-        """
-        Hash the Quantity object.
-
-        Returns:
-          int: The hash value of the Quantity object.
-        """
-        _dask_materialization_guard(self._mantissa, "hash(Quantity)")
-        try:
-            return hash((np.asarray(self.mantissa).tobytes(), self.unit))
-        except Exception:
-            return hash((id(self.mantissa), self.unit))
+    # Quantity is unhashable: ``__eq__`` returns an elementwise array, not a
+    # bool, so any hash would silently violate the hash/eq invariant and
+    # corrupt dict/set lookups. Use ``id(q)`` if a stable identity key is
+    # really required.
+    __hash__ = None
 
     def __repr__(self) -> str:
         value_str = self._format_value()
@@ -1469,6 +1511,13 @@ class Quantity:
         return Quantity(self.mantissa[index], unit=self.unit)
 
     def __setitem__(self, index, value: 'Quantity | jax.typing.ArrayLike'):
+        if _is_tracer(self.mantissa):
+            raise RuntimeError(
+                "Quantity[...] = value cannot mutate a Quantity whose mantissa "
+                "is a JAX tracer (e.g., inside jit/vmap/grad). Use the functional "
+                "form Quantity(q.mantissa.at[index].set(value.mantissa), unit=q.unit) "
+                "instead, or perform the update outside the traced function."
+            )
         # check value
         if not isinstance(value, Quantity):
             if self.is_unitless:
@@ -1852,12 +1901,25 @@ class Quantity:
 
         # format the unit and mantissa of "other"
         if fail_for_mismatch:
-            other = other.in_unit(
-                self.unit,
-                err_msg=f"Cannot calculate \n"
-                        f"{self} {operator_str} {other}, "
-                        f"because units do not match: {self.unit} != {other.unit}"
-            )
+            # 0-as-any-dimension: a concrete zero (unitless) is treated as
+            # dimensionally compatible with self, matching standard physics
+            # convention so e.g. ``0 + 3*ms`` works.
+            if (other.unit.is_unitless
+                    and not self.unit.is_unitless
+                    and _is_concrete_zero(other.mantissa)):
+                other = Quantity(other.mantissa, unit=self.unit)
+            elif (self.unit.is_unitless
+                    and not other.unit.is_unitless
+                    and _is_concrete_zero(self.mantissa)):
+                # mirror case: ``Quantity(0) + 3*ms``
+                self = Quantity(self.mantissa, unit=other.unit)
+            else:
+                other = other.in_unit(
+                    self.unit,
+                    err_msg=f"Cannot calculate \n"
+                            f"{self} {operator_str} {other}, "
+                            f"because units do not match: {self.unit} != {other.unit}"
+                )
         other_value = other.mantissa
         other_unit = other.unit
 
@@ -1869,6 +1931,10 @@ class Quantity:
 
         # update the mantissa in-place or not
         if inplace:
+            if _is_tracer(self.mantissa):
+                # Under JIT/vmap/grad, mutation isn't supported; degrade to the
+                # functional form so `q += x` still works (Python rebinds the name).
+                return r
             self.update_mantissa(r.mantissa)
             return self
         else:
@@ -1892,7 +1958,7 @@ class Quantity:
         return self._binary_operation(oc, operator.sub, fail_for_mismatch=True, operator_str="-")
 
     def __rsub__(self, oc):
-        return Quantity(oc).__sub__(self)
+        return _to_quantity(oc).__sub__(self)
 
     def __isub__(self, oc):
         # a -= b
@@ -2574,19 +2640,11 @@ class Quantity:
 
         xp = get_backend(self)
         prod_res = xp.prod(self.mantissa, *args, **kwds)
-        # Calculating the correct dimensions is not completly trivial (e.g.
-        # like doing self.dim**self.size) because prod can be called on
-        # multidimensional arrays along a certain axis.
-        # Our solution: Use a "dummy matrix" containing a 1 (without units) at
-        # each entry and sum it, using the same keyword arguments as provided.
-        # The result gives the exponent for the dimensions.
-        # This relies on sum and prod having the same arguments, which is true
-        # now and probably remains like this in the future
-        dim_exponent = xp.ones_like(self.mantissa).sum(*args, **kwds)
-        # The result is possibly multidimensional but all entries should be
-        # identical
-        if dim_exponent.size > 1:
-            dim_exponent = dim_exponent.ravel()[0]
+        # The unit exponent is the number of elements multiplied along the
+        # reduction axis. Derive it from the static shape so the computation
+        # is JIT-safe (no `bool(traced_array)` or traced unit exponents).
+        axis = args[0] if args else kwds.get('axis', None)
+        dim_exponent = _reduction_count_from_shape(self.mantissa.shape, axis)
         r = Quantity(prod_res, unit=self.unit ** dim_exponent)
         return maybe_decimal(r)
 
@@ -2619,21 +2677,29 @@ class Quantity:
         if self.is_unitless:
             return maybe_decimal(Quantity(prod_res, unit=self.unit))
 
-        # Count non-NaN elements along the reduction axis.
-        nan_mask = xp.isnan(self.mantissa)
-        non_nan_counts = xp.sum(xp.where(nan_mask, 0, 1), *args, **kwds)
+        # Unit exponent is the count of elements along the reduction axis.
+        # Use the static shape so the result is JIT-safe.
+        axis = args[0] if args else kwds.get('axis', None)
+        dim_exponent = _reduction_count_from_shape(self.mantissa.shape, axis)
 
-        # Verify uniform counts when axis is not None (result is not scalar).
-        if non_nan_counts.ndim > 0:
-            if not bool(xp.all(non_nan_counts == non_nan_counts.ravel()[0])):
-                raise ValueError(
-                    "nanprod over an axis with non-uniform NaN counts is not "
-                    "supported for quantities with units, because the resulting "
-                    "elements would have different unit exponents."
-                )
-            dim_exponent = non_nan_counts.ravel()[0]
-        else:
-            dim_exponent = non_nan_counts
+        # Eager (non-traced) inputs: verify NaN counts are uniform along the
+        # reduction axis. Otherwise different output elements would carry
+        # different unit exponents, which is unrepresentable. Skipped under
+        # tracing because traced booleans cannot drive a Python ``if``.
+        if not _is_tracer(self.mantissa):
+            nan_mask = xp.isnan(self.mantissa)
+            non_nan_counts = xp.sum(xp.where(nan_mask, 0, 1), *args, **kwds)
+            if non_nan_counts.ndim > 0:
+                first = non_nan_counts.ravel()[0]
+                if not bool(xp.all(non_nan_counts == first)):
+                    raise ValueError(
+                        "nanprod over an axis with non-uniform NaN counts is not "
+                        "supported for quantities with units, because the resulting "
+                        "elements would have different unit exponents."
+                    )
+                dim_exponent = int(first)
+            else:
+                dim_exponent = int(non_nan_counts)
 
         r = Quantity(prod_res, unit=self.unit ** dim_exponent)
         return maybe_decimal(r)
@@ -3257,7 +3323,12 @@ class Quantity:
         return saiunit_fn(*inputs, **kwargs)
 
     def __array__(self, dtype: jax.typing.DTypeLike | None = None) -> np.ndarray:
-        """Support ``numpy.array()`` and ``numpy.asarray()`` functions."""
+        """Support ``numpy.array()`` and ``numpy.asarray()`` functions.
+
+        Only dimensionless quantities are coercible — converting a unit-bearing
+        Quantity would silently drop the unit and produce a numerically
+        misleading array, so we raise ``TypeError`` instead.
+        """
         _dask_materialization_guard(self._mantissa, "np.asarray(Quantity)")
         if self.dim.is_dimensionless:
             return np.asarray(self.to_decimal(), dtype=dtype)

--- a/saiunit/_base_quantity_test.py
+++ b/saiunit/_base_quantity_test.py
@@ -1015,19 +1015,14 @@ class TestQuantityIntegration:
             with pytest.raises(u.UnitMismatchError):
                 np.array([5], dtype=np.float64) - q
 
-            # Check that operations with 0 raise
-            with pytest.raises(u.UnitMismatchError):
-                q + 0
-            with pytest.raises(u.UnitMismatchError):
-                0 + q
-            with pytest.raises(u.UnitMismatchError):
-                q - 0
-            with pytest.raises(u.UnitMismatchError):
-                q + np.float64(0)
-            with pytest.raises(u.UnitMismatchError):
-                np.float64(0) + q
-            with pytest.raises(u.UnitMismatchError):
-                q - np.float64(0)
+            # Concrete zero is treated as dimensionally compatible with any
+            # unit (physics convention: 0 has any dimension).
+            assert_quantity(q + 0, q.mantissa, unit)
+            assert_quantity(0 + q, q.mantissa, unit)
+            assert_quantity(q - 0, q.mantissa, unit)
+            assert_quantity(q + np.float64(0), q.mantissa, unit)
+            assert_quantity(np.float64(0) + q, q.mantissa, unit)
+            assert_quantity(q - np.float64(0), q.mantissa, unit)
 
     def test_binary_operations(self):
         """Test whether binary operations work when they should and raise
@@ -1218,8 +1213,11 @@ class TestQuantityIntegration:
 
         assert type(2 / meter) == Quantity
         assert type(2 * meter) == Quantity
-        assert type(meter + meter) == Unit
-        assert type(meter - meter) == Unit
+        # Unit + Unit / Unit - Unit are not defined; arithmetic is on quantities.
+        with pytest.raises(TypeError):
+            meter + meter
+        with pytest.raises(TypeError):
+            meter - meter
 
     def test_jit_array(self):
         @jax.jit

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -90,6 +90,11 @@ def _find_standard_unit(
     (name, dispname, is_fullname, is_dimensionless)
     """
     if dim == DIMENSIONLESS:
+        # Dimensionless aliases (radian, steradian, percent, ...) intentionally
+        # drop their display name in arithmetic results: ``radian / radian``
+        # is bare 1, not "rad". Callers needing to preserve a dimensionless
+        # alias (e.g. ``factorless()`` on radian) consult ``_standard_units``
+        # directly before invoking this helper.
         return None, None, False, True
     if isinstance(base, (int, float)):
         if isinstance(scale, (int, float)):
@@ -227,7 +232,11 @@ def add_standard_unit(u: 'Unit'):
     ):
         key = (u.dim, u.scale, u.base, u.factor)
         aliases = _standard_unit_aliases.setdefault(key, [])
-        aliases.append(u)
+        # Dedup by identity: a Unit instance is registered at most once.
+        # Without this, repeated calls grow the alias list unboundedly
+        # and poison the ambiguity heuristic below.
+        if not any(existing is u for existing in aliases):
+            aliases.append(u)
         _standard_units[key] = _select_preferred_standard_unit(aliases)
 
         # Auto-detect ambiguity: >=2 distinct display names → ambiguous
@@ -687,17 +696,17 @@ class Unit:
             self._display_parts = parsed._display_parts
             return
 
-        # The base for this unit (as the base of the exponent), i.e.
-        # a base of 10 means 10^3, for a "k" prefix.
+        # All Units canonicalize to base=10; a non-10 ``base`` is folded into
+        # ``factor`` as ``base**scale`` so that ``base**scale * factor`` is
+        # preserved. This keeps arithmetic on units (mul/div) closed without
+        # needing to reconcile mismatched bases at every call site.
+        if base != 10.:
+            factor = factor * (base ** scale)
+            base = 10.
+            scale = 0
+
         self._base = base
-
-        # The scale for this unit (as the integer exponent of 10), i.e.
-        # a scale of 3 means base^3, for a "k" prefix.
         self._scale = scale
-
-        # The factor for this unit (as the conversion factor), i.e.
-        # a factor of cal = 4.18400 means 1 cal = 4.18400 J,
-        # where 4.18400 is the factor.
         self._factor = factor
 
         # The physical unit dimensions of this unit
@@ -1564,38 +1573,32 @@ class Unit:
     def __ipow__(self, other, modulo=None):
         raise NotImplementedError("Units cannot be modified in-place")
 
-    def __add__(self, other: 'Unit') -> 'Unit':
-        # self + other
-        if not isinstance(other, Unit):
-            raise TypeError(f"Expected a Unit, but got {other}")
-        if self.has_same_dim(other):
-            if self.has_same_magnitude(other):
-                return self.copy()
-            else:
-                raise TypeError(f"Units {self} and {other} have different units.")
-        else:
-            raise TypeError(f"Units {self} and {other} have different dimensions.")
+    def __add__(self, other):
+        raise TypeError(
+            "Units cannot be added: addition is defined on quantities, not units. "
+            "To add quantities, attach mantissas first (e.g. 1*ms + 2*ms)."
+        )
 
-    def __radd__(self, oc: 'Unit') -> 'Unit':
-        return self.__add__(oc)
+    def __radd__(self, other):
+        raise TypeError(
+            "Units cannot be added: addition is defined on quantities, not units. "
+            "To add quantities, attach mantissas first (e.g. 1*ms + 2*ms)."
+        )
 
     def __iadd__(self, other):
         raise NotImplementedError("Units cannot be modified in-place")
 
-    def __sub__(self, other: 'Unit') -> 'Unit':
-        # self - other
-        if not isinstance(other, Unit):
-            raise TypeError(f"Expected a Unit, but got {other}")
-        if self.has_same_dim(other):
-            if self.has_same_magnitude(other):
-                return self.copy()
-            else:
-                raise TypeError(f"Units {self} and {other} have different units.")
-        else:
-            raise TypeError(f"Units {self} and {other} have different dimensions.")
+    def __sub__(self, other):
+        raise TypeError(
+            "Units cannot be subtracted: subtraction is defined on quantities, not "
+            "units. To subtract quantities, attach mantissas first (e.g. 2*ms - 1*ms)."
+        )
 
-    def __rsub__(self, oc: 'Unit') -> 'Unit':
-        return self.__sub__(oc)
+    def __rsub__(self, other):
+        raise TypeError(
+            "Units cannot be subtracted: subtraction is defined on quantities, not "
+            "units. To subtract quantities, attach mantissas first (e.g. 2*ms - 1*ms)."
+        )
 
     def __isub__(self, other):
         raise NotImplementedError("Units cannot be modified in-place")
@@ -1610,17 +1613,26 @@ class Unit:
         raise NotImplementedError("Units cannot be modified in-place")
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, Unit):
-            return (
-                (other.dim == self.dim)
-                and (other.scale == self.scale)
-                and (other.base == self.base)
-                and (other.factor == self.factor)
-                # and (other.name == self.name)
-                # and (other.dispname == self.dispname)
-            )
-        else:
+        # Two Units are equal when they represent the same physical
+        # quantity (matching dim/scale/base/factor) *and* render to the
+        # same canonical display string. The canonical string already
+        # folds registry-canonical aliases (e.g. ``A * ohm`` displays as
+        # ``V``) and respects the no-intermediate-simplification rule
+        # for genuinely composed units, so this comparison naturally
+        # treats math-equivalent aliases (metre/meter, A*ohm/volt) as
+        # equal without collapsing intermediate display order.
+        # Use ``is_unit_equal_math`` for a name-agnostic, math-only
+        # equivalence test.
+        if not isinstance(other, Unit):
             return False
+        if not (
+            (other.dim == self.dim)
+            and (other.scale == self.scale)
+            and (other.base == self.base)
+            and (other.factor == self.factor)
+        ):
+            return False
+        return self._canonical_str() == other._canonical_str()
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -134,8 +134,11 @@ class TestUnitProperties:
             u.factor = 1.0
 
     def test_base_property(self):
-        u = Unit(DIMENSIONLESS, base=2.0)
-        assert u.base == 2.0
+        # Units canonicalize to base=10; a base!=10 is folded into factor.
+        u = Unit(DIMENSIONLESS, base=2.0, scale=3)
+        assert u.base == 10.0
+        assert u.scale == 0
+        assert u.factor == 8.0
 
     def test_base_setter_raises(self):
         u = Unit()
@@ -262,12 +265,6 @@ class TestUnitComparison:
         u2 = Unit(d, base=10.)
         assert u1.has_same_base(u2)
 
-    def test_has_same_base_different(self):
-        d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
-        u1 = Unit(d, base=10.)
-        u2 = Unit(d, base=2.)
-        assert not u1.has_same_base(u2)
-
     def test_has_same_dim(self):
         d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         u1 = Unit(d, scale=0)
@@ -293,13 +290,6 @@ class TestUnitArithmetic:
         result = u1 * u2
         assert result.dim == d1 * d2
         assert result.scale == 0
-
-    def test_mul_different_base_raises(self):
-        d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
-        u1 = Unit(d, base=10.)
-        u2 = Unit(d, base=2.)
-        with pytest.raises(TypeError, match="different bases"):
-            u1 * u2
 
     def test_mul_by_dimension_raises(self):
         u = Unit()
@@ -352,39 +342,32 @@ class TestUnitArithmetic:
         with pytest.raises(TypeError, match="non-scalar"):
             u ** np.array([2, 3])
 
-    def test_add_same_unit(self):
+    def test_add_units_raises(self):
         d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         u1 = Unit(d, name="m", dispname="m", scale=0)
         u2 = Unit(d, name="m", dispname="m", scale=0)
-        result = u1 + u2
-        assert result == u1
+        with pytest.raises(TypeError, match="cannot be added"):
+            u1 + u2
 
     def test_add_different_dim_raises(self):
         d1 = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         d2 = get_or_create_dimension([0, 1, 0, 0, 0, 0, 0])
-        with pytest.raises(TypeError, match="different dimensions"):
+        with pytest.raises(TypeError, match="cannot be added"):
             Unit(d1, name="m", dispname="m") + Unit(d2, name="kg", dispname="kg")
 
-    def test_add_different_scale_raises(self):
-        d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
-        u1 = Unit(d, name="m", dispname="m", scale=0)
-        u2 = Unit(d, name="km", dispname="km", scale=3)
-        with pytest.raises(TypeError, match="different units"):
-            u1 + u2
-
     def test_add_non_unit_raises(self):
-        with pytest.raises(TypeError, match="Expected a Unit"):
+        with pytest.raises(TypeError, match="cannot be added"):
             Unit() + 42
 
-    def test_sub_same_unit(self):
+    def test_sub_units_raises(self):
         d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         u1 = Unit(d, name="m", dispname="m", scale=0)
         u2 = Unit(d, name="m", dispname="m", scale=0)
-        result = u1 - u2
-        assert result == u1
+        with pytest.raises(TypeError, match="cannot be subtracted"):
+            u1 - u2
 
     def test_sub_non_unit_raises(self):
-        with pytest.raises(TypeError, match="Expected a Unit"):
+        with pytest.raises(TypeError, match="cannot be subtracted"):
             Unit() - 42
 
     # ---- In-place raises ----
@@ -623,14 +606,6 @@ class TestDisplayParts:
         u2 = Unit(d, base=10.)
         _assert_same_base(u1, u2)  # should not raise
 
-    def test_assert_same_base_raises(self):
-        d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
-        u1 = Unit(d, base=10.)
-        u2 = Unit(d, base=2.)
-        with pytest.raises(TypeError, match="different bases"):
-            _assert_same_base(u1, u2)
-
-
 # =========================================================================
 # _find_standard_unit / _find_a_name / add_standard_unit
 # =========================================================================
@@ -698,12 +673,6 @@ class TestUnitIntegration:
 
         _ = u.Unit((u.ms / u.ms).dim, scale=2)
         _ = u.Unit(u.ms.dim, scale=2)
-
-    def test_mul_different_base_raises(self):
-        a = u.Unit(base=2)
-        b = u.Unit(base=10)
-        with pytest.raises(TypeError):
-            a * b
 
     def test_inplace_operations(self):
         # make sure that inplace operations do not work on units/dimensions

--- a/saiunit/_celsius.py
+++ b/saiunit/_celsius.py
@@ -23,6 +23,8 @@ from ._unit_common import kelvin
 __all__ = [
     "celsius2kelvin",
     "kelvin2celsius",
+    "fahrenheit2kelvin",
+    "kelvin2fahrenheit",
 ]
 
 
@@ -107,3 +109,70 @@ def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
             f"but got unit {value.unit}."
         )
     return value.to_decimal(kelvin) - 273.15
+
+
+def fahrenheit2kelvin(fahrenheit: jax.typing.ArrayLike) -> Quantity:
+    """
+    Convert a Fahrenheit value to a kelvin :class:`~saiunit.Quantity`.
+
+    Parameters
+    ----------
+    fahrenheit : jax.typing.ArrayLike
+        The temperature in degrees Fahrenheit. Must not be a
+        :class:`~saiunit.Quantity`.
+
+    Returns
+    -------
+    Quantity
+        The temperature expressed in kelvin.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import saiunit as u
+        >>> u.fahrenheit2kelvin(32.0)
+        273.15 * kelvin
+        >>> u.fahrenheit2kelvin(212.0)
+        373.15 * kelvin
+    """
+    fahrenheit = maybe_custom_array(fahrenheit)
+    if isinstance(fahrenheit, Quantity):
+        raise TypeError("The input value should be not be a Quantity.")
+    return ((fahrenheit - 32.0) * (5.0 / 9.0) + 273.15) * kelvin
+
+
+def kelvin2fahrenheit(value: Quantity) -> jax.typing.ArrayLike:
+    """
+    Convert a kelvin :class:`~saiunit.Quantity` to a Fahrenheit value.
+
+    Parameters
+    ----------
+    value : Quantity
+        The temperature expressed as a :class:`~saiunit.Quantity` with
+        kelvin units.
+
+    Returns
+    -------
+    jax.typing.ArrayLike
+        The temperature in degrees Fahrenheit (unitless scalar or array).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import saiunit as u
+        >>> u.kelvin2fahrenheit(273.15 * u.kelvin)
+        32.0
+        >>> u.kelvin2fahrenheit(373.15 * u.kelvin)
+        212.0
+    """
+    value = maybe_custom_array(value)
+    if not isinstance(value, Quantity):
+        raise TypeError("The input value should be a Quantity with a temperature unit.")
+    if not value.unit.has_same_dim(kelvin):
+        raise TypeError(
+            f"The input value should be a Quantity with a temperature unit, "
+            f"but got unit {value.unit}."
+        )
+    return (value.to_decimal(kelvin) - 273.15) * (9.0 / 5.0) + 32.0

--- a/saiunit/_celsius_test.py
+++ b/saiunit/_celsius_test.py
@@ -265,3 +265,43 @@ def test_docstring_example_kelvin2celsius():
     with pytest.raises(TypeError):
         u.kelvin2celsius(300.0)
 
+
+def test_docstring_example_fahrenheit2kelvin():
+    import saiunit as u
+
+    result_32 = u.fahrenheit2kelvin(32.0)
+    assert u.math.allclose(result_32, 273.15 * u.kelvin, atol=1e-10 * u.kelvin)
+
+    result_212 = u.fahrenheit2kelvin(212.0)
+    assert u.math.allclose(result_212, 373.15 * u.kelvin, atol=1e-10 * u.kelvin)
+
+    # Verify TypeError when passing a Quantity
+    with pytest.raises(TypeError):
+        u.fahrenheit2kelvin(100.0 * u.kelvin)
+
+
+def test_docstring_example_kelvin2fahrenheit():
+    import saiunit as u
+
+    result_freezing = u.kelvin2fahrenheit(273.15 * u.kelvin)
+    assert np.isclose(float(result_freezing), 32.0)
+
+    result_boiling = u.kelvin2fahrenheit(373.15 * u.kelvin)
+    assert np.isclose(float(result_boiling), 212.0)
+
+    # Verify TypeError when passing a plain number
+    with pytest.raises(TypeError):
+        u.kelvin2fahrenheit(300.0)
+
+    # Verify TypeError when passing a non-temperature Quantity
+    with pytest.raises(TypeError):
+        u.kelvin2fahrenheit(300.0 * u.meter)
+
+
+def test_fahrenheit_kelvin_roundtrip():
+    import saiunit as u
+
+    for f in [-40.0, 0.0, 32.0, 68.0, 100.0, 212.0]:
+        k = u.fahrenheit2kelvin(f)
+        assert np.isclose(float(u.kelvin2fahrenheit(k)), f, atol=1e-9)
+

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -43,13 +43,19 @@ try:
     from jax.core import concrete_or_error
 except ImportError:
     def concrete_or_error(typ, val, context=""):
-        """Minimal shim used when jax.core.concrete_or_error is unavailable."""
+        """Minimal shim used when jax.core.concrete_or_error is unavailable.
+
+        Raises TypeError for traced/abstract values so callers don't silently
+        receive a tracer where they expected a static Python value.
+        """
+        from jax.core import Tracer
+        if isinstance(val, Tracer):
+            raise TypeError(
+                f"Expected a concrete value but got a JAX tracer ({val!r}). {context}"
+            )
         if typ is None:
             return val
-        try:
-            return typ(val)
-        except Exception:
-            return val
+        return typ(val)
 
 
 def wrap_init(fun: Callable, args: tuple, kwargs: dict, name: str):

--- a/saiunit/_dask_laziness_test.py
+++ b/saiunit/_dask_laziness_test.py
@@ -133,5 +133,7 @@ def test_dask_quantity_hash_raises_clear_error():
     da = pytest.importorskip("dask.array")
     import saiunit as u
     q = u.Quantity(da.from_array(np.array([1.0]), chunks=1), unit=u.meter)
-    with pytest.raises(u.BackendError, match="compute"):
+    # Quantity is unhashable across all backends (Quantity.__hash__ is None
+    # to preserve the hash/eq invariant, since __eq__ returns an array).
+    with pytest.raises(TypeError, match="unhashable"):
         hash(q)

--- a/saiunit/_matplotlib_compat.py
+++ b/saiunit/_matplotlib_compat.py
@@ -145,4 +145,29 @@ def register_quantity_converter(units_module: Any | None = None) -> bool:
 
 
 matplotlib_installed = _has_matplotlib()
-matplotlib_converter_registered = register_quantity_converter()
+matplotlib_converter_registered = False
+
+
+def enable_matplotlib_support(units_module: Any | None = None) -> bool:
+    """
+    Opt in to Matplotlib unit support by registering :class:`QuantityConverter`.
+
+    Importing :mod:`saiunit` does not modify Matplotlib's global converter
+    registry on its own — callers that want Quantity values to render on
+    Matplotlib axes must invoke this function once at startup.
+
+    Parameters
+    ----------
+    units_module : Any, optional
+        A ``matplotlib.units``-like module, primarily for testing.
+
+    Returns
+    -------
+    bool
+        ``True`` if registration succeeded, otherwise ``False``.
+    """
+    global matplotlib_converter_registered
+    registered = register_quantity_converter(units_module)
+    if units_module is None and registered:
+        matplotlib_converter_registered = True
+    return registered

--- a/saiunit/_matplotlib_compat_test.py
+++ b/saiunit/_matplotlib_compat_test.py
@@ -21,15 +21,18 @@ import pytest
 import saiunit as u
 from saiunit import _matplotlib_compat as mpl_compat
 
-if not mpl_compat.matplotlib_converter_registered:
-    pytest.skip("matplotlib converter is not available", allow_module_level=True)
+if not mpl_compat.matplotlib_installed:
+    pytest.skip("matplotlib is not available", allow_module_level=True)
+
+if not u.enable_matplotlib_support():
+    pytest.skip("matplotlib converter could not be registered", allow_module_level=True)
 
 from matplotlib import units as mpl_units
 from matplotlib.units import ConversionError
 
 
 def test_quantity_converter_is_registered():
-    assert mpl_compat.register_quantity_converter()
+    assert u.enable_matplotlib_support()
     assert isinstance(mpl_units.registry[u.Quantity], mpl_compat.QuantityConverter)
 
 

--- a/saiunit/_misc.py
+++ b/saiunit/_misc.py
@@ -96,6 +96,10 @@ def maybe_custom_array(x):
         array([1, 2, 3])
 
     """
+    # Lazy import to avoid circular dependency. Concurrent callers may both
+    # see ``CustomArray is None`` and re-import — that's safe: CPython's
+    # module import lock makes the import itself atomic, and every winner
+    # rebinds the global to the same class object.
     global CustomArray
     if CustomArray is None:
         from saiunit.custom_array import CustomArray
@@ -144,6 +148,10 @@ def maybe_custom_array_tree(x):
         array([4])
 
     """
+    # Lazy import to avoid circular dependency. Concurrent callers may both
+    # see ``CustomArray is None`` and re-import — that's safe: CPython's
+    # module import lock makes the import itself atomic, and every winner
+    # rebinds the global to the same class object.
     global CustomArray
     if CustomArray is None:
         from saiunit.custom_array import CustomArray

--- a/saiunit/_sparse_base.py
+++ b/saiunit/_sparse_base.py
@@ -27,6 +27,25 @@ __all__ = [
 ]
 
 
+def _same_sparsity_pattern(a, b) -> bool:
+    """Check whether two index arrays describe the same sparsity pattern.
+
+    Returns ``True`` if ``a`` and ``b`` are the same Python object, or if both
+    are concrete arrays with equal shape and values. Under JIT tracing, falls
+    back to object identity since traced values aren't comparable in Python
+    boolean context.
+    """
+    if a is b:
+        return True
+    if isinstance(a, jax.core.Tracer) or isinstance(b, jax.core.Tracer):
+        return False
+    a_shape = getattr(a, "shape", None)
+    b_shape = getattr(b, "shape", None)
+    if a_shape is not None and b_shape is not None and a_shape != b_shape:
+        return False
+    return bool(np.array_equal(a, b))
+
+
 class SparseMatrix:
     """
     Base class for sparse matrices in ``saiunit``.

--- a/saiunit/_unit_constants.py
+++ b/saiunit/_unit_constants.py
@@ -51,9 +51,6 @@ Volume
 Speed
     ``speed_unit``, ``kmh``, ``mph``, ``mach``/``speed_of_sound``, ``knot``
 
-Temperature
-    ``degree_Fahrenheit``
-
 Energy
     ``eV``/``electron_volt``, ``calorie``/``calorie_th``, ``calorie_IT``,
     ``erg``, ``Btu``/``Btu_IT``, ``Btu_th``, ``ton_TNT``
@@ -67,7 +64,7 @@ Force
 """
 
 from ._base_unit import Unit
-from ._unit_common import joule, kilogram, second, meter, radian, pascal, meter2, meter3, kelvin, watt, newton
+from ._unit_common import joule, kilogram, second, meter, radian, pascal, meter2, meter3, watt, newton
 from .math import pi
 
 __all__ = [
@@ -77,7 +74,7 @@ __all__ = [
     "mil", "point", "pica", "survey_foot", "survey_mile", "nautical_mile", "fermi", "angstrom", "micron",
     "astronomical_unit", "au", "light_year", "parsec", "atm", "atmosphere", "bar", "mmHg", "torr", "psi",
     "hectare", "acre", "gallon", "gallon_US", "gallon_imp", "fluid_ounce", "fluid_ounce_US", "fluid_ounce_imp",
-    "bbl", "barrel", "speed_unit", "kmh", "mph", "mach", "speed_of_sound", "knot", "degree_Fahrenheit", "eV",
+    "bbl", "barrel", "speed_unit", "kmh", "mph", "mach", "speed_of_sound", "knot", "eV",
     "electron_volt", "calorie", "calorie_th", "calorie_IT", "erg", "Btu", "Btu_IT", "Btu_th", "ton_TNT", "hp",
     "horsepower", "dyn", "dyne", "lbf", "pound_force", "kgf", "kilogram_force", "IMF", 'kcal_per_h'
 ]
@@ -168,12 +165,6 @@ mph = Unit.create(speed_unit.dim, name="mile per hour", dispname="mph", scale=sp
 mach = speed_of_sound = Unit.create(speed_unit.dim, name="speed of sound", dispname="mach", scale=speed_unit.scale + 2,
                                     factor=3.405)
 knot = Unit.create(speed_unit.dim, name="knot", dispname="kn", scale=speed_unit.scale - 1, factor=5.14444444)
-
-# ----- Temperature -----
-# TODO: The relationship between Celsius and Kelvin should be linear, but the current implementation is not.
-# zero_Celsius = Unit.create(kelvin.dim, name="zero Celsius", dispname="0°C", scale=kelvin.scale, factor=273.15)
-degree_Fahrenheit = Unit.create(kelvin.dim, name="degree Fahrenheit", dispname="°F", scale=kelvin.scale,
-                                factor=5/9)
 
 # ----- Energy -----
 eV = electron_volt = Unit.create(joule.dim, name="electronvolt", dispname="eV", scale=joule.scale - 19, factor=1.602176634)

--- a/saiunit/_unit_constants_test.py
+++ b/saiunit/_unit_constants_test.py
@@ -29,7 +29,6 @@ from saiunit._unit_constants import (
     hectare, acre,
     gallon, gallon_US, gallon_imp, fluid_ounce, fluid_ounce_US, fluid_ounce_imp, bbl, barrel,
     speed_unit, kmh, mph, mach, speed_of_sound, knot,
-    degree_Fahrenheit,
     eV, electron_volt, calorie, calorie_th, calorie_IT, erg, Btu, Btu_IT, Btu_th, ton_TNT,
     hp, horsepower, kcal_per_h,
     dyn, dyne, lbf, pound_force, kgf, kilogram_force, IMF,
@@ -112,7 +111,6 @@ class TestUnitType:
         hectare, acre,
         gallon, gallon_imp, fluid_ounce, fluid_ounce_imp, barrel,
         speed_unit, kmh, mph, mach, knot,
-        degree_Fahrenheit,
         electron_volt, calorie, calorie_IT, erg, Btu, Btu_th, ton_TNT,
         horsepower, kcal_per_h,
         dyne, pound_force, kilogram_force, IMF,
@@ -314,12 +312,6 @@ class TestSpeedMagnitudes:
         assert_magnitude(knot, 1852.0 / 3600)
 
 
-class TestTemperatureMagnitudes:
-    def test_degree_fahrenheit(self):
-        # Scale factor only (no offset)
-        assert_magnitude(degree_Fahrenheit, 5.0 / 9)
-
-
 class TestEnergyMagnitudes:
     def test_electronvolt(self):
         # CODATA 2018 exact
@@ -423,7 +415,6 @@ class TestAgainstScipy:
         (mph, sc.mph),
         (mach, sc.mach),
         (knot, sc.knot),
-        (degree_Fahrenheit, sc.degree_Fahrenheit),
         (electron_volt, sc.eV),
         (calorie, sc.calorie),
         (calorie_IT, sc.calorie_IT),
@@ -594,10 +585,6 @@ class TestDimensions:
         from saiunit._unit_common import newton
         for unit_obj in [dyne, pound_force, kilogram_force, IMF]:
             assert unit_obj.dim == newton.dim, f"{unit_obj.name} dim mismatch"
-
-    def test_temperature_dimensions(self):
-        from saiunit._unit_common import kelvin
-        assert degree_Fahrenheit.dim == kelvin.dim
 
 
 # ===========================================================================

--- a/saiunit/autograd/_jacobian.py
+++ b/saiunit/autograd/_jacobian.py
@@ -69,7 +69,7 @@ def _split(x, indices, axis):
         return jnp.split(x, indices, axis)
 
 
-def _unravel_array_into_pytree(pytree, axis, arr, is_leaf=None, divide_units=False):
+def _unravel_array_into_pytree(pytree, axis, arr, is_leaf=None):
     """Unravel an array into a PyTree with a given structure.
 
     Args:
@@ -77,20 +77,12 @@ def _unravel_array_into_pytree(pytree, axis, arr, is_leaf=None, divide_units=Fal
         axis: The parameter axis is either -1, 0, or 1.
         arr: The array to be unraveled.
         is_leaf: Optional leaf predicate for tree flattening.
-        divide_units: If True, divide each part's unit by the corresponding leaf's unit.
     """
     leaves, treedef = jax.tree.flatten(pytree, is_leaf=is_leaf)
     axis = axis % arr.ndim
     shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis + 1:] for l in leaves]
     parts = _split(arr, np.cumsum(safe_map(np.size, leaves[:-1])), axis)
     reshaped_parts = [x.reshape(shape) for x, shape in zip(parts, shapes)]
-    if divide_units:
-        reshaped_parts = [
-            maybe_decimal(
-                Quantity(get_magnitude(part), unit=get_unit(part) / get_unit(leaf))
-            )
-            for part, leaf in zip(reshaped_parts, leaves)
-        ]
     return jax.tree.unflatten(treedef, reshaped_parts)
 
 
@@ -102,11 +94,48 @@ def _std_basis(pytree):
     return _unravel_array_into_pytree(pytree, 1, flat_basis)
 
 
+def _assign_jacobian_units(outputs, inputs, jac_tree):
+    """Walk an outputs-of-inputs jacobian pytree and stamp output/input units.
+
+    The Jacobian leaf at position ``(i, j)`` should carry unit
+    ``output_leaves[i].unit / input_leaves[j].unit`` regardless of which AD
+    mode produced it. Centralizing the assignment here makes ``jacrev`` and
+    ``jacfwd`` use the same unit logic.
+    """
+    out_leaves, _ = jax.tree.flatten(outputs, is_leaf=_is_quantity)
+    in_leaves, _ = jax.tree.flatten(inputs, is_leaf=_is_quantity)
+    out_units = [get_unit(l) for l in out_leaves]
+    in_units = [get_unit(l) for l in in_leaves]
+
+    out_paths_leaves, out_treedef = jax.tree.flatten(jac_tree, is_leaf=_is_quantity)
+    # jac_tree has shape: outputs-tree of inputs-trees; flatten gives
+    # output_size * input_size leaves in row-major order.
+    inner_size = len(in_leaves)
+    if len(out_paths_leaves) != inner_size * len(out_leaves):
+        raise TypeError(
+            f"Jacobian tree has {len(out_paths_leaves)} leaves but expected "
+            f"{inner_size * len(out_leaves)} (output_leaves * input_leaves)."
+        )
+
+    new_leaves = []
+    for i in range(len(out_leaves)):
+        for j in range(inner_size):
+            leaf = out_paths_leaves[i * inner_size + j]
+            new_leaves.append(
+                maybe_decimal(
+                    Quantity(get_magnitude(leaf), unit=out_units[i] / in_units[j])
+                )
+            )
+    return jax.tree.unflatten(out_treedef, new_leaves)
+
+
 def _tree_transpose(outer, inner, pytree_to_transpose):
-    outer_leaves, outer_treedef = jax.tree.flatten(outer, is_leaf=_is_quantity)
-    inner_leaves, inner_treedef = jax.tree.flatten(inner, is_leaf=_is_quantity)
-    outer_leaf_units = [get_unit(leaf) for leaf in outer_leaves]
-    inner_leaf_units = [get_unit(leaf) for leaf in inner_leaves]
+    """Transpose a tree of structure outer-of-inner into inner-of-outer.
+
+    Structural only; unit assignment is handled by ``_assign_jacobian_units``.
+    """
+    _, outer_treedef = jax.tree.flatten(outer, is_leaf=_is_quantity)
+    _, inner_treedef = jax.tree.flatten(inner, is_leaf=_is_quantity)
 
     flat, treedef = jax.tree.flatten(pytree_to_transpose, is_leaf=_is_quantity)
     inner_size = inner_treedef.num_leaves
@@ -114,18 +143,9 @@ def _tree_transpose(outer, inner, pytree_to_transpose):
     if treedef.num_leaves != (inner_size * outer_size):
         expected_treedef = outer_treedef.compose(inner_treedef)
         raise TypeError(f"Mismatch\n{treedef}\n != \n{expected_treedef}")
-    iter_flat = iter(flat)
 
     lol = [
-        [
-            maybe_decimal(
-                Quantity(
-                    get_magnitude(next(iter_flat)),
-                    unit=inner_leaf_units[j] / outer_leaf_units[i]
-                )
-            )
-            for j in range(inner_size)
-        ]
+        [flat[i * inner_size + j] for j in range(inner_size)]
         for i in range(outer_size)
     ]
     transposed_lol = zip(*lol)
@@ -238,6 +258,7 @@ def jacrev(
         )
         example_args = dyn_args[0] if isinstance(argnums_, int) else dyn_args
         jac_tree = _tree_transpose(outer=example_args, inner=y, pytree_to_transpose=jac_tree)
+        jac_tree = _assign_jacobian_units(y, example_args, jac_tree)
         if not has_aux:
             return jac_tree
         else:
@@ -409,10 +430,11 @@ def jacfwd(
         jax.tree.map(partial(_check_dtype, holomorphic=holomorphic, name="jacfwd"), y)
         example_args = dyn_args[0] if isinstance(argnums_, int) else dyn_args
         jac_tree = jax.tree.map(
-            lambda arr: _unravel_array_into_pytree(example_args, -1, arr, is_leaf=_is_quantity, divide_units=True),
+            lambda arr: _unravel_array_into_pytree(example_args, -1, arr, is_leaf=_is_quantity),
             jac,
             is_leaf=_is_quantity,
         )
+        jac_tree = _assign_jacobian_units(y, example_args, jac_tree)
         if not has_aux:
             return jac_tree
         else:

--- a/saiunit/constants.py
+++ b/saiunit/constants.py
@@ -61,9 +61,6 @@ The constants are organised into the following groups:
     ``fluid_ounce`` / ``fluid_ounce_US``, ``fluid_ounce_imp``,
     ``bbl`` / ``barrel``
 
-**Temperature**
-    ``degree_Fahrenheit`` (size of one Fahrenheit degree in kelvin)
-
 **Speed**
     ``kmh``, ``mph``, ``knot``, ``mach``
 
@@ -82,17 +79,20 @@ The constants are organised into the following groups:
 Fundamental Constants Table
 ---------------------------
 
+All fundamental-constant values below match CODATA 2018 (the 2019 SI
+redefinition fixed several to exact values, marked *exact*).
+
 ==================== ================== ======================= ==================================================================
 Constant             Symbol(s)          Name                    Value
 ==================== ================== ======================= ==================================================================
-Avogadro constant    :math:`N_A, L`     ``avogadro``            :math:`6.022140857\times 10^{23}\,\mathrm{mol}^{-1}`
-Boltzmann constant   :math:`k`          ``boltzmann``           :math:`1.38064852\times 10^{-23}\,\mathrm{J}\,\mathrm{K}^{-1}`
-Electric constant    :math:`\epsilon_0` ``electric``            :math:`8.854187817\times 10^{-12}\,\mathrm{F}\,\mathrm{m}^{-1}`
-Electron mass        :math:`m_e`        ``electron_mass``       :math:`9.10938356\times 10^{-31}\,\mathrm{kg}`
-Elementary charge    :math:`e`          ``elementary_charge``   :math:`1.6021766208\times 10^{-19}\,\mathrm{C}`
-Faraday constant     :math:`F`          ``faraday``             :math:`96485.33289\,\mathrm{C}\,\mathrm{mol}^{-1}`
-Gas constant         :math:`R`          ``gas``                 :math:`8.3144598\,\mathrm{J}\,\mathrm{mol}^{-1}\,\mathrm{K}^{-1}`
-Magnetic constant    :math:`\mu_0`      ``magnetic``            :math:`12.566370614\times 10^{-7}\,\mathrm{N}\,\mathrm{A}^{-2}`
+Avogadro constant    :math:`N_A, L`     ``avogadro``            :math:`6.02214076\times 10^{23}\,\mathrm{mol}^{-1}` (exact)
+Boltzmann constant   :math:`k`          ``boltzmann``           :math:`1.380649\times 10^{-23}\,\mathrm{J}\,\mathrm{K}^{-1}` (exact)
+Electric constant    :math:`\epsilon_0` ``electric``            :math:`8.8541878188\times 10^{-12}\,\mathrm{F}\,\mathrm{m}^{-1}`
+Electron mass        :math:`m_e`        ``electron_mass``       :math:`9.1093837139\times 10^{-31}\,\mathrm{kg}`
+Elementary charge    :math:`e`          ``elementary_charge``   :math:`1.602176634\times 10^{-19}\,\mathrm{C}` (exact)
+Faraday constant     :math:`F`          ``faraday``             :math:`96485.33212331\,\mathrm{C}\,\mathrm{mol}^{-1}`
+Gas constant         :math:`R`          ``gas``                 :math:`8.31446261815324\,\mathrm{J}\,\mathrm{mol}^{-1}\,\mathrm{K}^{-1}`
+Magnetic constant    :math:`\mu_0`      ``magnetic``            :math:`1.25663706127\times 10^{-6}\,\mathrm{N}\,\mathrm{A}^{-2}`
 Molar mass constant  :math:`M_u`        ``molar_mass``          :math:`1\times 10^{-3}\,\mathrm{kg}\,\mathrm{mol}^{-1}`
 0 deg C                                 ``zero_celsius``        :math:`273.15\,\mathrm{K}`
 ==================== ================== ======================= ==================================================================
@@ -148,7 +148,7 @@ from ._unit_constants import speed_unit
 __all__ = [
     'acre', 'arcmin', 'arcminute', 'arcsec', 'arcsecond', 'atomic_mass', 'au', 'astronomical_unit',
     'angstrom', 'atm', 'atmosphere', 'avogadro', 'bar', 'barrel', 'bbl', 'blob', 'boltzmann', 'Btu', 'Btu_IT',
-    'Btu_th', 'carat', 'calorie', 'calorie_IT', 'calorie_th', 'day', 'degree', 'degree_Fahrenheit',
+    'Btu_th', 'carat', 'calorie', 'calorie_IT', 'calorie_th', 'day', 'degree',
     'dyn', 'dyne', 'eV', 'electron_mass', 'electric', 'electronvolt', 'elementary_charge', 'erg',
     'faraday', 'fermi', 'fluid_ounce', 'fluid_ounce_US', 'fluid_ounce_imp', 'foot', 'gas', 'grain',
     'gallon', 'gallon_US', 'gallon_imp', 'gram', 'hectare', 'hour', 'hp', 'horsepower', 'IMF',
@@ -245,11 +245,6 @@ gallon_imp = np.asarray(4.54609e-3) * meter3  # Imperial gallon
 fluid_ounce = fluid_ounce_US = np.asarray(2.95735295625e-5) * meter3  # Fluid ounce (US)
 fluid_ounce_imp = np.asarray(2.84130625e-5) * meter3  # Imperial fluid ounce
 bbl = barrel = np.asarray(1.58987294928e-1) * meter3  # Barrel (oil)
-
-# ----- Temperature -----
-# Note: Fahrenheit is a temperature scale, not a unit. Use conversion functions instead.
-# This constant represents the conversion factor from Fahrenheit to Kelvin degrees
-degree_Fahrenheit = np.asarray(5/9) * kelvin  # Fahrenheit degree size in Kelvin
 
 # ----- Speed -----
 kmh = np.asarray(2.77777778e-1) * speed_unit  # Kilometer per hour

--- a/saiunit/constants_test.py
+++ b/saiunit/constants_test.py
@@ -47,8 +47,6 @@ constants_list = [
     'gallon', 'gallon_imp', 'fluid_ounce', 'fluid_ounce_imp', 'bbl',
     # Speed
     'kmh', 'mph', 'knot', 'mach',
-    # Temperature
-    'degree_Fahrenheit',
     # Energy
     'eV', 'calorie', 'calorie_IT', 'erg', 'Btu', 'Btu_IT', 'ton_TNT',
     # Power
@@ -355,10 +353,6 @@ class TestQuantityConstantValues:
 
     def test_mach(self):
         self._check("mach", 340.5)
-
-    # Temperature
-    def test_degree_fahrenheit(self):
-        self._check("degree_Fahrenheit", 5.0 / 9)
 
     # Energy
     def test_ev(self):

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -15,12 +15,15 @@
 from __future__ import annotations
 
 import builtins
-from typing import Union, Sequence, Callable
+from typing import Any, Union, Sequence, Callable
 
 import jax
 import numpy as np
 from jax import lax
-from jax._src.typing import Shape
+
+# Mirror of ``jax._src.typing.Shape`` (which has no public alias).
+# Used purely for type-hint clarity in this module.
+Shape = Sequence[Union[int, Any]]
 
 from saiunit._base_getters import has_same_unit, maybe_decimal
 from saiunit._base_quantity import Quantity

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -23,6 +23,7 @@ import numpy as np
 from jax import Array
 
 from saiunit._backend import get_backend, get_default_backend
+from saiunit._base_dimension import UnitMismatchError
 from saiunit._base_unit import UNITLESS, Unit
 from saiunit._base_getters import fail_for_unit_mismatch, get_unit, unit_scale_align_to_first
 from saiunit._base_quantity import Quantity
@@ -159,9 +160,9 @@ def eye(
     if not isinstance(unit, Unit):
         raise TypeError(f'eye requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     if not unit.is_unitless:
-        return jnp.eye(N, M, k, dtype=dtype) * unit
+        return _default_xp().eye(N, M, k, dtype=dtype) * unit
     else:
-        return jnp.eye(N, M, k, dtype=dtype)
+        return _default_xp().eye(N, M, k, dtype=dtype)
 
 
 @set_module_as('saiunit.math')
@@ -207,9 +208,9 @@ def identity(
     if not isinstance(unit, Unit):
         raise TypeError(f'identity requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     if not unit.is_unitless:
-        return jnp.identity(n, dtype=dtype) * unit
+        return _default_xp().identity(n, dtype=dtype) * unit
     else:
-        return jnp.identity(n, dtype=dtype)
+        return _default_xp().identity(n, dtype=dtype)
 
 
 @set_module_as('saiunit.math')
@@ -262,9 +263,9 @@ def tri(
     if not isinstance(unit, Unit):
         raise TypeError(f'tri requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     if not unit.is_unitless:
-        return jnp.tri(N, M, k, dtype=dtype) * unit
+        return _default_xp().tri(N, M, k, dtype=dtype) * unit
     else:
-        return jnp.tri(N, M, k, dtype=dtype)
+        return _default_xp().tri(N, M, k, dtype=dtype)
 
 
 @set_module_as('saiunit.math')
@@ -445,11 +446,12 @@ def full_like(
     """
     a = maybe_custom_array(a)
     fill_value = maybe_custom_array(fill_value)
+    xp = get_backend(a.mantissa if isinstance(a, Quantity) else a)
     if isinstance(fill_value, Quantity):
         if isinstance(a, Quantity):
             fill_value = fill_value.in_unit(a.unit)
             return Quantity(
-                jnp.full_like(a.mantissa, fill_value.mantissa, dtype=dtype, shape=shape),
+                xp.full_like(a.mantissa, fill_value.mantissa, dtype=dtype, shape=shape),
                 unit=a.unit
             )
         else:
@@ -460,7 +462,7 @@ def full_like(
                     f'Either pass a plain number as fill_value or wrap "a" as a Quantity.'
                 )
             return Quantity(
-                jnp.full_like(a, fill_value.mantissa, dtype=dtype, shape=shape),
+                xp.full_like(a, fill_value.mantissa, dtype=dtype, shape=shape),
                 unit=fill_value.unit
             )
     else:
@@ -471,9 +473,9 @@ def full_like(
                     f'but got a with unit={a.unit}. '
                     f'Either pass a Quantity as fill_value or use a plain array for "a".'
                 )
-            return jnp.full_like(a.mantissa, fill_value, dtype=dtype, shape=shape)
+            return xp.full_like(a.mantissa, fill_value, dtype=dtype, shape=shape)
         else:
-            return jnp.full_like(a, fill_value, dtype=dtype, shape=shape)
+            return xp.full_like(a, fill_value, dtype=dtype, shape=shape)
 
 
 @set_module_as('saiunit.math')
@@ -523,15 +525,16 @@ def diag(
     if not isinstance(unit, Unit):
         raise TypeError(f'diag requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     v = maybe_custom_array(v)
+    xp = get_backend(v.mantissa if isinstance(v, Quantity) else v)
     if isinstance(v, Quantity):
         if not unit.is_unitless:
             v = v.in_unit(unit)
-        return Quantity(jnp.diag(v.mantissa, k=k), unit=v.unit)
+        return Quantity(xp.diag(v.mantissa, k=k), unit=v.unit)
     else:
         if not unit.is_unitless:
-            return jnp.diag(v, k=k) * unit
+            return xp.diag(v, k=k) * unit
         else:
-            return jnp.diag(v, k=k)
+            return xp.diag(v, k=k)
 
 
 @set_module_as('saiunit.math')
@@ -576,15 +579,16 @@ def tril(
     if not isinstance(unit, Unit):
         raise TypeError(f'tril requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     m = maybe_custom_array(m)
+    xp = get_backend(m.mantissa if isinstance(m, Quantity) else m)
     if isinstance(m, Quantity):
         if not unit.is_unitless:
             m = m.in_unit(unit)
-        return Quantity(jnp.tril(m.mantissa, k=k), unit=m.unit)
+        return Quantity(xp.tril(m.mantissa, k=k), unit=m.unit)
     else:
         if not unit.is_unitless:
-            return jnp.tril(m, k=k) * unit
+            return xp.tril(m, k=k) * unit
         else:
-            return jnp.tril(m, k=k)
+            return xp.tril(m, k=k)
 
 
 @set_module_as('saiunit.math')
@@ -633,15 +637,16 @@ def triu(
     if not isinstance(unit, Unit):
         raise TypeError(f'triu requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     m = maybe_custom_array(m)
+    xp = get_backend(m.mantissa if isinstance(m, Quantity) else m)
     if isinstance(m, Quantity):
         if not unit.is_unitless:
             m = m.in_unit(unit)
-        return Quantity(jnp.triu(m.mantissa, k=k), unit=m.unit)
+        return Quantity(xp.triu(m.mantissa, k=k), unit=m.unit)
     else:
         if not unit.is_unitless:
-            return jnp.triu(m, k=k) * unit
+            return xp.triu(m, k=k) * unit
         else:
-            return jnp.triu(m, k=k)
+            return xp.triu(m, k=k)
 
 
 @set_module_as('saiunit.math')
@@ -686,15 +691,16 @@ def empty_like(
     if not isinstance(unit, Unit):
         raise TypeError(f'empty_like requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     prototype = maybe_custom_array(prototype)
+    xp = get_backend(prototype.mantissa if isinstance(prototype, Quantity) else prototype)
     if isinstance(prototype, Quantity):
         if not unit.is_unitless:
             prototype = prototype.in_unit(unit)
-        return Quantity(jnp.empty_like(prototype.mantissa, dtype=dtype), unit=prototype.unit)
+        return Quantity(xp.empty_like(prototype.mantissa, dtype=dtype), unit=prototype.unit)
     else:
         if not unit.is_unitless:
-            return jnp.empty_like(prototype, dtype=dtype, shape=shape) * unit
+            return xp.empty_like(prototype, dtype=dtype, shape=shape) * unit
         else:
-            return jnp.empty_like(prototype, dtype=dtype, shape=shape)
+            return xp.empty_like(prototype, dtype=dtype, shape=shape)
 
 
 @set_module_as('saiunit.math')
@@ -739,15 +745,16 @@ def ones_like(
     if not isinstance(unit, Unit):
         raise TypeError(f'ones_like requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     a = maybe_custom_array(a)
+    xp = get_backend(a.mantissa if isinstance(a, Quantity) else a)
     if isinstance(a, Quantity):
         if not unit.is_unitless:
             a = a.in_unit(unit)
-        return Quantity(jnp.ones_like(a.mantissa, dtype=dtype, shape=shape), unit=a.unit)
+        return Quantity(xp.ones_like(a.mantissa, dtype=dtype, shape=shape), unit=a.unit)
     else:
         if not unit.is_unitless:
-            return jnp.ones_like(a, dtype=dtype, shape=shape) * unit
+            return xp.ones_like(a, dtype=dtype, shape=shape) * unit
         else:
-            return jnp.ones_like(a, dtype=dtype, shape=shape)
+            return xp.ones_like(a, dtype=dtype, shape=shape)
 
 
 @set_module_as('saiunit.math')
@@ -792,15 +799,16 @@ def zeros_like(
     if not isinstance(unit, Unit):
         raise TypeError(f'zeros_like requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     a = maybe_custom_array(a)
+    xp = get_backend(a.mantissa if isinstance(a, Quantity) else a)
     if isinstance(a, Quantity):
         if not unit.is_unitless:
             a = a.in_unit(unit)
-        return Quantity(jnp.zeros_like(a.mantissa, dtype=dtype, shape=shape), unit=a.unit)
+        return Quantity(xp.zeros_like(a.mantissa, dtype=dtype, shape=shape), unit=a.unit)
     else:
         if not unit.is_unitless:
-            return jnp.zeros_like(a, dtype=dtype, shape=shape) * unit
+            return xp.zeros_like(a, dtype=dtype, shape=shape) * unit
         else:
-            return jnp.zeros_like(a, dtype=dtype, shape=shape)
+            return xp.zeros_like(a, dtype=dtype, shape=shape)
 
 
 @set_module_as('saiunit.math')
@@ -858,6 +866,11 @@ def asarray(
     """
     if a is None:
         return a
+    if isinstance(a, dict):
+        raise TypeError(
+            f"asarray does not accept dict inputs (got {type(a).__name__}); "
+            "pass an array, list, or Quantity."
+        )
 
     # get leaves
     leaves, treedef = jax.tree.flatten(a, is_leaf=lambda x: isinstance(x, Quantity))
@@ -874,7 +887,7 @@ def asarray(
 
     # reconstruct mantissa
     a = treedef.unflatten([leaf.mantissa for leaf in leaves])
-    a = jnp.asarray(a, dtype=dtype, order=order)
+    a = _default_xp().asarray(a, dtype=dtype, order=order)
 
     # returns
     if unit.is_unitless:
@@ -958,7 +971,7 @@ def arange(
     step = step.in_unit(unit).mantissa if isinstance(step, Quantity) else step
     # compute
     with jax.ensure_compile_time_eval():
-        r = jnp.arange(start, stop, step, dtype=dtype)
+        r = _default_xp().arange(start, stop, step, dtype=dtype)
     return r if unit.is_unitless else Quantity(r, unit=unit)
 
 
@@ -1030,14 +1043,14 @@ def linspace(
     start = start.in_unit(unit).mantissa if isinstance(start, Quantity) else start
     stop = stop.in_unit(unit).mantissa if isinstance(stop, Quantity) else stop
     with jax.ensure_compile_time_eval():
-        result = jnp.linspace(start, stop, num=num, endpoint=endpoint, retstep=retstep, dtype=dtype)
+        result = _default_xp().linspace(start, stop, num=num, endpoint=endpoint, retstep=retstep, dtype=dtype)
     return result if unit.is_unitless else Quantity(result, unit=unit)
 
 
 @set_module_as('saiunit.math')
 def logspace(
-    start: Union[Quantity, jax.typing.ArrayLike],
-    stop: Union[Quantity, jax.typing.ArrayLike],
+    start: jax.typing.ArrayLike,
+    stop: jax.typing.ArrayLike,
     num: Optional[int] = 50,
     endpoint: Optional[bool] = True,
     base: Optional[float] = 10.0,
@@ -1047,16 +1060,18 @@ def logspace(
     Return numbers spaced evenly on a log scale.
 
     In linear space, the sequence starts at ``base ** start`` and ends with
-    ``base ** stop`` in ``num`` steps.
+    ``base ** stop`` in ``num`` steps. Because ``base ** x`` is dimensionless,
+    ``start`` and ``stop`` must be dimensionless and the result is a plain
+    array (never a :class:`Quantity`).
 
     Parameters
     ----------
-    start : Quantity or array_like
-        ``base ** start`` is the starting value of the sequence.
-    stop : Quantity or array_like
+    start : array_like
+        ``base ** start`` is the starting value of the sequence. Must be
+        dimensionless.
+    stop : array_like
         ``base ** stop`` is the final value of the sequence (unless
-        ``endpoint`` is ``False``).  Must share the same unit as ``start``
-        when either is a ``Quantity``.
+        ``endpoint`` is ``False``). Must be dimensionless.
     num : int, optional
         Number of samples to generate.  Default is 50.
     endpoint : bool, optional
@@ -1069,13 +1084,13 @@ def logspace(
 
     Returns
     -------
-    samples : Quantity or jax.Array
+    samples : jax.Array
         ``num`` samples, equally spaced on a log scale.
 
     Raises
     ------
     UnitMismatchError
-        If ``start`` and ``stop`` do not share the same unit.
+        If ``start`` or ``stop`` carries a non-trivial unit.
 
     Examples
     --------
@@ -1087,19 +1102,19 @@ def logspace(
     """
     start = maybe_custom_array(start)
     stop = maybe_custom_array(stop)
-    fail_for_unit_mismatch(
-        start,
-        stop,
-        error_message="Start value {start} and stop value {stop} have to have the same units.",
-        start=start,
-        stop=stop,
-    )
-    unit = get_unit(start)
-    start = start.in_unit(unit).mantissa if isinstance(start, Quantity) else start
-    stop = stop.in_unit(unit).mantissa if isinstance(stop, Quantity) else stop
+    for argname, value in (("start", start), ("stop", stop)):
+        u = get_unit(value)
+        if not u.is_unitless:
+            raise UnitMismatchError(
+                f"logspace requires dimensionless `{argname}`, got unit {u!r}. "
+                f"`base ** x` is intrinsically dimensionless; pass a plain "
+                f"scalar/array instead.",
+                u,
+            )
+    start = start.mantissa if isinstance(start, Quantity) else start
+    stop = stop.mantissa if isinstance(stop, Quantity) else stop
     with jax.ensure_compile_time_eval():
-        result = jnp.logspace(start, stop, num=num, endpoint=endpoint, base=base, dtype=dtype)
-    return result if unit.is_unitless else Quantity(result, unit=unit)
+        return _default_xp().logspace(start, stop, num=num, endpoint=endpoint, base=base, dtype=dtype)
 
 
 @set_module_as('saiunit.math')
@@ -1147,17 +1162,18 @@ def fill_diagonal(
     """
     a = maybe_custom_array(a)
     val = maybe_custom_array(val)
+    xp = get_backend(a.mantissa if isinstance(a, Quantity) else a)
     if isinstance(val, Quantity):
         if isinstance(a, Quantity):
             val = val.in_unit(a.unit)
-            return Quantity(jnp.fill_diagonal(a.mantissa, val.mantissa, wrap, inplace=inplace), unit=a.unit)
+            return Quantity(xp.fill_diagonal(a.mantissa, val.mantissa, wrap, inplace=inplace), unit=a.unit)
         else:
-            return Quantity(jnp.fill_diagonal(a, val.mantissa, wrap, inplace=inplace), unit=val.unit)
+            return Quantity(xp.fill_diagonal(a, val.mantissa, wrap, inplace=inplace), unit=val.unit)
     else:
         if isinstance(a, Quantity):
-            return Quantity(jnp.fill_diagonal(a.mantissa, val, wrap, inplace=inplace), unit=a.unit)
+            return Quantity(xp.fill_diagonal(a.mantissa, val, wrap, inplace=inplace), unit=a.unit)
         else:
-            return jnp.fill_diagonal(a, val, wrap, inplace=inplace)
+            return xp.fill_diagonal(a, val, wrap, inplace=inplace)
 
 
 @set_module_as('saiunit.math')
@@ -1284,7 +1300,7 @@ def vander(
                 f'Pass "unit_to_scale" or strip the unit before calling vander.'
             )
         x = x.mantissa
-    r = jnp.vander(x, N=N, increasing=increasing)
+    r = get_backend(x).vander(x, N=N, increasing=increasing)
     if not isinstance(unit, Unit):
         raise TypeError(f'vander requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
     if not unit.is_unitless:
@@ -1296,7 +1312,8 @@ def vander(
 # indexing funcs
 # --------------
 
-tril_indices = jnp.tril_indices
+def tril_indices(n, k=0, m=None):
+    return _default_xp().tril_indices(n, k=k, m=m)
 
 
 @set_module_as('saiunit.math')
@@ -1331,13 +1348,12 @@ def tril_indices_from(
         Array([0, 1, 1, 2, 2, 2], dtype=int32)
     """
     arr = maybe_custom_array(arr)
-    if isinstance(arr, Quantity):
-        return jnp.tril_indices_from(arr.mantissa, k=k)
-    else:
-        return jnp.tril_indices_from(arr, k=k)
+    inner = arr.mantissa if isinstance(arr, Quantity) else arr
+    return get_backend(inner).tril_indices_from(inner, k=k)
 
 
-triu_indices = jnp.triu_indices
+def triu_indices(n, k=0, m=None):
+    return _default_xp().triu_indices(n, k=k, m=m)
 
 
 @set_module_as('saiunit.math')
@@ -1372,10 +1388,8 @@ def triu_indices_from(
         Array([0, 0, 0, 1, 1, 2], dtype=int32)
     """
     arr = maybe_custom_array(arr)
-    if isinstance(arr, Quantity):
-        return jnp.triu_indices_from(arr.mantissa, k=k)
-    else:
-        return jnp.triu_indices_from(arr, k=k)
+    inner = arr.mantissa if isinstance(arr, Quantity) else arr
+    return get_backend(inner).triu_indices_from(inner, k=k)
 
 
 # --- others ---
@@ -1414,9 +1428,10 @@ def from_numpy(
     x = maybe_custom_array(x)
     if not isinstance(unit, Unit):
         raise TypeError(f'from_numpy requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
+    xp = _default_xp()
     if not unit.is_unitless:
-        return jnp.array(x) * unit
-    return jnp.array(x)
+        return xp.asarray(x) * unit
+    return xp.asarray(x)
 
 
 @set_module_as('saiunit.math')

--- a/saiunit/math/_fun_array_creation_test.py
+++ b/saiunit/math/_fun_array_creation_test.py
@@ -458,6 +458,21 @@ class TestFunArrayCreation(parameterized.TestCase):
 
                 with pytest.raises(u.UnitMismatchError):
                     result = bm_fun(3, 9, 1 * unit)
+            elif bm_fun.__name__ == 'logspace':
+                # logspace rejects unit-bearing start/stop: the result lives in
+                # multiplicative space (10**x), so inputs must be dimensionless.
+                result = bm_fun(5, 15, 5)
+                expected = jnp_fun(5, 15, 5)
+                assert_quantity(result, expected)
+
+                with pytest.raises(u.UnitMismatchError):
+                    result = bm_fun(5 * unit, 15 * unit, 5)
+
+                with pytest.raises(u.UnitMismatchError):
+                    result = bm_fun(5, 15 * unit, 5)
+
+                with pytest.raises(u.UnitMismatchError):
+                    result = bm_fun(5 * unit, 15, 5)
             else:
                 result = bm_fun(5, 15, 5)
                 expected = jnp_fun(5, 15, 5)

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -21,9 +21,21 @@ from typing import (Union, Sequence, Tuple, Optional)
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax._src.numpy.util import promote_dtypes as _promote_dtypes
 
 from saiunit._backend import get_backend
+
+
+def _promote_dtypes(*arrays):
+    """Cast a sequence of arrays to a common dtype via the public JAX API.
+
+    Avoids depending on the private ``jax._src.numpy.util.promote_dtypes``
+    helper, which can move or change shape between JAX releases.
+    """
+    if not arrays:
+        return []
+    dtype = jnp.result_type(*arrays)
+    return [jnp.asarray(a, dtype=dtype) for a in arrays]
+
 from saiunit._base_unit import UNITLESS
 from saiunit._base_getters import (
     fail_for_dimension_mismatch,

--- a/saiunit/sparse/_coo.py
+++ b/saiunit/sparse/_coo.py
@@ -34,7 +34,7 @@ from saiunit._base_getters import (
 )
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
-from saiunit._sparse_base import SparseMatrix
+from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
 from saiunit.math._fun_array_creation import asarray
 from saiunit.math._fun_keep_unit import promote_dtypes
 
@@ -359,7 +359,7 @@ class COO(SparseMatrix):
 
     def _binary_op(self, other, op):
         if isinstance(other, COO):
-            if id(self.row) == id(other.row) and id(self.col) == id(other.col):
+            if _same_sparsity_pattern(self.row, other.row) and _same_sparsity_pattern(self.col, other.col):
                 return COO(
                     (
                         op(self.data, other.data),
@@ -402,7 +402,7 @@ class COO(SparseMatrix):
 
     def _binary_rop(self, other, op):
         if isinstance(other, COO):
-            if id(self.row) == id(other.row) and id(self.col) == id(other.col):
+            if _same_sparsity_pattern(self.row, other.row) and _same_sparsity_pattern(self.col, other.col):
                 return COO(
                     (
                         op(other.data, self.data),

--- a/saiunit/sparse/_csr.py
+++ b/saiunit/sparse/_csr.py
@@ -31,7 +31,7 @@ from saiunit._base_getters import (
 )
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
-from saiunit._sparse_base import SparseMatrix
+from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
 from saiunit.math._fun_array_creation import asarray
 from saiunit.math._fun_keep_unit import promote_dtypes
 
@@ -233,7 +233,7 @@ class CSR(SparseMatrix):
 
     def _binary_op(self, other, op):
         if isinstance(other, CSR):
-            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+            if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSR(
                     (op(self.data, other.data),
                      self.indices,
@@ -263,7 +263,7 @@ class CSR(SparseMatrix):
 
     def _binary_rop(self, other, op):
         if isinstance(other, CSR):
-            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+            if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSR(
                     (op(other.data, self.data),
                      self.indices,
@@ -577,7 +577,7 @@ class CSC(SparseMatrix):
 
     def _binary_op(self, other, op):
         if isinstance(other, CSC):
-            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+            if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSC(
                     (op(self.data, other.data),
                      self.indices,
@@ -609,7 +609,7 @@ class CSC(SparseMatrix):
 
     def _binary_rop(self, other, op):
         if isinstance(other, CSC):
-            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+            if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSC(
                     (op(other.data, self.data),
                      self.indices,


### PR DESCRIPTION
## Summary

- **Quantity hash/eq invariant**: `Quantity.__hash__ = None`. Since `__eq__` returns an elementwise array, any hash silently corrupts dict/set lookups. Now unhashable across all backends.
- **Strict `Unit.__eq__`**: compares dim/scale/base/factor *and* `_canonical_str()`. Math-equivalent aliases (metre/meter, A*ohm/volt) test equal; composed units like `amp*second*meter` retain their `'A * m * s'` display order (no intermediate simplification).
- **New `is_unit_equal_math(u1, u2)`** helper for name-agnostic math equivalence (dim+scale+base+factor only). `has_same_unit()` delegates to it. Re-exported through the brainunit shim.
- **Tracer safety**: `update_mantissa()` and `Quantity.__setitem__` now raise a clear `RuntimeError` on traced mantissas instead of producing silently wrong state. Functional alternatives (`q.mantissa.at[i].set(v)`) are recommended in the error message.
- **Reduction helpers**: `_reduction_count_from_shape` keeps JIT-safe reductions purely shape-dependent; `_is_concrete_zero` ensures the "0 is dimensionless" convention only fires for concrete zeros, never tracers.
- **Backend compat shims**: `brainunit/_backend.py` and `brainunit/_exceptions.py` re-export from saiunit, so legacy code can access the new backend selectors and `BackendError`. `brainunit/__init__.py` re-exports `is_unit_equal_math` plus the backend helpers.
- Dask laziness test updated: `hash(q)` now raises plain `TypeError("unhashable")` rather than `BackendError`.
- `_compatible_import.py` adjustments for current JAX versions.
- `.gitignore`: add `/AGENTS.md`. `docs/requirements.txt`: add `array_api_compat`.

## Test plan

- [x] `pytest saiunit/` — 3163 passed, 21 skipped (skips are environmental: cupy / ndonnx not installed)
- [x] Verify brainunit shim: `bu.is_unit_equal_math(bu.metre, bu.meter) == True`, `bu.amp * bu.ohm == bu.volt`, `bu.has_same_unit(...)` still works
- [x] Verify `Quantity` is unhashable across jax / numpy / dask backends (raises `TypeError`)
- [x] Verify `amp*second*meter` displays as `'A * m * s'` (permutation invariance preserved)
- [ ] CI on Linux, macOS, Windows (Python 3.13)

## Summary by Sourcery

Tighten unit/quantity semantics and backend behavior for JAX/Dask while improving math helpers, temperature conversions, constants, and Matplotlib integration.

New Features:
- Introduce is_unit_equal_math helper for math-only unit equivalence and expose it through saiunit and brainunit.
- Add Fahrenheit–Kelvin conversion helpers and roundtrip tests, and expose them in public APIs.
- Provide an opt-in enable_matplotlib_support hook instead of auto-registering Matplotlib converters.

Bug Fixes:
- Make Quantity unhashable and guard in-place mutations and numpy coercions to prevent hash/eq violations and unsafe tracer mutations.
- Ensure reductions, nanprod unit exponents, sparse operations, and logspace behave correctly and JIT-safely across backends.
- Align array-creation, diag/tri* helpers, and vandermonde utilities with the active backend instead of hardcoding JAX operations.
- Canonicalize units to a base-10 representation, forbid unit addition/subtraction, and fix Dimension equality and caching under concurrency.
- Tighten JAX compatibility shims, asarray behavior, and dask laziness tests to avoid silent materialization or tracer misuse.
- Remove the degree_Fahrenheit unit constant in favor of explicit conversions and update fundamental constant values to CODATA 2018.

Enhancements:
- Document and enforce dimensionless handling for certain APIs (e.g., logspace, np.asarray on unitful quantities) and clarify dimensionless alias behavior.
- Refactor Jacobian unit assignment into a shared helper so jacrev/jacfwd share consistent unit logic.
- Improve custom array handling, sparse sparsity checks, and lazy CustomArray imports to be concurrency-safe and tracer-aware.

Tests:
- Update and extend unit, quantity, array-creation, Celsius/Fahrenheit, constants, matplotlib, sparse, and dask tests to cover the new semantics and error conditions.