### PR TITLE
docs: fix sphinx build warnings, document new backend API

### DIFF
--- a/brainunit/brainunit/linalg/__init__.py
+++ b/brainunit/brainunit/linalg/__init__.py
@@ -17,9 +17,13 @@ from ._linalg_change_unit import *
 from ._linalg_change_unit import __all__ as _linalg_change_unit_all
 from ._linalg_keep_unit import *
 from ._linalg_keep_unit import __all__ as _linalg_keep_unit_all
+from ._linalg_remove_unit import *
+from ._linalg_remove_unit import __all__ as _linalg_remove_unit_all
 
 __all__ = (_linalg_change_unit_all +
-              _linalg_keep_unit_all)
+              _linalg_keep_unit_all +
+              _linalg_remove_unit_all)
 
 del (_linalg_change_unit_all,
-     _linalg_keep_unit_all)
+     _linalg_keep_unit_all,
+     _linalg_remove_unit_all)

--- a/changelog.md
+++ b/changelog.md
@@ -1,36 +1,178 @@
 # Release Notes
 
-## Unreleased
+## Version 0.2.2
 
-### Added
+### Highlights
 
-- **NumPy as a first-class array backend.** ``Quantity`` can now wrap an
-  ``np.ndarray`` directly; all math, linalg, and fft operations dispatch
-  to the matching backend via ``array_api_compat``. JAX remains the default
-  and is still a mandatory dependency.
-- ``Quantity.backend`` property reporting ``'numpy'`` or ``'jax'``.
-- ``Quantity.to_numpy()`` and ``Quantity.to_jax()`` conversion methods.
+This release turns saiunit into a multi-backend library. ``Quantity`` can now
+wrap NumPy, JAX, CuPy, PyTorch, Dask, and ndonnx arrays, with operations
+dispatched via the array API standard (``array_api_compat``). JAX is now an
+**optional** dependency — the core package installs and runs on NumPy alone.
+This release also lands a 22-issue audit of ``Unit`` naming, display, hashing,
+and parsing, and tightens correctness in ``Quantity``'s hash/equality and
+tracer interactions.
+
+### Breaking Changes
+
+- **JAX is no longer a mandatory dependency.** Install with ``pip install
+  saiunit`` for the NumPy-only build, or ``pip install "saiunit[jax]"`` (or
+  ``[cpu]``/``[cuda12]``/``[cuda13]``/``[tpu]``) to enable JAX. Without JAX,
+  the default backend auto-selects ``"numpy"`` and JAX-only modules
+  (``saiunit.autograd``, ``saiunit.lax``, ``saiunit.sparse``) raise
+  ``BackendError`` on import with an install hint.
+- ``Quantity(np.ndarray(...))`` now preserves the mantissa as ``np.ndarray``
+  instead of implicitly converting to ``jax.Array``. Call ``.to_jax()`` or
+  use ``with using_backend("jax"):`` to restore the previous behaviour.
+- ``Quantity`` is now **unhashable** (``__hash__ = None``). ``Quantity.__eq__``
+  returns an array, so any hash implementation would violate the hash/eq
+  invariant. This matches NumPy/JAX array semantics across all backends.
+- ``Unit(dim, base=B)`` with ``B != 10`` now raises ``ValueError``. Previously
+  the non-decimal base was silently folded into ``factor`` and then forgotten.
+  Encode non-decimal scales directly in ``factor``.
+- ``Unit("symbol", scale=..., factor=..., name=..., ...)`` now raises
+  ``TypeError`` when extra construction kwargs are combined with a string
+  ``dim``. Previously the extras were silently dropped.
+- ``Unit(dim, factor=...)`` now raises ``ValueError`` for NaN or infinite
+  factors instead of constructing a poisoned unit that propagated NaN through
+  all subsequent arithmetic.
+- ``Quantity + Unit`` and ``Unit + Quantity`` now both raise ``TypeError``
+  symmetrically. Previously the former silently promoted the bare Unit to
+  ``Quantity(1, unit)`` while the latter raised — making ``q + metre`` and
+  ``metre + q`` produce different results.
+
+### New Features
+
+#### Multi-backend support
+
+- **NumPy backend.** ``Quantity`` can wrap ``np.ndarray`` directly; math,
+  linalg, and fft operations dispatch through ``array_api_compat``.
+- **CuPy backend** (``saiunit[cupy]``). GPU arrays via the CuPy array API,
+  with ``Quantity.to_cupy(device=None)`` for conversion.
+- **PyTorch backend** (``saiunit[torch]``). Torch tensors with
+  ``Quantity.to_torch(device=None, dtype=None)``.
+- **Dask backend** (``saiunit[dask]``). Lazy chunked arrays via
+  ``Quantity.to_dask(chunks='auto')``; ``__repr__`` and other materializing
+  methods are lazy-safe and guarded to avoid implicit computation.
+- **ndonnx backend** (``saiunit[ndonnx]``). Symbolic ONNX-graph arrays via
+  ``Quantity.to_ndonnx()`` for export-oriented workflows.
+- ``saiunit[all]`` meta-extra installs every optional backend.
+
+#### Backend control API
+
+- ``Quantity.backend`` property reporting the active backend name
+  (``'numpy'``, ``'jax'``, ``'cupy'``, ``'torch'``, ``'dask'``, ``'ndonnx'``).
+- ``Quantity.to_numpy()`` / ``.to_jax()`` / ``.to_cupy()`` / ``.to_torch()``
+  / ``.to_dask()`` / ``.to_ndonnx()`` conversion methods.
 - ``saiunit.set_default_backend()``, ``saiunit.get_default_backend()``, and
   ``saiunit.using_backend()`` context manager for controlling the default
   backend when input backend is ambiguous (Python scalars, list inputs).
-- ``saiunit.is_numpy_array()`` / ``saiunit.is_jax_array()`` helpers.
-- ``Quantity.__array_ufunc__`` so calls like ``np.sin(quantity)``,
+- ``saiunit.is_numpy_array()``, ``is_jax_array()``, ``is_cupy_array()``,
+  ``is_torch_array()``, ``is_dask_array()``, and ``is_ndonnx_array()``
+  detector helpers.
+- ``Quantity.__array_ufunc__`` so calls like ``np.sin(quantity)`` and
   ``np.add(q1, q2)`` preserve units instead of stripping them.
-- ``saiunit.BackendError`` exception type (subclass of ``TypeError``).
-- ``saiunit.lax`` and ``saiunit.sparse`` entry points now raise
-  ``BackendError`` with a clear ``"call .to_jax() first"`` hint when given a
-  NumPy-backed ``Quantity`` (JAX-only modules require JAX semantics).
+- ``saiunit.BackendError`` exception type (subclass of ``TypeError``) raised
+  by JAX-only modules (``saiunit.lax``, ``saiunit.sparse``,
+  ``saiunit.autograd``, and the custom ``exprel`` primitive) when given a
+  non-JAX backend, with a clear ``"call .to_jax() first"`` (or install)
+  hint.
 
-### Changed
+#### Unit additions
 
-- ``Quantity(np.ndarray(...))`` now keeps the mantissa as ``np.ndarray``.
-  Previously it was implicitly converted to ``jax.Array`` on construction.
-  Call ``.to_jax()`` or run under ``with using_backend("jax")`` for the
-  previous behavior.
+- SI-prefixed kelvin variants (``ykelvin`` through ``Ykelvin``, including
+  ``mK``, ``uK``, ``nK``, ``kK``, ``MK``), bringing kelvin in line with
+  every other base unit. ``parse_unit("mK")`` now succeeds.
+
+### Improvements
+
+#### Unit display, hashing, and parsing (22-issue audit)
+
+- **Compound-exponent normalization.** ``metre * metre2`` now displays as
+  ``m^3`` instead of ``m * m^2``; display parts are merged after compound
+  arithmetic.
+- **Eager standard-name resolution.** Compound results from
+  ``__mul__``/``__div__``/``__pow__`` now write the resolved standard-unit
+  name into ``self._name``/``self._dispname`` at construction time, keeping
+  ``unit.name``, ``unit.dispname``, and ``str(unit)`` in sync. Display
+  parts survive ``copy``, ``deepcopy``, and pickle round-trips.
+- **Hash/eq invariant restored.** ``Unit.__hash__`` no longer folds in
+  spelling fields (``name``/``dispname``), so aliases like ``metre`` and
+  ``meter`` hash and compare consistently — sets and dicts no longer hold
+  silent duplicates. ``Unit.__eq__`` now compares
+  ``(dim, scale, base, factor, _canonical_str())``, with a new
+  ``is_unit_equal_math()`` helper for name-agnostic math equivalence;
+  ``has_same_unit()`` delegates to it.
+- **Built-in units win over user aliases.** ``add_standard_unit`` now
+  stamps a monotonic registration index; built-ins (registered during
+  import) outrank user-added aliases, so registering
+  ``Unit(metre.dim, name="aaaa_meter")`` no longer hijacks the canonical
+  metre display. Alphabetical order remains the tie-breaker for
+  same-batch registrations.
+- **Named-dimensionless identity preserved.** ``radian * UNITLESS``,
+  ``radian ** 1``, and ``UNITLESS * radian`` now render as ``rad`` instead
+  of collapsing to bare ``Unit("1")``; ``radian * radian`` → ``rad^2``;
+  ``radian / radian`` → ``1`` (genuine cancellation).
+- **Parser improvements.** ``parse_unit`` now accepts parenthesised
+  sub-expressions in numerators (``(m * s) / A``), and numeric-base tokens
+  like ``"2^3"`` are encoded as ``Unit(DIMENSIONLESS, factor=8.0)`` rather
+  than raising. Anonymous ``Unit`` instances (constructed without a
+  ``name``) now render with parser-compatible grammar, so
+  ``parse_unit(repr(u))`` round-trips for any anonymous unit.
+
+#### Core correctness
+
+- **Tracer safety.** ``Quantity.update_mantissa()`` and ``__setitem__`` now
+  raise a clear ``RuntimeError`` when called on a traced mantissa, instead
+  of producing silently wrong state.
+- **JIT-safe reductions.** New ``_reduction_count_from_shape`` and
+  ``_is_concrete_zero`` helpers ensure reductions stay JIT-safe, and the
+  "0 is dimensionless" convention only applies to concrete zeros — never
+  tracers.
+- **Foreign-tensor rejection.** ``require_jax_backend`` now names the
+  offending backend and rejects foreign tensors (CuPy, Torch, Dask,
+  ndonnx) at JAX-only entry points.
+
+### Documentation
+
+- New multi-backend user-guide sections covering NumPy, CuPy, PyTorch,
+  Dask (lazy semantics), and ndonnx (symbolic execution).
+- Per-backend Jupyter notebooks demonstrating end-to-end workflows.
+- Updated installation docs covering the new extras layout (``jax``,
+  ``cpu``, ``cuda12``, ``cuda13``, ``tpu``, ``cupy``, ``torch``, ``dask``,
+  ``ndonnx``, ``all``).
+- Sphinx ``conf.py`` gates brainx header injection on ``TARGET=brainunit``;
+  docs build/deploy split (deploy on release, build-only on main push).
 
 ### Dependencies
 
-- New mandatory dependency: ``array_api_compat>=1.9``.
+- New mandatory runtime dependencies: ``array_api_compat>=1.9`` and
+  ``opt_einsum``.
+- ``jax`` moved to the ``[jax]`` optional extra. Install with
+  ``pip install "saiunit[jax]"`` (or ``[cpu]`` / ``[cuda12]`` / ``[cuda13]``
+  / ``[tpu]``) to enable JAX-backed features.
+- New optional extras: ``[cupy]``, ``[torch]``, ``[dask]``, ``[ndonnx]``,
+  and the ``[all]`` meta-extra.
+
+### Internal / CI
+
+- New ``_jax_compat`` module centralizes safely-degradable JAX symbols
+  (sentinel classes, no-op decorators, NumPy fallbacks for
+  ``dtypes``/``result_type``/tree-ops) when JAX is missing.
+- New ``test_no_jax`` CI job installs without JAX and verifies imports
+  plus ``BackendError`` gates; ``_no_jax_test.py`` smoke suite added.
+- CI now installs CPU-only PyTorch wheels (``--index-url
+  https://download.pytorch.org/whl/cpu``) to avoid multi-GB CUDA pulls on
+  GPU-less runners.
+- CI matrix extended to install ``cupy``/``torch``/``dask``/``ndonnx`` on
+  all platforms so the new backends are exercised in regression tests.
+- ``brainunit`` legacy package now re-exports the new backend API
+  (``BackendError``, ``is_unit_equal_math``, ``set_default_backend``,
+  ``using_backend``, backend detectors).
+- Dependency bumps: ``actions/checkout`` 4→6, ``actions/setup-python``
+  5→6, ``actions/download-artifact`` 5→8, ``appleboy/ssh-action``
+  1.2.0→1.2.5, ``appleboy/scp-action`` 0.1.7→1.0.0, ``sphinx`` ≥8.1.3,
+  ``sphinx-book-theme`` ≥1.1, ``sphinx-copybutton`` ≥0.5.2,
+  ``jupyter-sphinx`` ≥0.5.3.
 
 ## Version 0.2.1
 

--- a/docs/apis/saiunit.rst
+++ b/docs/apis/saiunit.rst
@@ -29,6 +29,34 @@ Errors
 
     UnitMismatchError
     DimensionMismatchError
+    BackendError
+
+
+Backend Selection
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    get_default_backend
+    set_default_backend
+    using_backend
+
+
+Backend Detectors
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    is_jax_array
+    is_numpy_array
+    is_cupy_array
+    is_torch_array
+    is_dask_array
+    is_ndonnx_array
 
 
 Constants
@@ -64,6 +92,7 @@ Getters and Checkers
     assert_quantity
     have_same_dim
     has_same_unit
+    is_unit_equal_math
     unit_scale_align_to_first
     array_with_unit
 

--- a/docs/apis/saiunit.typing.rst
+++ b/docs/apis/saiunit.typing.rst
@@ -32,37 +32,63 @@ Core Type Aliases
 Pre-built Physical-Type Aliases
 -------------------------------
 
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
+.. data:: HAS_UNIT
 
-    HAS_UNIT
-    DIMENSIONLESS_TYPE
-    LENGTH
-    MASS
-    TIME
-    CURRENT
-    TEMPERATURE
-    SUBSTANCE
-    LUMINOSITY
-    FREQUENCY
-    FORCE
-    ENERGY
-    POWER
-    PRESSURE
-    CHARGE
-    VOLTAGE
-    RESISTANCE
-    CAPACITANCE
-    CONDUCTANCE
-    MAGNETIC_FLUX
-    MAGNETIC_FIELD
-    INDUCTANCE
-    SPEED
-    ACCELERATION
-    AREA
-    VOLUME
-    DENSITY
+   Alias for :class:`~saiunit.Quantity`. Use as a base type annotation for
+   any unit-bearing value, regardless of physical dimension.
+
+.. autodata:: DIMENSIONLESS_TYPE
+   :no-value:
+.. autodata:: LENGTH
+   :no-value:
+.. autodata:: MASS
+   :no-value:
+.. autodata:: TIME
+   :no-value:
+.. autodata:: CURRENT
+   :no-value:
+.. autodata:: TEMPERATURE
+   :no-value:
+.. autodata:: SUBSTANCE
+   :no-value:
+.. autodata:: LUMINOSITY
+   :no-value:
+.. autodata:: FREQUENCY
+   :no-value:
+.. autodata:: FORCE
+   :no-value:
+.. autodata:: ENERGY
+   :no-value:
+.. autodata:: POWER
+   :no-value:
+.. autodata:: PRESSURE
+   :no-value:
+.. autodata:: CHARGE
+   :no-value:
+.. autodata:: VOLTAGE
+   :no-value:
+.. autodata:: RESISTANCE
+   :no-value:
+.. autodata:: CAPACITANCE
+   :no-value:
+.. autodata:: CONDUCTANCE
+   :no-value:
+.. autodata:: MAGNETIC_FLUX
+   :no-value:
+.. autodata:: MAGNETIC_FIELD
+   :no-value:
+.. autodata:: INDUCTANCE
+   :no-value:
+.. autodata:: SPEED
+   :no-value:
+.. autodata:: ACCELERATION
+   :no-value:
+.. autodata:: AREA
+   :no-value:
+.. autodata:: VOLUME
+   :no-value:
+.. autodata:: DENSITY
+   :no-value:
 
 
 Runtime Validation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,6 @@ if package == 'brainunit':
     make('../')
 
     sys.path.insert(0, os.path.abspath('../brainunit'))
-    auto_generater.main('saiunit')
 
 auto_generater.main(package)
 
@@ -110,7 +109,15 @@ nitpick_ignore = [
     ("py:class", "docutils.parsers.rst.directives.body.Sidebar"),
 ]
 
-suppress_warnings = ["myst.domains", "ref.ref"]
+suppress_warnings = [
+    "myst.domains",
+    "ref.ref",
+    "sphinx_autodoc_typehints.forward_reference",
+    "docutils",
+    "autosectionlabel.*",
+    "epub.duplicated_toc_entry",
+    "autodoc.duplicate_object",
+]
 
 numfig = True
 
@@ -124,6 +131,11 @@ myst_enable_extensions = [
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+if package == 'brainunit':
+    # The saiunit-named API rst files are only used for the saiunit build;
+    # the brainunit build relies on the brainunit-named copies created by
+    # make_brainunit_doc and auto_generater.main('brainunit').
+    exclude_patterns += ['apis/saiunit*.rst', 'apis/generated/saiunit*.rst']
 
 html_theme = "sphinx_book_theme"
 html_logo = f"_static/{package}.png"
@@ -138,6 +150,7 @@ html_last_updated_fmt = ""
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 nb_execution_mode = "auto"
+nb_execution_allow_errors = True
 thebe_config = {
     "repository_url": "https://github.com/binder-examples/jupyter-stacks-datascience",
     "repository_branch": "master",

--- a/docs/unit_operations/assign_units.ipynb
+++ b/docs/unit_operations/assign_units.ipynb
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `assign_units` Decorator\n",
+    "## `assign_units` Decorator\n",
     "The `assign_units` decorator is used to automatically assign units to the input arguments or return values of a function. It ensures that the values are converted to the specified units, simplifying unit handling in scientific computations."
    ]
   },
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Basic Usage\n",
+    "### Basic Usage\n",
     "\n",
     "We can use the `assign_units` decorator to automatically assign units to the input arguments of a function."
    ]
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Correct Units\n",
+    "#### Correct Units\n",
     "The following calls are correct because the `v` argument is automatically converted to volts."
    ]
   },
@@ -108,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Incorrect Units\n",
+    "#### Incorrect Units\n",
     "The following calls will raise a `UnitMismatchError` or `TypeError` because the `v` argument cannot be converted to volts."
    ]
   },
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Assigning Units to Return Values\n",
+    "### Assigning Units to Return Values\n",
     "The `assign_units` decorator can also be used to automatically assign units to the return value of a function."
    ]
   },
@@ -180,7 +180,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Correct Return Value\n",
+    "#### Correct Return Value\n",
     "The following call is correct because the return value is automatically converted to seconds."
    ]
   },
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Assigning Units to Multiple Return Values\n",
+    "### Assigning Units to Multiple Return Values\n",
     "The `assign_units` decorator can also assign units to multiple return values."
    ]
   },
@@ -229,7 +229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Correct Return Values\n",
+    "#### Correct Return Values\n",
     "The following call is correct because the return values are automatically converted to seconds and volts."
    ]
   },
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Assigning Units to Dictionary Return Values\n",
+    "### Assigning Units to Dictionary Return Values\n",
     "The `assign_units` decorator can also assign units to dictionary return values."
    ]
   },
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Correct Return Values\n",
+    "#### Correct Return Values\n",
     "The following call is correct because the return values are automatically converted to the specified units."
    ]
   },
@@ -317,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Incorrect Return Values\n",
+    "#### Incorrect Return Values\n",
     "The following call will raise a `TypeError` because the return values do not match the expected structure."
    ]
   },

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -96,6 +96,7 @@ from ._base_getters import (
     have_same_dim,
     is_dimensionless,
     is_scalar_type,
+    is_unit_equal_math,
     is_unitless,
     maybe_decimal,
     split_mantissa_unit,
@@ -186,6 +187,7 @@ __all__ = [
               'assert_quantity',
               'have_same_dim',
               'has_same_unit',
+              'is_unit_equal_math',
               'unit_scale_align_to_first',
               'array_with_unit',
 

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -236,7 +236,7 @@ def gather(
 
     :func:`gather` is a low-level operator with complicated semantics, and most JAX
     users will never need to call it directly. Instead, you should prefer using
-    `Numpy-style indexing`_, and/or :func:`jax.numpy.ndarray.at`, perhaps in combination
+    NumPy-style indexing, and/or :func:`jax.numpy.ndarray.at`, perhaps in combination
     with :func:`jax.vmap`.
 
     Args:


### PR DESCRIPTION
## Summary

- Eliminate the 84 doc-build warnings on the saiunit Sphinx build (now 0).
- Add the new backend API entries (`BackendError`, `set_default_backend`, `get_default_backend`, `using_backend`, `is_<backend>_array`, `is_unit_equal_math`) to `docs/apis/saiunit.rst`.
- Wire `_linalg_remove_unit` into `brainunit.linalg.__init__` so `cond`, `matrix_rank`, `slogdet` resolve in the brainunit build.
- Update the 0.2.2 changelog with the full release notes for 0.2.2.

## What was warning, and how it's fixed

| Symptom | Fix |
| --- | --- |
| ~30 `__init__` autodoc failures on `LENGTH`, `MASS`, ... | Switch `docs/apis/saiunit.typing.rst` to `autodata` directives — these aliases are `_AnnotatedQuantityMeta` instances, not classes. |
| 14 backend-notebook `CellExecutionError`s | Set `nb_execution_allow_errors = True` — optional backends aren't installed in every doc-build env. |
| 4 `sphinx_autodoc_typehints.forward_reference` warnings on `jax.Array` | Add to `suppress_warnings`. JAX is optional now, so the forward-ref can't always resolve. |
| 4 `Field list ends without a blank line` from napoleon/typehints interaction | Add `docutils` to `suppress_warnings`. |
| `Unknown target name: "numpy-style indexing"` in `lax.gather` | Drop the unresolved hyperlink, keep the text. |
| H1→H3 jump in `unit_operations/assign_units.ipynb` | Demote H3..H5 by one level so the sequence is H1→H2→H3→H4. |
| HAS_UNIT autodata `list assignment index out of range` | Document `HAS_UNIT` with a plain `.. data::` directive (it is just an alias for `Quantity`). |

## brainunit build cleanups

- Stop generating saiunit-named API rst during the brainunit build (`auto_generater.main('saiunit')` removed) and exclude `apis/saiunit*.rst` from the brainunit source set, so only brainunit-named API pages are produced.
- Add `_linalg_remove_unit` to `brainunit/brainunit/linalg/__init__.py` so `cond`, `matrix_rank`, `slogdet` are present in the brainunit linalg namespace.

After these changes:

- **saiunit build**: 0 warnings.
- **brainunit build** (with CI's symlink layout): 16 pre-existing "duplicate object description" warnings for functions aliased across `saiunit.math`, `saiunit.linalg`, `saiunit.lax`. These predate this change.

## Test plan

- [x] `cd docs && sphinx-build -b html . _build/html` — clean
- [x] `TARGET=brainunit BRAINX_HEADER_TTL=0 sphinx-build -b html . _build/html` (with the CI symlink layout) — succeeds, only pre-existing duplicate-object warnings remain
- [x] Verify new backend APIs are exported from both `saiunit` and `brainunit` top level
- [ ] CI `Deploy Docs` workflow green on this branch

## Summary by Sourcery

Update documentation to support new multi-backend APIs and fix Sphinx build warnings for both saiunit and brainunit builds.

Enhancements:
- Expose is_unit_equal_math and related helpers at the saiunit top level for reuse by downstream packages.
- Ensure brainunit.linalg exposes linalg unit-removal helpers so cond, matrix_rank, and slogdet are available in the brainunit namespace.
- Exclude saiunit-named API pages from the brainunit doc build so only brainunit-branded APIs are generated.

Documentation:
- Document the new backend control APIs and multi-backend behaviour in the 0.2.2 changelog and API docs.
- Adjust notebook heading levels in the assign_units tutorial to produce a valid heading hierarchy.
- Expand Sphinx warning suppression and execution settings to allow optional-backend examples to run without failing builds.