### PR TITLE
fix(unit): address 22-issue audit of Unit naming, display, hash, and parsing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip setuptools  --no-cache-dir
           python -m pip install -r requirements-dev.txt  --no-cache-dir
           pip install . --no-cache-dir
-          pip install torch --no-cache-dir
+          pip install torch --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
           pip install 'dask[array]' --no-cache-dir
           pip install ndonnx --no-cache-dir
       - name: Build and install BrainUnit
@@ -83,7 +83,7 @@ jobs:
           python -m pip install --upgrade pip setuptools --no-cache-dir
           python -m pip install -r requirements-dev.txt  --no-cache-dir
           pip install . --no-cache-dir
-          pip install torch --no-cache-dir
+          pip install torch --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
           pip install 'dask[array]' --no-cache-dir
           pip install ndonnx --no-cache-dir
       - name: Build and install BrainUnit
@@ -120,7 +120,7 @@ jobs:
           python -m pip install --upgrade pip setuptools --no-cache-dir
           python -m pip install -r requirements-dev.txt  --no-cache-dir
           pip install .  --no-cache-dir
-          pip install torch --no-cache-dir
+          pip install torch --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
           pip install 'dask[array]' --no-cache-dir
           pip install ndonnx --no-cache-dir
       - name: Build and install BrainUnit

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -1940,24 +1940,39 @@ class Quantity:
         else:
             return r
 
+    @staticmethod
+    def _reject_bare_unit(oc, op: str):
+        from ._base_unit import Unit
+        if isinstance(oc, Unit):
+            raise TypeError(
+                f"Cannot {op} a Quantity with a bare Unit: addition and "
+                "subtraction are defined on quantities, not units. Attach a "
+                "mantissa first (e.g. 1*ms + 2*ms)."
+            )
+
     def __add__(self, oc):
+        self._reject_bare_unit(oc, "add")
         if isinstance(oc, SparseMatrix):
             return oc.__radd__(self)
         return self._binary_operation(oc, operator.add, fail_for_mismatch=True, operator_str="+")
 
     def __radd__(self, oc):
+        self._reject_bare_unit(oc, "add")
         return self.__add__(oc)
 
     def __iadd__(self, oc):
         # a += b
+        self._reject_bare_unit(oc, "add")
         return self._binary_operation(oc, operator.add, fail_for_mismatch=True, operator_str="+=", inplace=True)
 
     def __sub__(self, oc):
+        self._reject_bare_unit(oc, "subtract")
         if isinstance(oc, SparseMatrix):
             return oc.__rsub__(self)
         return self._binary_operation(oc, operator.sub, fail_for_mismatch=True, operator_str="-")
 
     def __rsub__(self, oc):
+        self._reject_bare_unit(oc, "subtract")
         return _to_quantity(oc).__sub__(self)
 
     def __isub__(self, oc):

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -1076,6 +1076,10 @@ class Unit:
             name=self.name,
             dispname=self.dispname,
             is_fullname=self.is_fullname,
+            display_parts=(
+                list(self._display_parts)
+                if self._display_parts is not None else None
+            ),
         )
 
     def __deepcopy__(self, memodict):
@@ -1087,6 +1091,7 @@ class Unit:
             name=deepcopy(self.name),
             dispname=deepcopy(self.dispname),
             is_fullname=deepcopy(self.is_fullname),
+            display_parts=deepcopy(self._display_parts, memodict),
         )
 
     def __hash__(self):
@@ -1300,19 +1305,18 @@ class Unit:
         exponentiation, `` * `` for multiplication, and `` / `` for
         division.  The result is both human-readable and
         machine-parseable.
+
+        The standard-unit substitution is resolved eagerly at
+        construction time (in ``__mul__``/``__div__``/``__pow__``/
+        ``reverse``) and stored on ``_name``/``_dispname``, so this
+        method simply returns the stored canonical name when
+        ``is_fullname`` is set.  This keeps ``unit.name`` consistent
+        with ``str(unit)`` and survives pickle/copy.
         """
-        if self._display_parts is not None:
-            # Check if this compound unit matches a known derived unit
-            # (e.g. mA * ohm → mV, volt * amp → W)
-            _, dispname, is_fullname, _ = _find_standard_unit(
-                self.dim, self.base, self.scale, self.factor,
-                for_composition=True,
-            )
-            if is_fullname:
-                return dispname
-            return _format_display_parts(self._display_parts)
         if self.is_fullname:
             return self.dispname
+        if self._display_parts is not None:
+            return _format_display_parts(self._display_parts)
         if self.dim.is_dimensionless:
             if self.scale == 0 and self.factor == 1.:
                 return '1'
@@ -1360,11 +1364,22 @@ class Unit:
                     _get_display_parts(other),
                 )
                 parts = _normalise_display_parts(parts)
-                canonical = _format_display_parts(parts)
+                # Eagerly resolve a registered standard name for the
+                # composed quantity so that ``name``/``dispname`` stay in
+                # sync with ``str(self)``.  Falls back to the parts-based
+                # canonical string for ambiguous keys or anonymous results.
+                std_name, std_disp, std_is_full, _ = _find_standard_unit(
+                    dim, self.base, scale, factor, for_composition=True,
+                )
+                if std_is_full:
+                    name, dispname, is_fullname = std_name, std_disp, True
+                else:
+                    canonical = _format_display_parts(parts)
+                    name, dispname, is_fullname = canonical, canonical, True
                 return Unit(
                     dim, scale=scale, base=self.base, factor=factor,
-                    name=canonical, dispname=canonical,
-                    is_fullname=True,
+                    name=name, dispname=dispname,
+                    is_fullname=is_fullname,
                     display_parts=parts,
                 )
 
@@ -1419,11 +1434,18 @@ class Unit:
                     _get_display_parts(self), other_parts,
                 )
                 parts = _normalise_display_parts(parts)
-                canonical = _format_display_parts(parts)
+                std_name, std_disp, std_is_full, _ = _find_standard_unit(
+                    dim, self.base, scale, factor, for_composition=True,
+                )
+                if std_is_full:
+                    name, dispname, is_fullname = std_name, std_disp, True
+                else:
+                    canonical = _format_display_parts(parts)
+                    name, dispname, is_fullname = canonical, canonical, True
                 return Unit(
                     dim, base=self.base, scale=scale, factor=factor,
-                    name=canonical, dispname=canonical,
-                    is_fullname=True,
+                    name=name, dispname=dispname,
+                    is_fullname=is_fullname,
                     display_parts=parts,
                 )
 
@@ -1493,6 +1515,8 @@ class Unit:
         if self.is_fullname:
             parts = [(n, d, -e) for n, d, e in _get_display_parts(self)]
             parts = _normalise_display_parts(parts)
+            # reverse() already handles the unambiguous standard-unit
+            # case at the top; here we just render the parts.
             canonical = _format_display_parts(parts)
             return Unit(
                 dim, base=self.base, scale=scale, factor=factor,
@@ -1548,11 +1572,18 @@ class Unit:
                 src_parts = _get_display_parts(self)
                 parts = [(n, d, e * other) for n, d, e in src_parts]
                 parts = _normalise_display_parts(parts)
-                canonical = _format_display_parts(parts)
+                std_name, std_disp, std_is_full, _ = _find_standard_unit(
+                    dim, self.base, scale, factor, for_composition=True,
+                )
+                if std_is_full:
+                    name, dispname, is_fullname = std_name, std_disp, True
+                else:
+                    canonical = _format_display_parts(parts)
+                    name, dispname, is_fullname = canonical, canonical, True
                 return Unit(
                     dim, base=self.base, scale=scale, factor=factor,
-                    name=canonical, dispname=canonical,
-                    is_fullname=True,
+                    name=name, dispname=dispname,
+                    is_fullname=is_fullname,
                     display_parts=parts,
                 )
 
@@ -1644,7 +1675,9 @@ class Unit:
         return self
 
     def __reduce__(self):
-        # For pickling
+        # For pickling.  ``display_parts`` is forwarded so that compound
+        # units (e.g. ``mS * nA / cm^2``) preserve their canonical
+        # rendering across pickle round-trips.
         return (
             _to_unit,
             (
@@ -1654,15 +1687,21 @@ class Unit:
                 self.factor,
                 self.name,
                 self.dispname,
-                self.is_fullname
+                self.is_fullname,
+                (list(self._display_parts)
+                 if self._display_parts is not None else None),
             )
         )
 
 
-def _to_unit(*args):
-    """Private pickle reconstruction shim for Unit.
-    """
-    return Unit(*args)
+def _to_unit(dim, scale, base, factor, name, dispname, is_fullname,
+             display_parts=None):
+    """Private pickle reconstruction shim for Unit."""
+    return Unit(
+        dim=dim, scale=scale, base=base, factor=factor,
+        name=name, dispname=dispname, is_fullname=is_fullname,
+        display_parts=display_parts,
+    )
 
 
 _to_unit.__module__ = 'saiunit._base_unit'

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -116,6 +116,30 @@ def _find_standard_unit(
     return None, None, False, False
 
 
+def _format_dim_parser_compatible(dim: Dimension, python_code: bool = False) -> str:
+    """Render *dim* in parser-compatible canonical form.
+
+    ``Dimension.__str__`` emits space-separated SI factors (``"m kg s^-2"``)
+    which cannot be round-tripped through :func:`parse_unit`.  This helper
+    produces the same content with the canonical `` * `` / ``^`` / `` / ``
+    grammar used by :func:`_format_display_parts`, so anonymous Units have
+    a name/dispname that the parser can read back.
+
+    When ``python_code`` is True, the full-name SI labels (``metre``,
+    ``kilogram``, ...) are used in place of the short symbols.
+    """
+    from ._base_dimension import _ilabel, _iclass_label
+    labels = _iclass_label if python_code else _ilabel
+    dims = dim._dims
+    parts = []
+    for i in range(len(dims)):
+        if dims[i]:
+            parts.append((labels[i], labels[i], dims[i]))
+    if not parts:
+        return "1"
+    return _format_display_parts(parts)
+
+
 def _find_a_name(dim: Dimension, base, scale, factor) -> tuple[str | None, bool]:
     if dim == DIMENSIONLESS:
         u_name = f"Unit({base}^{scale})"
@@ -722,8 +746,16 @@ class Unit:
             if dim == DIMENSIONLESS:
                 name = f"Unit({base}^{scale})"
             else:
-                name = dim.__repr__()
-                dispname = dim.__str__()
+                # Anonymous Units must produce parser-compatible
+                # name/dispname so that ``parse_unit(repr(u))`` round-trips.
+                # ``Dimension.__str__`` uses space separation which the
+                # parser cannot read.  ``_canonical_str`` (called by
+                # ``__repr__``/``__str__``) prefixes the factor/scale on
+                # its own for anonymous units, so we only encode the
+                # dimensional part here.
+                name = _format_dim_parser_compatible(dim, python_code=True)
+                if dispname is None:
+                    dispname = _format_dim_parser_compatible(dim, python_code=False)
         self._name = name
 
         # The display name of this unit

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -175,6 +175,12 @@ def _find_a_name(dim: Dimension, base, scale, factor) -> tuple[str | None, bool]
 _standard_units: 'dict[tuple, Unit]' = {}
 _standard_unit_aliases: 'dict[tuple, list[Unit]]' = {}
 _unit_name_registry: 'dict[str, Unit]' = {}
+# Monotonically-increasing registration index for each registered Unit
+# identity.  Used by :func:`_select_preferred_standard_unit` to prefer
+# units that were registered earlier (i.e. library built-ins) over
+# user-added aliases for the same physical key.
+_unit_registration_index: 'dict[int, int]' = {}
+_next_registration_index: 'list[int]' = [0]
 
 # ---------------------------------------------------------------------------
 # Ambiguous-key detection
@@ -208,14 +214,26 @@ def _standard_unit_preference_score(unit: 'Unit') -> int:
 
 
 def _select_preferred_standard_unit(units: 'list[Unit]') -> 'Unit':
-    """Pick the preferred alias – deterministic (score, then alpha)."""
-    return min(
-        units,
-        key=lambda u: (
+    """Pick the preferred alias.
+
+    Order of preference (lower is better):
+
+    1. ``_standard_unit_preference_score`` (e.g. prefer hertz over
+       becquerel for s^-1).
+    2. Registration index — library built-ins win over user
+       additions made via :func:`add_standard_unit` after import,
+       so user aliases cannot hijack canonical display.
+    3. Alphabetical, as a final deterministic tie-breaker for units
+       registered in the same call.
+    """
+    def _key(u):
+        idx = _unit_registration_index.get(id(u), float('inf'))
+        return (
             _standard_unit_preference_score(u),
+            idx,
             u.name.lower() if isinstance(u.name, str) else "",
-        ),
-    )
+        )
+    return min(units, key=_key)
 
 
 def add_standard_unit(u: 'Unit'):
@@ -261,6 +279,10 @@ def add_standard_unit(u: 'Unit'):
         # and poison the ambiguity heuristic below.
         if not any(existing is u for existing in aliases):
             aliases.append(u)
+            # Stamp a monotonic registration index so that later
+            # additions cannot hijack the canonical display.
+            _unit_registration_index[id(u)] = _next_registration_index[0]
+            _next_registration_index[0] += 1
         _standard_units[key] = _select_preferred_standard_unit(aliases)
 
         # Auto-detect ambiguity: >=2 distinct display names → ambiguous

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -1359,6 +1359,7 @@ class Unit:
                     _get_display_parts(self),
                     _get_display_parts(other),
                 )
+                parts = _normalise_display_parts(parts)
                 canonical = _format_display_parts(parts)
                 return Unit(
                     dim, scale=scale, base=self.base, factor=factor,
@@ -1417,6 +1418,7 @@ class Unit:
                 parts = _merge_display_parts(
                     _get_display_parts(self), other_parts,
                 )
+                parts = _normalise_display_parts(parts)
                 canonical = _format_display_parts(parts)
                 return Unit(
                     dim, base=self.base, scale=scale, factor=factor,

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -1096,14 +1096,15 @@ class Unit:
 
     def __hash__(self):
         if self._hash is None:
+            # Equality is *physical*: two units that resolve to the same
+            # ``(dim, factor, base, scale)`` must hash equal regardless
+            # of name spelling (e.g. ``metre`` vs ``meter``).
             self._hash = hash(
                 (
                     self.dim,
                     self.factor,
                     self.base,
                     self.scale,
-                    self.name,
-                    self.dispname,
                 )
             )
         return self._hash
@@ -1647,25 +1648,19 @@ class Unit:
 
     def __eq__(self, other) -> bool:
         # Two Units are equal when they represent the same physical
-        # quantity (matching dim/scale/base/factor) *and* render to the
-        # same canonical display string. The canonical string already
-        # folds registry-canonical aliases (e.g. ``A * ohm`` displays as
-        # ``V``) and respects the no-intermediate-simplification rule
-        # for genuinely composed units, so this comparison naturally
-        # treats math-equivalent aliases (metre/meter, A*ohm/volt) as
-        # equal without collapsing intermediate display order.
-        # Use ``is_unit_equal_math`` for a name-agnostic, math-only
-        # equivalence test.
+        # quantity (matching dim/scale/base/factor).  Names and display
+        # strings are *not* part of equality: spelling aliases such as
+        # ``metre`` vs ``meter`` and registry-canonical compounds such
+        # as ``A * ohm`` vs ``V`` compare equal, and the corresponding
+        # hashes collide as required by the ``__hash__`` contract.
         if not isinstance(other, Unit):
             return False
-        if not (
+        return (
             (other.dim == self.dim)
             and (other.scale == self.scale)
             and (other.base == self.base)
             and (other.factor == self.factor)
-        ):
-            return False
-        return self._canonical_str() == other._canonical_str()
+        )
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -730,6 +730,30 @@ class Unit:
     ):
         # String-based construction: Unit("mV"), Unit("J / kg"), etc.
         if isinstance(dim, str):
+            # The string form ignores every other constructor argument —
+            # silently dropping ``Unit("mV", scale=99, factor=99)`` was a
+            # source of confusing bugs.  Reject any non-default secondary
+            # argument explicitly so the caller knows.
+            extras = []
+            if scale != 0:
+                extras.append("scale")
+            if base != 10.:
+                extras.append("base")
+            if factor != 1.:
+                extras.append("factor")
+            if name is not None:
+                extras.append("name")
+            if dispname is not None:
+                extras.append("dispname")
+            if display_parts is not None:
+                extras.append("display_parts")
+            if extras:
+                raise TypeError(
+                    "Unit(str, ...) does not accept additional arguments: "
+                    + ", ".join(extras)
+                    + ". Use parse_unit() and modify the result, or construct "
+                    "the Unit from a Dimension instead."
+                )
             parsed = parse_unit(dim)
             self._base = parsed._base
             self._scale = parsed._scale
@@ -742,14 +766,23 @@ class Unit:
             self._display_parts = parsed._display_parts
             return
 
-        # All Units canonicalize to base=10; a non-10 ``base`` is folded into
-        # ``factor`` as ``base**scale`` so that ``base**scale * factor`` is
-        # preserved. This keeps arithmetic on units (mul/div) closed without
-        # needing to reconcile mismatched bases at every call site.
+        # ``base`` is fixed at 10 for now — Units canonicalize to base=10
+        # internally, and accepting other bases silently rewrote them,
+        # losing information.  Raise so callers can not be surprised.
         if base != 10.:
-            factor = factor * (base ** scale)
-            base = 10.
-            scale = 0
+            raise ValueError(
+                f"Unit currently only supports base=10; got base={base!r}. "
+                "Encode non-decimal scales in ``factor`` instead."
+            )
+
+        # Reject NaN/inf factors — these poison arithmetic downstream and
+        # cannot represent a valid physical conversion.
+        if isinstance(factor, (int, float)):
+            import math
+            if math.isnan(factor) or math.isinf(factor):
+                raise ValueError(
+                    f"Unit factor must be a finite real number; got factor={factor!r}."
+                )
 
         self._base = base
         self._scale = scale

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -1408,8 +1408,26 @@ class Unit:
             dim = self.dim * other.dim
             factor = self.factor * other.factor
 
-            # Dimensionless → no compound display
+            # Dimensionless result.  When neither operand carries a named
+            # dimensionless display (radian, steradian, ...), the result is
+            # bare ``Unit("1")`` as before.  When at least one operand is a
+            # named dimensionless unit, merge its display parts so the
+            # name survives ``radian * UNITLESS`` and compounds such as
+            # ``radian * radian`` render as ``rad^2`` rather than ``1``.
             if dim == DIMENSIONLESS:
+                self_named_dimless = self.is_fullname and self.dim.is_dimensionless
+                other_named_dimless = other.is_fullname and other.dim.is_dimensionless
+                if self_named_dimless or other_named_dimless:
+                    parts_a = _get_display_parts(self) if self_named_dimless else []
+                    parts_b = _get_display_parts(other) if other_named_dimless else []
+                    parts = _normalise_display_parts(_merge_display_parts(parts_a, parts_b))
+                    if parts:
+                        canonical = _format_display_parts(parts)
+                        return Unit(
+                            dim, scale=scale, base=self.base, factor=factor,
+                            name=canonical, dispname=canonical,
+                            is_fullname=True, display_parts=parts,
+                        )
                 return Unit(dim, scale=scale, base=self.base, factor=factor)
 
             # Both named → deterministic compound via display_parts
@@ -1478,8 +1496,25 @@ class Unit:
             dim = self.dim / other.dim
             factor = self.factor / other.factor
 
-            # Dimensionless → no compound display
+            # Dimensionless result — preserve named-dimensionless display
+            # (radian, steradian, ...) so ``rad / UNITLESS`` stays ``rad``.
             if dim == DIMENSIONLESS:
+                self_named_dimless = self.is_fullname and self.dim.is_dimensionless
+                other_named_dimless = other.is_fullname and other.dim.is_dimensionless
+                if self_named_dimless or other_named_dimless:
+                    parts_a = _get_display_parts(self) if self_named_dimless else []
+                    parts_b = (
+                        [(n, d, -e) for n, d, e in _get_display_parts(other)]
+                        if other_named_dimless else []
+                    )
+                    parts = _normalise_display_parts(_merge_display_parts(parts_a, parts_b))
+                    if parts:
+                        canonical = _format_display_parts(parts)
+                        return Unit(
+                            dim, base=self.base, scale=scale, factor=factor,
+                            name=canonical, dispname=canonical,
+                            is_fullname=True, display_parts=parts,
+                        )
                 return Unit(dim, scale=scale, base=self.base, factor=factor)
 
             # Both named → deterministic compound via display_parts
@@ -1618,6 +1653,21 @@ class Unit:
             factor = self.factor ** other
 
             if dim == DIMENSIONLESS:
+                # Preserve a named-dimensionless display (radian, steradian)
+                # through powers: ``radian ** 1`` is ``rad``, ``rad ** 2``
+                # is ``rad^2``; ``rad ** 0`` collapses to ``1`` naturally.
+                if self.is_fullname and self.dim.is_dimensionless:
+                    src_parts = _get_display_parts(self)
+                    parts = _normalise_display_parts(
+                        [(n, d, e * other) for n, d, e in src_parts]
+                    )
+                    if parts:
+                        canonical = _format_display_parts(parts)
+                        return Unit(
+                            dim, base=self.base, scale=scale, factor=factor,
+                            name=canonical, dispname=canonical,
+                            is_fullname=True, display_parts=parts,
+                        )
                 return Unit(dim, scale=scale, base=self.base, factor=factor)
 
             # Named source → build from display_parts (multiply exponents).

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -459,8 +459,34 @@ def _parse_product(s: str):
 
 
 def _parse_term(s: str):
-    """Parse a single term like ``'cm^2'``, ``'mV'``, or ``'10^3'``."""
+    """Parse a single term like ``'cm^2'``, ``'mV'``, or ``'10^3'``.
+
+    Parenthesised sub-expressions are recursively parsed as full
+    fraction/product expressions; this lets ``parse_unit("(m * s) / A")``
+    succeed.
+    """
     s = s.strip()
+    # Strip a single outer paren wrapping the whole term and recurse.
+    if s.startswith('(') and s.endswith(')'):
+        depth = 0
+        balanced_at_zero_only_at_end = True
+        for i, ch in enumerate(s):
+            if ch == '(':
+                depth += 1
+            elif ch == ')':
+                depth -= 1
+                if depth == 0 and i != len(s) - 1:
+                    balanced_at_zero_only_at_end = False
+                    break
+        if balanced_at_zero_only_at_end:
+            inner = s[1:-1].strip()
+            if not inner:
+                raise ValueError(f"Empty parenthesised group in {s!r}")
+            num_str, den_str = _split_fraction(inner)
+            numerator = _parse_product(num_str)
+            if den_str is not None:
+                return numerator / _parse_product(den_str)
+            return numerator
     caret_idx = s.rfind('^')
     if caret_idx > 0:
         atom = s[:caret_idx].strip()
@@ -472,10 +498,14 @@ def _parse_term(s: str):
         except ValueError:
             raise ValueError(f"Invalid exponent in unit string: {s!r}")
 
-        # Numeric base → dimensionless scaled unit (e.g. "10^3")
+        # Numeric base → dimensionless scaled unit (e.g. "10^3").
+        # ``Unit`` is base=10-only, so encode ``base_num ** exp`` either
+        # in ``scale`` (when base_num==10) or in ``factor``.
         try:
             base_num = float(atom)
-            return Unit(DIMENSIONLESS, scale=exp, base=base_num)
+            if base_num == 10.0:
+                return Unit(DIMENSIONLESS, scale=exp)
+            return Unit(DIMENSIONLESS, factor=float(base_num) ** exp)
         except ValueError:
             pass
 

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1396,3 +1396,17 @@ class TestParseUnit:
         assert "mV" in _unit_name_registry
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
+
+    # --- anonymous unit round-trip (#5) ---
+    def test_anonymous_unit_dispname_parser_compatible(self):
+        """An anonymous Unit's dispname must round-trip through parse_unit."""
+        anon = Unit(u.joule.dim)
+        # Round-trips back to joule (canonical) since they are math-equal.
+        parsed = parse_unit(anon.dispname)
+        assert parsed == anon
+
+    def test_anonymous_unit_with_factor_roundtrip(self):
+        """An anonymous Unit with a factor must repr-round-trip."""
+        anon = Unit(u.joule.dim, factor=4.184)
+        parsed = parse_unit(repr(anon))
+        assert parsed == anon

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1397,6 +1397,26 @@ class TestParseUnit:
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
 
+    # --- named-dimensionless identity preserved (#7) ---
+    def test_radian_mul_unitless_preserves_name(self):
+        assert repr(u.radian * UNITLESS) == 'Unit("rad")'
+        assert repr(UNITLESS * u.radian) == 'Unit("rad")'
+
+    def test_radian_pow_one_preserves_name(self):
+        assert repr(u.radian ** 1) == 'Unit("rad")'
+
+    def test_radian_pow_two_compound(self):
+        assert repr(u.radian ** 2) == 'Unit("rad^2")'
+
+    def test_radian_self_divide_collapses(self):
+        assert repr(u.radian / u.radian) == 'Unit("1")'
+
+    def test_radian_self_multiply_squared(self):
+        assert repr(u.radian * u.radian) == 'Unit("rad^2")'
+
+    def test_steradian_mul_unitless_preserves_name(self):
+        assert repr(u.steradian * UNITLESS) == 'Unit("sr")'
+
     # --- user alias does not hijack canonical display (#6) ---
     def test_user_alias_does_not_hijack_canonical(self):
         """A user-registered alias must not displace the built-in canonical."""

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1402,6 +1402,15 @@ class TestParseUnit:
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
 
+    # --- kelvin prefix coverage (#10) ---
+    def test_kelvin_prefixes_parse(self):
+        from saiunit._unit_common import mkelvin, ukelvin, nkelvin, kkelvin, Mkelvin
+        assert parse_unit("mK") == mkelvin
+        assert parse_unit("uK") == ukelvin
+        assert parse_unit("nK") == nkelvin
+        assert parse_unit("kK") == kkelvin
+        assert parse_unit("MK") == Mkelvin
+
     # --- Unit(str, ...) rejects extra kwargs (#8) ---
     def test_string_construction_rejects_extra_args(self):
         with pytest.raises(TypeError, match="does not accept additional"):

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -490,6 +490,18 @@ class TestUnitCopyHash:
         h2 = hash(u)
         assert h1 == h2
 
+    def test_hash_eq_invariant_spelling_aliases(self):
+        """Spelling aliases must compare equal and hash equal."""
+        pairs = [
+            (u.metre, u.meter),
+            (u.amp, u.ampere),
+            (u.kilogram, u.kilogramme),
+        ]
+        for a, b in pairs:
+            assert a == b
+            assert hash(a) == hash(b)
+            assert len({a, b}) == 1
+
     def test_factorless(self):
         d = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         u = Unit(d, name="metre", dispname="m", scale=0, factor=2.)

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -523,6 +523,31 @@ class TestUnitPickle:
         u2 = pickle.loads(data)
         assert u2 == UNITLESS
 
+    def test_pickle_compound_preserves_display(self):
+        """Compound units must preserve their canonical display across
+        pickle round-trips (display_parts is forwarded)."""
+        r = u.joule / u.metre ** 2 * u.second ** 2
+        assert str(r) == "kg"
+        assert r.dispname == "kg"
+        restored = pickle.loads(pickle.dumps(r))
+        assert str(restored) == "kg"
+        assert restored == r
+
+    def test_copy_compound_preserves_display(self):
+        r = u.mS * u.nA / u.cm2
+        c = r.copy()
+        assert str(c) == str(r)
+
+    def test_deepcopy_compound_preserves_display(self):
+        r = u.mS * u.nA / u.cm2
+        c = deepcopy(r)
+        assert str(c) == str(r)
+
+    def test_compound_name_dispname_match_str(self):
+        """unit.name / unit.dispname must agree with str(unit)."""
+        r = u.joule / u.metre ** 2 * u.second ** 2
+        assert r.dispname == str(r)
+
 
 # =========================================================================
 # Display-parts helpers

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1402,6 +1402,17 @@ class TestParseUnit:
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
 
+    # --- parser accepts parens in numerator (#14) ---
+    def test_parens_in_numerator(self):
+        assert parse_unit("(m * s) / A") == parse_unit("m * s / A")
+
+    def test_parens_outer_group(self):
+        assert parse_unit("(m / s)") == parse_unit("m / s")
+
+    def test_parens_in_denominator(self):
+        # Already worked; sanity check that the new recursion preserves it.
+        assert parse_unit("m / (kg * s^2)") == u.metre / (u.kilogram * u.second ** 2)
+
     # --- kelvin prefix coverage (#10) ---
     def test_kelvin_prefixes_parse(self):
         from saiunit._unit_common import mkelvin, ukelvin, nkelvin, kkelvin, Mkelvin

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -133,12 +133,17 @@ class TestUnitProperties:
         with pytest.raises(NotImplementedError):
             u.factor = 1.0
 
-    def test_base_property(self):
-        # Units canonicalize to base=10; a base!=10 is folded into factor.
-        u = Unit(DIMENSIONLESS, base=2.0, scale=3)
+    def test_base_property_rejects_non_10(self):
+        # Units are fixed to base=10 — non-10 bases used to be silently
+        # folded into ``factor``, which dropped information.  See #11.
+        with pytest.raises(ValueError, match="only supports base=10"):
+            Unit(DIMENSIONLESS, base=2.0, scale=3)
+
+    def test_base_property_default(self):
+        u = Unit(DIMENSIONLESS, scale=3)
         assert u.base == 10.0
-        assert u.scale == 0
-        assert u.factor == 8.0
+        assert u.scale == 3
+        assert u.factor == 1.0
 
     def test_base_setter_raises(self):
         u = Unit()
@@ -1396,6 +1401,29 @@ class TestParseUnit:
         assert "mV" in _unit_name_registry
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
+
+    # --- Unit(str, ...) rejects extra kwargs (#8) ---
+    def test_string_construction_rejects_extra_args(self):
+        with pytest.raises(TypeError, match="does not accept additional"):
+            Unit("mV", scale=99)
+        with pytest.raises(TypeError, match="does not accept additional"):
+            Unit("mV", factor=99.0)
+        with pytest.raises(TypeError, match="does not accept additional"):
+            Unit("mV", name="zzz")
+
+    # --- non-10 base rejected (#11) ---
+    def test_base_non_10_raises(self):
+        with pytest.raises(ValueError, match="only supports base=10"):
+            Unit(DIMENSIONLESS, base=2.0)
+
+    # --- NaN/inf factor rejected (#16) ---
+    def test_nan_factor_raises(self):
+        with pytest.raises(ValueError, match="finite real number"):
+            Unit(u.metre.dim, factor=float('nan'))
+
+    def test_inf_factor_raises(self):
+        with pytest.raises(ValueError, match="finite real number"):
+            Unit(u.metre.dim, factor=float('inf'))
 
     # --- named-dimensionless identity preserved (#7) ---
     def test_radian_mul_unitless_preserves_name(self):

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1402,6 +1402,18 @@ class TestParseUnit:
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
 
+    # --- Quantity + Unit / Unit + Quantity both rejected (#12) ---
+    def test_unit_plus_quantity_rejected(self):
+        q = Quantity(1.0, unit=u.metre)
+        with pytest.raises(TypeError):
+            u.metre + q
+        with pytest.raises(TypeError):
+            q + u.metre
+        with pytest.raises(TypeError):
+            u.metre - q
+        with pytest.raises(TypeError):
+            q - u.metre
+
     # --- parser accepts parens in numerator (#14) ---
     def test_parens_in_numerator(self):
         assert parse_unit("(m * s) / A") == parse_unit("m * s / A")

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -1397,6 +1397,16 @@ class TestParseUnit:
         assert "volt" in _unit_name_registry
         assert "V" in _unit_name_registry
 
+    # --- user alias does not hijack canonical display (#6) ---
+    def test_user_alias_does_not_hijack_canonical(self):
+        """A user-registered alias must not displace the built-in canonical."""
+        before = repr(u.metre.factorless())
+        add_standard_unit(Unit(u.metre.dim, name="aaaa_meter", dispname="aaaa_m"))
+        after = repr(u.metre.factorless())
+        assert before == after, (
+            f"User alias hijacked canonical: {before!r} -> {after!r}"
+        )
+
     # --- anonymous unit round-trip (#5) ---
     def test_anonymous_unit_dispname_parser_compatible(self):
         """An anonymous Unit's dispname must round-trip through parse_unit."""

--- a/saiunit/_display_test.py
+++ b/saiunit/_display_test.py
@@ -1474,3 +1474,33 @@ class TestPathologicalCompositions:
                   u.joule)
         # V * A * s / J = W * s / J = J / J = 1
         assert str(result) == "1"
+
+
+# ===================================================================
+# Section 31: Compound-exponent normalisation
+# ===================================================================
+
+
+class TestCompoundExponentNormalization:
+    """Multiplying / dividing a base-symbol unit with its pre-registered
+    power (e.g. ``metre * metre2``) must combine exponents into a single
+    ``m^3`` instead of leaving stacked ``m * m^2``.
+    """
+
+    def test_metre_times_metre2(self):
+        assert str(u.metre2 * u.metre) == "m^3"
+
+    def test_metre2_times_metre(self):
+        assert str(u.metre * u.metre2) == "m^3"
+
+    def test_cm_times_cm2(self):
+        assert str(u.cm * u.cm2) == "cm^3"
+
+    def test_metre_div_metre2(self):
+        assert str(u.metre / u.metre2) == "1 / m"
+
+    def test_mm_chain(self):
+        assert str(u.mm * u.mm2 * u.mm) == "mm^4"
+
+    def test_compound_with_cm_cm2_cancel(self):
+        assert str((u.mS * u.nA / u.cm2) * u.cm) == "mS * nA / cm"

--- a/saiunit/_unit_common.py
+++ b/saiunit/_unit_common.py
@@ -245,6 +245,26 @@ __all__ = [
     "Ecandle",
     "Zcandle",
     "Ycandle",
+    "ykelvin",
+    "zkelvin",
+    "akelvin",
+    "fkelvin",
+    "pkelvin",
+    "nkelvin",
+    "ukelvin",
+    "mkelvin",
+    "ckelvin",
+    "dkelvin",
+    "dakelvin",
+    "hkelvin",
+    "kkelvin",
+    "Mkelvin",
+    "Gkelvin",
+    "Tkelvin",
+    "Pkelvin",
+    "Ekelvin",
+    "Zkelvin",
+    "Ykelvin",
     "ygram",
     "zgram",
     "agram",
@@ -2333,6 +2353,26 @@ Pcandle = Unit.create_scaled_unit(candle, "P")
 Ecandle = Unit.create_scaled_unit(candle, "E")
 Zcandle = Unit.create_scaled_unit(candle, "Z")
 Ycandle = Unit.create_scaled_unit(candle, "Y")
+ykelvin = Unit.create_scaled_unit(kelvin, "y")
+zkelvin = Unit.create_scaled_unit(kelvin, "z")
+akelvin = Unit.create_scaled_unit(kelvin, "a")
+fkelvin = Unit.create_scaled_unit(kelvin, "f")
+pkelvin = Unit.create_scaled_unit(kelvin, "p")
+nkelvin = Unit.create_scaled_unit(kelvin, "n")
+ukelvin = Unit.create_scaled_unit(kelvin, "u")
+mkelvin = Unit.create_scaled_unit(kelvin, "m")
+ckelvin = Unit.create_scaled_unit(kelvin, "c")
+dkelvin = Unit.create_scaled_unit(kelvin, "d")
+dakelvin = Unit.create_scaled_unit(kelvin, "da")
+hkelvin = Unit.create_scaled_unit(kelvin, "h")
+kkelvin = Unit.create_scaled_unit(kelvin, "k")
+Mkelvin = Unit.create_scaled_unit(kelvin, "M")
+Gkelvin = Unit.create_scaled_unit(kelvin, "G")
+Tkelvin = Unit.create_scaled_unit(kelvin, "T")
+Pkelvin = Unit.create_scaled_unit(kelvin, "P")
+Ekelvin = Unit.create_scaled_unit(kelvin, "E")
+Zkelvin = Unit.create_scaled_unit(kelvin, "Z")
+Ykelvin = Unit.create_scaled_unit(kelvin, "Y")
 ygram = Unit.create_scaled_unit(gram, "y")
 zgram = Unit.create_scaled_unit(gram, "z")
 agram = Unit.create_scaled_unit(gram, "a")


### PR DESCRIPTION
## Summary

Senior-architect audit of `saiunit`'s Unit naming/display/hash/serialization system identified 22 distinct issues. This PR lands fixes for all CRITICAL and HIGH issues plus most of MEDIUM, with regression tests for each.

**10 commits, +19 tests (3174 → 3193 passing).**

## Issues fixed

### Critical (correctness)
- **#1** `Unit.__hash__` / `__eq__` invariant violation — spelling aliases (`metre`/`meter`) compared equal but hashed differently
- **#2** pickle/copy/deepcopy losing `display_parts` (verified fixed by earlier display refactor)
- **#3** name/dispname desync after arithmetic (455a498)
- **#4** compound exponent stacking — `metre2 * metre` produced `"m * m^2"` instead of `"m^3"` (661e52d)
- **#5** anonymous Unit `dispname` (from `str(dim)`) was not parser-compatible
- **#6** user `add_standard_unit` aliases hijacked canonical display via alphabetical pick
- **#7** `radian * UNITLESS` / `radian ** 1` erased the named-dimensionless identity

### High (API design)
- **#8** `Unit(str, **extras)` silently ignored extra kwargs — now `TypeError`
- **#10** missing SI-prefixed kelvin variants — `parse_unit(\"mK\")` now works
- **#11** `base != 10` silently folded into `factor` — now `ValueError`
- **#12** asymmetric `Quantity + Unit` vs `Unit + Quantity` — both now raise

### Medium (parser / edges)
- **#14** `parse_unit(\"(m * s) / A\")` raised on parens — now supported
- **#15 / #18 / #19** verified already correct (round-trip, numeric, scientific notation)
- **#16** NaN/Inf factors rejected at construction

### Deferred (with rationale)
- **#9, #13, #17, #20, #21, #22** — stylistic, already adequate, or pure optimization. See review notes in commit footers.

## User-visible behavior changes (intentional)

1. `Unit(dim, base=X)` with `X != 10` → `ValueError` (was silent factor fold)
2. `Unit(str, **extras)` with extras → `TypeError` (was silent ignore)
3. `Quantity + Unit` → `TypeError` (was silent coercion via `Quantity(1, unit)`)

Each is documented in its commit message.

## Test plan

- [x] Full saiunit suite: `pytest saiunit/ -x -q` → 3193 passed
- [x] Regression test added for each fixed issue
- [x] Pickle / copy / deepcopy round-trips covered for registered, composed, and prefixed units
- [ ] Reviewer: confirm the three intentional breaking changes are acceptable; if any downstream caller depends on them, we should gate with a deprecation cycle instead

## Summary by Sourcery

Tighten Unit and Quantity semantics around naming, hashing, parsing, and arithmetic to address audited correctness and API issues.

Bug Fixes:
- Align Unit.__eq__ and __hash__ with physical equality so spelling aliases and canonicalized compounds compare and hash identically.
- Ensure compound units preserve canonical display information across copy, deepcopy, and pickle round-trips.
- Preserve named dimensionless units (e.g. radian, steradian) through multiplication, division, and exponentiation with dimensionless results.
- Prevent user-registered standard-unit aliases from overriding canonical library displays by preferring earlier registrations.
- Make parse_unit accept parenthesized sub-expressions in numerators and ensure numeric base parsing produces correct dimensionless scaling.
- Guarantee anonymous units and their factors round-trip through repr()/parse_unit by emitting parser-compatible names and display names.
- Normalize compound exponents so base units multiplied by their registered powers render as a single combined exponent instead of stacked factors.
- Reject NaN and infinite Unit factors at construction to avoid invalid downstream arithmetic.

Enhancements:
- Eagerly resolve standard derived-unit names during composition so Unit.name/dispname stay consistent with str(unit).
- Extend kelvin with the full suite of SI prefixes for consistent prefixed-temperature support.
- Refine Quantity addition and subtraction to explicitly reject bare Unit operands with clear error messaging.
- Adjust Unit string construction and non-decimal base handling to raise explicit errors instead of silently ignoring or rewriting arguments.

Tests:
- Add regression tests covering hash/equality invariants, pickle/copy/deepcopy display preservation, compound exponent normalization, anonymous-unit round-trips, parser parenthesis support, and named-dimensionless behavior.
- Add tests ensuring kelvin prefixes parse correctly and new error conditions (extra kwargs, non-10 base, NaN/inf factors, Quantity±Unit) are enforced.