### PR TITLE
feat: multi-backend Quantity.at and backend-compat fixes (v0.3.0)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,97 @@
 # Release Notes
 
+## Version 0.3.0
+
+### Highlights
+
+``Quantity.at`` now works on every supported backend. Previously, indexed
+functional updates (``x.at[idx].set(...)``, ``.add(...)``, etc.) required a
+JAX-backed mantissa and raised ``BackendError`` for NumPy and the other
+backends, forcing users to call ``.to_jax()`` first. As of this release the
+same expression works directly on ``numpy``, ``jax``, ``cupy``, ``torch``, and
+``dask`` arrays, with documented scope limits for ``dask`` and a clean
+``BackendError`` for ``ndonnx``.
+
+### New features
+
+- **Multi-backend ``Quantity.at``.** All nine ``.at[idx].<op>(...)``
+  operations — ``get``, ``set``, ``add``, ``multiply``/``mul``,
+  ``divide``/``div``, ``power``, ``min``, ``max``, ``apply`` — work across
+  every supported backend. The unit-tracking semantics are unchanged: the
+  same dimension/magnitude checks fire regardless of backend, and the result
+  preserves the original mantissa backend (a torch-backed Quantity stays
+  torch, a dask-backed Quantity stays dask).
+- **Unified scatter dispatch (``saiunit._scatter``).** ``Quantity.at`` and
+  ``Quantity.__setitem__`` / ``scatter_add`` / ``scatter_mul`` /
+  ``scatter_div`` / ``scatter_max`` / ``scatter_min`` now all route through
+  one backend-aware module. This fixes a latent bug where the old in-line
+  ``_scatter`` helper silently called ``jnp.asarray`` on cupy, torch, dask,
+  and ndonnx mantissas.
+- **Emulated ``mode`` and ``fill_value`` on non-JAX backends.** JAX's
+  ``mode`` (``'promise_in_bounds'``/``'clip'``/``'drop'``/``'fill'``) and
+  ``fill_value`` arguments are emulated on ``numpy``/``cupy``/``torch`` for
+  scalar-int and 1D-integer-array indices, so the same code that uses
+  ``x.at[20].get(mode='fill', fill_value=-1 * u.mV)`` on JAX now runs
+  unchanged on NumPy. For more complex index expressions (slices, boolean
+  masks, multi-axis tuples) the native backend semantics apply — these
+  indices don't have an out-of-bounds notion to honor.
+
+### Backend-specific notes
+
+- **NumPy / CuPy:** repeated-index updates use ``np.<op>.at`` /
+  ``cupy.<op>.at`` so the JAX "all-updates-applied" semantics carry over.
+- **PyTorch:** ``add`` uses ``index_put_(accumulate=True)`` and matches JAX
+  for repeated indices. ``multiply``/``divide``/``min``/``max``/``apply`` use
+  gather + op + scatter and follow last-write-wins semantics for repeated
+  indices (one of the rare places torch's native semantics differ from JAX).
+- **Dask:** updates are expressed via ``da.where`` over a positional boolean
+  mask, so the task graph stays lazy and chunked. Supported index types:
+  scalar int, 1D integer array, slice, ellipsis, and same-shape boolean
+  mask. Multi-dim fancy integer indexing raises ``NotImplementedError`` —
+  call ``.to_numpy()`` first for those cases.
+- **ndonnx:** raises ``BackendError`` on every ``.at[...].set/get/...``
+  call. ndonnx builds a symbolic ONNX graph; it can't represent a functional
+  in-place update cleanly. Call ``.to_numpy()`` to materialize first.
+
+### Known limitations
+
+- ``mode`` emulation is best-effort on non-JAX backends for scalar-int and
+  1D-integer-array indices only. Slice/boolean/ellipsis indices ignore
+  ``mode`` because they cannot go out of bounds against a same-shape source.
+- ``dask`` does not yet support multi-dim fancy integer indexing under
+  ``.at``; use ``.to_numpy()`` for those patterns.
+
+### Backend-compatibility fixes
+
+A focused sweep through the rest of the dispatcher closed several silent
+JAX-coercion paths and replaced raw ``AttributeError`` failure modes with
+``BackendError``:
+
+- ``CustomArray.__setitem__`` no longer assumes JAX-style ``.at[idx].set(...)``;
+  it routes through the unified ``saiunit._scatter`` dispatcher so subclasses
+  with numpy / cupy / torch / dask mantissas work without a JAX install.
+- ``Quantity(mantissa, dtype=...)`` now honors ``dtype`` for cupy / torch /
+  dask / ndonnx mantissas. Previously the dtype kwarg was silently ignored
+  for those backends.
+- ``Quantity.mantissa`` setter coerces the new value to the *existing*
+  backend of the Quantity rather than silently lifting torch / cupy / dask /
+  ndonnx arrays to JAX.
+- ``_check_units_and_collect_values`` (the helper behind
+  ``Quantity([q1, q2, ...])``) honors ``set_default_backend()`` /
+  ``using_backend()`` instead of always landing on JAX when JAX is installed.
+- ``Quantity.strides`` / ``.flat`` / ``.T`` / ``.mT`` raise ``BackendError``
+  on lazy mantissas (dask, ndonnx) instead of silently calling
+  ``.compute()`` / ``.unwrap_numpy()`` on them.
+- ``saiunit.fft.fftn`` / ``ifftn`` / ``rfftn`` / ``irfftn`` no longer force
+  Python-scalar / list inputs through ``jnp.asarray`` for the input-ndim
+  probe.
+- ``saiunit.math`` activation functions (``relu``, ``sigmoid``, ``softplus``,
+  ``gelu``, …) now guard with ``require_jax_backend`` and raise a clean
+  ``BackendError`` on non-JAX inputs, instead of crashing with
+  ``AttributeError: 'NoneType' object has no attribute 'relu'`` when JAX
+  isn't installed or when called on a torch / cupy / dask mantissa.
+  ``leaky_relu`` is implemented via ``where`` and remains backend-agnostic.
+
 ## Version 0.2.2
 
 ### Highlights

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -48,6 +48,7 @@ from ._base_getters import (
     unit_scale_align_to_first,
 )
 from ._base_unit import Unit, UNITLESS
+from ._exceptions import BackendError
 from ._misc import maybe_custom_array_tree
 from ._sparse_base import SparseMatrix
 
@@ -253,6 +254,13 @@ def _check_units_and_collect_values(lst) -> tuple[jax.typing.ArrayLike, Unit]:
             values.append(item)
             units.append(None)
 
+    # Respect the active default backend rather than always falling to
+    # ``jnp.asarray`` when JAX is installed — otherwise a user inside
+    # ``using_backend("torch")`` would still get a JAX array out of
+    # ``Quantity([1*mV, 2*mV])``.
+    from saiunit._backend import _xp_for, get_default_backend
+    _xp = _xp_for(get_default_backend() or ("jax" if HAS_JAX else "numpy"))
+
     if len(units):
         # Normalize None (plain scalars) to UNITLESS so they are
         # compatible with explicitly unitless Quantity values.
@@ -260,11 +268,9 @@ def _check_units_and_collect_values(lst) -> tuple[jax.typing.ArrayLike, Unit]:
         first_unit = units[0]
         if not all(first_unit.has_same_dim(unit) for unit in units):
             raise TypeError(f"All elements must have the same units, but got {units}")
-        _asarray = jnp.asarray if HAS_JAX else np.asarray
-        return _asarray(_zoom_values_with_units(values, units)), first_unit
+        return _xp.asarray(_zoom_values_with_units(values, units)), first_unit
     else:
-        _asarray = jnp.asarray if HAS_JAX else np.asarray
-        return _asarray(values), UNITLESS
+        return _xp.asarray(values), UNITLESS
 
 
 def _process_list_with_units(value: list) -> tuple[jax.typing.ArrayLike, Unit]:
@@ -329,45 +335,46 @@ def _quantity_with_unit(mantissa, unit):
 _quantity_with_unit.__module__ = 'saiunit._base_quantity'
 
 
+def _reject_lazy_materialization(m, attr_name: str) -> None:
+    """Raise :class:`BackendError` if accessing ``attr_name`` would force
+    materialisation of a lazy / symbolic mantissa.
+
+    Used by property fallbacks (``Quantity.strides``, ``.flat``, ``.T`` …)
+    that would otherwise silently call ``.compute()`` on a dask graph or
+    ``.unwrap_numpy()`` on an ndonnx symbolic array.
+    """
+    from saiunit._backend import is_dask_array, is_ndonnx_array
+    if is_dask_array(m):
+        raise BackendError(
+            f"{attr_name} requires materializing a lazy dask array. "
+            f"Call .compute() on the mantissa explicitly first."
+        )
+    if is_ndonnx_array(m):
+        raise BackendError(
+            f"{attr_name} is not supported for ndonnx symbolic arrays."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Scatter helper (backend-aware ``arr.at[idx].<op>(value)`` equivalent)
 # ---------------------------------------------------------------------------
 
+# Map legacy op names used by Quantity.__setitem__ / scatter_* to the
+# canonical names exported by saiunit._scatter.
+_LEGACY_SCATTER_OP_ALIASES = {"mul": "multiply"}
+
+
 def _scatter(mantissa, index, value, op: str):
     """Return a new array with ``op`` applied at ``index``.
 
-    Works for both NumPy and JAX backends.
-
-    Parameters
-    ----------
-    mantissa : array
-    index : index expression
-    value : scalar or array
-    op : {'set', 'add', 'mul', 'divide', 'max', 'min'}
+    Thin wrapper around :func:`saiunit._scatter.scatter` that translates the
+    legacy op names used internally (``"mul"``) into the canonical ones
+    (``"multiply"``). All supported backends (numpy, jax, cupy, torch, dask,
+    ndonnx) are routed through the unified dispatch.
     """
-    if is_numpy_array(mantissa):
-        out = mantissa.copy()
-        if op == "set":
-            out[index] = value
-        elif op == "add":
-            np.add.at(out, index, value)
-        elif op == "mul":
-            np.multiply.at(out, index, value)
-        elif op == "divide":
-            np.divide.at(out, index, value)
-        elif op == "max":
-            np.maximum.at(out, index, value)
-        elif op == "min":
-            np.minimum.at(out, index, value)
-        else:
-            raise ValueError(f"unknown scatter op: {op!r}")
-        return out
-    if not HAS_JAX:
-        from saiunit._jax_compat import require_jax
-        require_jax("functional in-place updates on non-NumPy mantissas")
-    arr = jnp.asarray(mantissa)
-    at = arr.at[index]
-    return getattr(at, op)(value)
+    from saiunit._scatter import scatter as _scatter_dispatch
+    canonical = _LEGACY_SCATTER_OP_ALIASES.get(op, op)
+    return _scatter_dispatch(mantissa, index, value, canonical)
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +621,23 @@ class Quantity:
                 pass  # keep as-is; jnp.array conversion deferred to use-site
 
             else:
-                pass  # keep as-is for other pytree types
+                # cupy / torch / dask / ndonnx mantissas: preserve the input's
+                # native backend, honouring ``dtype`` when requested.
+                from saiunit._backend import (
+                    get_backend as _gb,
+                    is_cupy_array, is_torch_array, is_dask_array,
+                    is_ndonnx_array,
+                )
+                if (
+                    is_cupy_array(mantissa)
+                    or is_torch_array(mantissa)
+                    or is_dask_array(mantissa)
+                    or is_ndonnx_array(mantissa)
+                ):
+                    if dtype is not None and getattr(mantissa, "dtype", None) != dtype:
+                        xp = _gb(mantissa)
+                        mantissa = xp.asarray(mantissa, dtype=dtype)
+                # else: keep as-is for arbitrary pytree leaves
 
         # mantissa
         self._mantissa = mantissa
@@ -650,14 +673,40 @@ class Quantity:
         a modified copy of ``x``. However, inside a :py:func:`~jax.jit` compiled function,
         expressions like :code:`x = x.at[idx].set(y)` are guaranteed to be applied in-place.
 
-        Unlike NumPy in-place operations such as :code:`x[idx] += y`, if multiple
-        indices refer to the same location, all updates will be applied (NumPy would
-        only apply the last update, rather than applying all updates.) The order
-        in which conflicting updates are applied is implementation-defined and may be
-        nondeterministic (e.g., due to concurrency on some hardware platforms).
+        ``Quantity.at`` is multi-backend: it works for ``numpy``, ``jax``, ``cupy``,
+        ``torch``, and ``dask`` mantissas. The ``ndonnx`` backend cannot represent
+        functional in-place updates in its symbolic graph and raises
+        :class:`saiunit.BackendError` — call ``.to_numpy()`` first. On ``dask`` the
+        update is expressed via ``da.where`` so the task graph stays lazy; only
+        slice / scalar-int / 1-D integer / boolean-mask indices are supported on
+        dask (multi-dim fancy-integer indexing raises ``NotImplementedError`` —
+        use ``.to_numpy()`` for that case).
 
-        By default, JAX assumes that all indices are in-bounds. Alternative out-of-bound
-        index semantics can be specified via the ``mode`` parameter (see below).
+        Repeated-index semantics differ across backends. When multiple indices
+        refer to the same location, JAX applies *all* updates (NumPy in-place
+        ``x[idx] += y`` would apply only the last). The summary:
+
+        ============  ========================  =========================
+        Backend       ``add``                   ``multiply / divide /
+                                                min / max / apply``
+        ============  ========================  =========================
+        ``jax``       accumulates               accumulates
+        ``numpy``     accumulates (np.add.at)   accumulates (np.<op>.at)
+        ``cupy``      accumulates               accumulates
+        ``torch``     accumulates               last-write-wins
+                      (index_put_(accumulate))
+        ``dask``      last-write-wins via mask  last-write-wins via mask
+        ``ndonnx``    raises BackendError       raises BackendError
+        ============  ========================  =========================
+
+        By default, JAX assumes that all indices are in-bounds. Alternative
+        out-of-bound semantics can be specified via the ``mode`` parameter
+        (see below). On non-JAX backends ``mode`` and ``fill_value`` are
+        emulated for scalar-int and 1-D integer-array indices; for slice /
+        boolean / ellipsis / tuple indices the kwarg is silently ignored
+        because out-of-bounds cannot occur for same-shape sources.
+        ``indices_are_sorted`` and ``unique_indices`` are hints only —
+        silently ignored outside JAX.
 
         Arguments
         ---------
@@ -796,7 +845,12 @@ class Quantity:
         elif isinstance(mantissa, _JaxArray):
             pass
         else:
-            mantissa = jnp.asarray(mantissa, dtype=self.dtype) if HAS_JAX else np.asarray(mantissa, dtype=self.dtype)
+            # Coerce ``mantissa`` to whatever backend ``self`` already lives on
+            # rather than silently lifting torch / cupy / dask / ndonnx mantissas
+            # to JAX.
+            from saiunit._backend import get_backend as _gb
+            xp = _gb(self_value)
+            mantissa = xp.asarray(mantissa, dtype=self.dtype)
         # check
         if mantissa.shape != self_value.shape:
             raise ValueError(f"The shape of the original data is {self_value.shape}, "
@@ -1117,14 +1171,21 @@ class Quantity:
             return repr(m)
         if isinstance(m, (_JaxArray, np.ndarray)):
             value = m
-        else:
+        elif isinstance(m, (numbers.Number, list, tuple)):
+            # Python scalars / sequences — promote so we get a printable array.
+            # Prefer ``jnp.asarray`` when JAX is installed so the precision
+            # matches JAX's x32 default (test fixtures key off this); fall
+            # back to NumPy when JAX is unavailable.
             try:
-                # jnp default dtype mirrors JAX's x32 mode so scalar
-                # representations match the historical behavior. Fall back
-                # to NumPy when JAX isn't installed.
                 value = jnp.asarray(m) if HAS_JAX else np.asarray(m)
             except TypeError:
                 value = m
+        else:
+            # cupy / torch / dask / ndonnx arrays: don't lift to JAX (that
+            # would silently move the data between backends). Let the outer
+            # try/except at the bottom of this function fall back to
+            # ``str(value)`` if numpy printing can't handle it.
+            value = m
 
         if _is_tracer(value):
             return str(value)
@@ -1377,31 +1438,53 @@ class Quantity:
     def nbytes(self) -> int:
         """Total bytes consumed by the mantissa array."""
         m = self._mantissa
-        return m.nbytes if hasattr(m, "nbytes") else np.asarray(m).nbytes
+        if hasattr(m, "nbytes"):
+            return m.nbytes
+        _reject_lazy_materialization(m, "Quantity.nbytes")
+        return np.asarray(m).nbytes
 
     @property
     def itemsize(self) -> int:
         """Length (in bytes) of one array element."""
         m = self._mantissa
-        return m.itemsize if hasattr(m, "itemsize") else np.asarray(m).itemsize
+        if hasattr(m, "itemsize"):
+            return m.itemsize
+        _reject_lazy_materialization(m, "Quantity.itemsize")
+        return np.asarray(m).itemsize
 
     @property
     def strides(self):
         """Tuple of byte-steps in each dimension (mirrors numpy.ndarray.strides)."""
-        return np.asarray(self.mantissa).strides
+        m = self._mantissa
+        if hasattr(m, "strides"):
+            # numpy / cupy expose ``.strides`` natively; for torch this is a
+            # method, so we still fall through to the materialise path.
+            strides = m.strides
+            if not callable(strides):
+                return strides
+        _reject_lazy_materialization(m, "Quantity.strides")
+        return np.asarray(m).strides
 
     @property
     def flat(self):
         """1-D iterator over the mantissa elements, unit preserved."""
         m = self._mantissa
-        flat = m.flat if hasattr(m, "flat") else np.asarray(m).flat
+        if hasattr(m, "flat"):
+            flat = m.flat
+        else:
+            _reject_lazy_materialization(m, "Quantity.flat")
+            flat = np.asarray(m).flat
         for v in flat:
             yield Quantity(v, unit=self.unit)
 
     @property
     def T(self) -> 'Quantity':
         m = self._mantissa
-        t = m.T if hasattr(m, "T") else np.asarray(m).T
+        if hasattr(m, "T"):
+            t = m.T
+        else:
+            _reject_lazy_materialization(m, "Quantity.T")
+            t = np.asarray(m).T
         return Quantity(t, unit=self.unit)
 
     @property
@@ -1427,7 +1510,11 @@ class Quantity:
             (2, 2)
         """
         m = self._mantissa
-        mt = m.mT if hasattr(m, "mT") else np.asarray(m).mT
+        if hasattr(m, "mT"):
+            mt = m.mT
+        else:
+            _reject_lazy_materialization(m, "Quantity.mT")
+            mt = np.asarray(m).mT
         return Quantity(mt, unit=self.unit)
 
     @property
@@ -3618,36 +3705,46 @@ class _IndexUpdateRef:
     """
     Helper object to call indexed update functions for an (advanced) index.
 
-    This object references a source array and a specific indexer into that array.
-    Methods on this object return copies of the source array that have been
-    modified at the positions specified by the indexer.
+    This object references a source array and a specific indexer into that
+    array. Methods on this object return copies of the source array that have
+    been modified at the positions specified by the indexer. Updates are
+    dispatched through :func:`saiunit._scatter.scatter`, which supports every
+    backend saiunit ships with: ``numpy``, ``jax``, ``cupy``, ``torch``,
+    ``dask``, and ``ndonnx`` (ndonnx raises a :class:`BackendError` because
+    its symbolic graph cannot represent in-place updates — call
+    ``.to_numpy()`` first).
     """
-    __slots__ = ("quantity", "index", "mantissa_at", "unit")
+    __slots__ = ("quantity", "index", "unit")
 
     def __init__(self, index, quantity: Quantity):
         self.index = _jtree.map(_element_not_quantity, index, is_leaf=lambda x: isinstance(x, Quantity))
         self.quantity = quantity
-        # ``.at`` indexed-update is JAX-only. For numpy-backed Quantity the user
-        # must call .to_jax() first; this matches the behavior documented for
-        # the lax/autograd/sparse modules.
-        from saiunit._exceptions import BackendError
-        if is_numpy_array(quantity.mantissa):
-            raise BackendError(
-                "Quantity.at indexed-update requires the jax backend; got "
-                "numpy-backed Quantity. Call .to_jax() on the input first."
-            )
-        self.mantissa_at = jnp.asarray(quantity.mantissa).at
         self.unit = quantity.unit
 
     def __repr__(self) -> str:
         return f"_IndexUpdateRef({self.quantity}, {self.index!r})"
+
+    def _scatter(self, op: str, value, *, indices_are_sorted, unique_indices,
+                 mode, fill_value=None):
+        """Internal: dispatch ``op`` on the underlying mantissa."""
+        from saiunit._scatter import scatter as _scatter_dispatch
+        return _scatter_dispatch(
+            self.quantity.mantissa,
+            self.index,
+            value,
+            op,
+            indices_are_sorted=indices_are_sorted,
+            unique_indices=unique_indices,
+            mode=mode,
+            fill_value=fill_value,
+        )
 
     def get(
         self,
         indices_are_sorted: bool = False,
         unique_indices: bool = False,
         mode: str | None = None,
-        fill_value: StaticScalar | None = None
+        fill_value: StaticScalar | Quantity | None = None
     ) -> Quantity:
         """Equivalent to ``x[idx]``.
 
@@ -3659,13 +3756,15 @@ class _IndexUpdateRef:
         if fill_value is not None:
             fill_value = Quantity(fill_value).in_unit(self.unit).mantissa
         return Quantity(
-            self.mantissa_at[self.index].get(
+            self._scatter(
+                "get",
+                None,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
                 mode=mode,
-                fill_value=fill_value
+                fill_value=fill_value,
             ),
-            unit=self.unit
+            unit=self.unit,
         )
 
     def set(
@@ -3682,13 +3781,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values).in_unit(self.unit).mantissa
         return Quantity(
-            self.mantissa_at[self.index].set(
-                values,
+            self._scatter(
+                "set", values,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
                 mode=mode,
             ),
-            unit=self.unit
+            unit=self.unit,
         )
 
     def add(
@@ -3706,13 +3805,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values).in_unit(self.unit).mantissa
         return Quantity(
-            self.mantissa_at[self.index].add(
-                values,
+            self._scatter(
+                "add", values,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit
+            unit=self.unit,
         )
 
     def multiply(
@@ -3730,13 +3829,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values)
         return Quantity(
-            self.mantissa_at[self.index].multiply(
-                values.mantissa,
+            self._scatter(
+                "multiply", values.mantissa,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit * values.unit
+            unit=self.unit * values.unit,
         )
 
     mul = multiply
@@ -3756,13 +3855,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values)
         return Quantity(
-            self.mantissa_at[self.index].divide(
-                values.mantissa,
+            self._scatter(
+                "divide", values.mantissa,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit / values.unit
+            unit=self.unit / values.unit,
         )
 
     div = divide
@@ -3783,13 +3882,13 @@ class _IndexUpdateRef:
         if not isinstance(values, int):
             raise TypeError(f"values must be an integer, but got {values}")
         return Quantity(
-            self.mantissa_at[self.index].power(
-                values,
+            self._scatter(
+                "power", values,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit ** values
+            unit=self.unit ** values,
         )
 
     def min(
@@ -3808,13 +3907,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values).in_unit(self.unit).mantissa
         return Quantity(
-            self.mantissa_at[self.index].min(
-                values,
+            self._scatter(
+                "min", values,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit
+            unit=self.unit,
         )
 
     def max(
@@ -3833,13 +3932,13 @@ class _IndexUpdateRef:
         """
         values = Quantity(values).in_unit(self.unit).mantissa
         return Quantity(
-            self.mantissa_at[self.index].max(
-                values,
+            self._scatter(
+                "max", values,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=self.unit
+            unit=self.unit,
         )
 
     def apply(
@@ -3871,13 +3970,13 @@ class _IndexUpdateRef:
         """
         result_unit = unit_fun(self.unit) if unit_fun is not None else self.unit
         return Quantity(
-            self.mantissa_at[self.index].apply(
-                mantissa_fun,
+            self._scatter(
+                "apply", mantissa_fun,
                 indices_are_sorted=indices_are_sorted,
                 unique_indices=unique_indices,
-                mode=mode
+                mode=mode,
             ),
-            unit=result_unit
+            unit=result_unit,
         )
 
 

--- a/saiunit/_scatter.py
+++ b/saiunit/_scatter.py
@@ -1,0 +1,755 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Multi-backend functional scatter dispatch.
+
+This module powers ``Quantity.at[...].set(...)`` (and the other index-update
+ops) on every supported backend: numpy, jax, cupy, torch, dask, and ndonnx.
+
+The public surface is a single function, :func:`scatter`. It takes a backend
+mantissa array, an index expression, a value (or callable for ``"apply"``),
+and an operation name. It returns a new array with the update applied,
+matching JAX's functional-update semantics as closely as the backend permits.
+
+Backend support matrix
+----------------------
+
+================  =======  =====  =====  =====  ============  =====
+Op                jax      numpy  cupy   torch  dask          ndonnx
+================  =======  =====  =====  =====  ============  =====
+get               native   ok     ok     ok     ok            err
+set               native   ok     ok     ok     mask/slice    err
+add               native   ok     ok     ok     mask/slice    err
+multiply          native   ok     ok     ok*    mask/slice    err
+divide            native   ok     ok     ok*    mask/slice    err
+power             native   ok     ok     ok*    mask/slice    err
+min               native   ok     ok     ok*    mask/slice    err
+max               native   ok     ok     ok*    mask/slice    err
+apply             native   ok     ok     ok*    mask/slice    err
+================  =======  =====  =====  =====  ============  =====
+
+*torch does not natively scatter-multiply/divide/min/max with repeated-index
+accumulation; this dispatch uses gather + op + scatter so repeated indices on
+torch follow last-write-wins semantics rather than JAX's all-updates-applied.
+For ``add`` torch uses ``index_put_(accumulate=True)`` and matches JAX.
+
+The four JAX-only kwargs are handled as follows on non-JAX backends:
+
+* ``mode='clip'``: emulated for scalar-int and 1D integer-array indices.
+* ``mode='drop'``/``'fill'`` / default ``'promise_in_bounds'``: emulated for
+  the same index shapes; out-of-bounds updates are dropped (or, for ``get``,
+  filled with ``fill_value``).
+* ``indices_are_sorted`` / ``unique_indices``: silently ignored.
+
+For other index types (slice, boolean mask, ellipsis, tuples mixing these),
+``mode`` falls back to the backend's native behavior — usually a no-op since
+slices and boolean masks of the source shape can't go out of bounds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from saiunit._backend import (
+    is_cupy_array,
+    is_dask_array,
+    is_jax_array,
+    is_ndonnx_array,
+    is_numpy_array,
+    is_torch_array,
+)
+from saiunit._exceptions import BackendError
+from saiunit._jax_compat import HAS_JAX
+
+__all__ = ["scatter"]
+
+_VALID_OPS = frozenset(
+    {"get", "set", "add", "multiply", "divide", "power", "min", "max", "apply"}
+)
+# Ops on which 'value' is the function to apply, not data to scatter.
+_FUNCTIONAL_OPS = frozenset({"apply"})
+
+
+def scatter(
+    mantissa,
+    index,
+    value,
+    op: str,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | None = None,
+    fill_value: Any = None,
+):
+    """Return a new array with ``op`` applied at ``index``.
+
+    Parameters
+    ----------
+    mantissa : array
+        Backend-native source array (numpy, jax, cupy, torch, dask, or ndonnx).
+    index : int, slice, ellipsis, tuple, array
+        Index expression to scatter at.
+    value : array_like or callable
+        For ``op='apply'``, a callable taking ``mantissa[index]`` and returning
+        a new value. For ``op='power'``, an integer exponent. Otherwise the
+        value(s) to scatter. ``op='get'`` ignores this argument.
+    op : str
+        One of ``'get'``, ``'set'``, ``'add'``, ``'multiply'``, ``'divide'``,
+        ``'power'``, ``'min'``, ``'max'``, ``'apply'``.
+    indices_are_sorted, unique_indices : bool
+        Hints. Honored on JAX; ignored elsewhere.
+    mode : {'promise_in_bounds', 'clip', 'drop', 'fill'} or None
+        Out-of-bounds behavior. Emulated on non-JAX backends for scalar-int and
+        1D-integer-array indices; falls back to native semantics for other
+        index types.
+    fill_value : scalar, optional
+        For ``op='get'`` with ``mode='fill'``, the value returned at
+        out-of-bounds positions.
+    """
+    if op not in _VALID_OPS:
+        raise ValueError(
+            f"unknown scatter op: {op!r}; must be one of {sorted(_VALID_OPS)}"
+        )
+
+    if is_jax_array(mantissa):
+        return _scatter_jax(
+            mantissa, index, value, op,
+            indices_are_sorted=indices_are_sorted,
+            unique_indices=unique_indices,
+            mode=mode,
+            fill_value=fill_value,
+        )
+    if is_numpy_array(mantissa):
+        return _scatter_numpy(mantissa, index, value, op, mode=mode, fill_value=fill_value)
+    if is_cupy_array(mantissa):
+        return _scatter_cupy(mantissa, index, value, op, mode=mode, fill_value=fill_value)
+    if is_torch_array(mantissa):
+        return _scatter_torch(mantissa, index, value, op, mode=mode, fill_value=fill_value)
+    if is_dask_array(mantissa):
+        return _scatter_dask(mantissa, index, value, op, mode=mode, fill_value=fill_value)
+    if is_ndonnx_array(mantissa):
+        raise BackendError(
+            "Quantity.at indexed-update is not supported on the ndonnx backend. "
+            "Call .to_numpy() (or another concrete backend) on the input first."
+        )
+
+    # Bare Python scalar / list / tuple: promote to the default backend and retry.
+    from saiunit._backend import _xp_for, get_default_backend
+    default = get_default_backend() or ("jax" if HAS_JAX else "numpy")
+    xp = _xp_for(default)
+    promoted = xp.asarray(mantissa)
+    return scatter(
+        promoted, index, value, op,
+        indices_are_sorted=indices_are_sorted,
+        unique_indices=unique_indices,
+        mode=mode,
+        fill_value=fill_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JAX — pass through to .at[index].<op>(...)
+# ---------------------------------------------------------------------------
+
+def _scatter_jax(
+    mantissa,
+    index,
+    value,
+    op: str,
+    *,
+    indices_are_sorted: bool,
+    unique_indices: bool,
+    mode: str | None,
+    fill_value: Any,
+):
+    at = mantissa.at[index]
+    common_kw = dict(
+        indices_are_sorted=indices_are_sorted,
+        unique_indices=unique_indices,
+        mode=mode,
+    )
+    if op == "get":
+        return at.get(fill_value=fill_value, **common_kw)
+    if op == "apply":
+        return at.apply(value, **common_kw)
+    if op == "power":
+        return at.power(value, **common_kw)
+    # set / add / multiply / divide / min / max
+    return getattr(at, op)(value, **common_kw)
+
+
+# ---------------------------------------------------------------------------
+# Simple-index normalization (shared by numpy/cupy/torch emulation paths)
+# ---------------------------------------------------------------------------
+
+def _is_simple_int_index(index) -> bool:
+    """Return True iff ``index`` is a scalar int or a 1D integer ndarray.
+
+    These are the cases for which we can cheaply emulate JAX's ``mode``
+    semantics. Anything else (slices, boolean masks, tuples, ellipsis) falls
+    through to the backend's native behavior.
+    """
+    if isinstance(index, (int, np.integer)):
+        return True
+    if isinstance(index, np.ndarray) and index.ndim == 1 and index.dtype.kind in ("i", "u"):
+        return True
+    return False
+
+
+def _normalize_simple_int(index, n: int, mode: str | None):
+    """Map a scalar-int or 1D-int index to ``(safe_index, valid_mask)``.
+
+    ``safe_index`` is always in ``[0, n)`` so the caller can index without
+    raising. ``valid_mask`` mirrors ``index`` and tells which positions were
+    originally in bounds; ``None`` means "all valid" (e.g., ``mode='clip'``
+    has no notion of validity — it just clips).
+    """
+    if isinstance(index, (int, np.integer)):
+        idx = int(index)
+        in_bounds = -n <= idx < n
+        norm = idx % n if in_bounds else 0
+        if mode == "clip":
+            # Clip — clamp negative-OOB to 0 and positive-OOB to n-1.
+            norm = max(0, min(n - 1, idx if idx >= 0 else idx + n))
+            return norm, None
+        return norm, np.bool_(in_bounds)
+    # 1D int array
+    arr = np.asarray(index)
+    if mode == "clip":
+        safe = np.where(arr < 0, np.maximum(0, arr + n), np.minimum(n - 1, arr))
+        return safe, None
+    valid = (arr >= -n) & (arr < n)
+    safe = np.where(valid, arr % n, 0)
+    return safe, valid
+
+
+# ---------------------------------------------------------------------------
+# NumPy
+# ---------------------------------------------------------------------------
+
+_NUMPY_UFUNC_AT = {
+    "add": "add",
+    "multiply": "multiply",
+    "divide": "true_divide",
+    "min": "minimum",
+    "max": "maximum",
+}
+
+
+def _scatter_numpy(mantissa, index, value, op: str, *, mode, fill_value):
+    return _scatter_npy_like(np, mantissa, index, value, op, mode=mode, fill_value=fill_value)
+
+
+def _scatter_cupy(mantissa, index, value, op: str, *, mode, fill_value):
+    import cupy as cp  # type: ignore
+    return _scatter_npy_like(cp, mantissa, index, value, op, mode=mode, fill_value=fill_value)
+
+
+def _scatter_npy_like(xp, mantissa, index, value, op: str, *, mode, fill_value):
+    """Shared numpy/cupy scatter. ``xp`` is the numpy-API module."""
+    if op == "get":
+        return _scatter_npy_get(xp, mantissa, index, mode=mode, fill_value=fill_value)
+
+    # apply takes a callable in `value`
+    if op == "apply":
+        out = mantissa.copy()
+        if not _is_simple_int_index(index) or mode == "clip":
+            # native indexing; mode='clip' falls through to natural semantics
+            out[index] = value(out[index])
+            return out
+        safe, valid = _normalize_simple_int(index, mantissa.shape[0], mode)
+        if valid is None or (isinstance(valid, np.bool_) and bool(valid)):
+            out[safe] = value(out[safe])
+        elif isinstance(valid, np.bool_):
+            # scalar idx, OOB: drop
+            pass
+        else:
+            # 1D mask: only apply where valid
+            sub_safe = safe[valid]
+            out[sub_safe] = value(out[sub_safe])
+        return out
+
+    # power: gather + pow + scatter (np.power.at doesn't exist)
+    if op == "power":
+        if not isinstance(value, (int, np.integer)):
+            raise TypeError(f"power exponent must be an integer, but got {type(value).__name__}")
+        out = mantissa.copy()
+        if not _is_simple_int_index(index) or mode == "clip":
+            out[index] = out[index] ** value
+            return out
+        safe, valid = _normalize_simple_int(index, mantissa.shape[0], mode)
+        if valid is None or (isinstance(valid, np.bool_) and bool(valid)):
+            out[safe] = out[safe] ** value
+        elif isinstance(valid, np.bool_):
+            pass
+        else:
+            sub_safe = safe[valid]
+            out[sub_safe] = out[sub_safe] ** value
+        return out
+
+    out = mantissa.copy()
+
+    # `set` — for simple int idx with mode emulation, drop OOB; for everything
+    # else, native assignment.
+    if op == "set":
+        if not _is_simple_int_index(index) or mode == "clip":
+            if mode == "clip" and _is_simple_int_index(index):
+                safe, _ = _normalize_simple_int(index, mantissa.shape[0], "clip")
+                out[safe] = value
+            else:
+                out[index] = value
+            return out
+        safe, valid = _normalize_simple_int(index, mantissa.shape[0], mode)
+        if valid is None or (isinstance(valid, np.bool_) and bool(valid)):
+            out[safe] = value
+        elif isinstance(valid, np.bool_):
+            pass  # scalar OOB → drop
+        else:
+            # 1D mask: write only where valid
+            sub_safe = safe[valid]
+            sub_value = _take_masked(value, valid, xp)
+            out[sub_safe] = sub_value
+        return out
+
+    # add / multiply / divide / min / max — use ufunc.at on the backend
+    ufunc_name = _NUMPY_UFUNC_AT[op]
+    ufunc = getattr(xp, ufunc_name)
+    if not _is_simple_int_index(index) or mode == "clip":
+        if mode == "clip" and _is_simple_int_index(index):
+            safe, _ = _normalize_simple_int(index, mantissa.shape[0], "clip")
+            ufunc.at(out, safe, value)
+        else:
+            ufunc.at(out, index, value)
+        return out
+    safe, valid = _normalize_simple_int(index, mantissa.shape[0], mode)
+    if valid is None or (isinstance(valid, np.bool_) and bool(valid)):
+        ufunc.at(out, safe, value)
+    elif isinstance(valid, np.bool_):
+        pass
+    else:
+        sub_safe = safe[valid]
+        sub_value = _take_masked(value, valid, xp)
+        ufunc.at(out, sub_safe, sub_value)
+    return out
+
+
+def _take_masked(value, valid, xp):
+    """Subset ``value`` by ``valid`` if it's a 1D array of matching length."""
+    if isinstance(value, (int, float, complex, np.number)):
+        return value
+    arr = xp.asarray(value)
+    if arr.ndim == 0:
+        return arr
+    if arr.ndim == 1 and arr.shape[0] == valid.shape[0]:
+        return arr[valid]
+    # broadcast cases (e.g. value is scalar-like 0-D); return as-is
+    return arr
+
+
+def _scatter_npy_get(xp, mantissa, index, *, mode, fill_value):
+    """Get with optional mode emulation. Mirrors JAX's ``.at[idx].get()``."""
+    n = mantissa.shape[0] if mantissa.ndim else 0
+    if not _is_simple_int_index(index):
+        # Native indexing; mode is best-effort no-op for complex index types
+        return mantissa[index]
+    if mode in (None, "promise_in_bounds", "clip"):
+        # JAX clips OOB on get for both default and 'clip'
+        safe, _ = _normalize_simple_int(index, n, "clip")
+        return mantissa[safe]
+    if mode in ("drop", "fill"):
+        if isinstance(index, (int, np.integer)):
+            idx = int(index)
+            in_bounds = -n <= idx < n
+            if in_bounds:
+                return mantissa[idx % n]
+            fill = _resolve_fill_value(fill_value, mantissa.dtype, xp)
+            return xp.asarray(fill, dtype=mantissa.dtype) if hasattr(xp, "asarray") else fill
+        # 1D int array
+        arr = np.asarray(index)
+        valid = (arr >= -n) & (arr < n)
+        safe = np.where(valid, arr % n, 0)
+        result = mantissa[safe]
+        fill = _resolve_fill_value(fill_value, mantissa.dtype, xp)
+        return xp.where(xp.asarray(valid), result, xp.asarray(fill, dtype=mantissa.dtype))
+    # Unknown mode — fall through
+    return mantissa[index]
+
+
+def _resolve_fill_value(fill_value, dtype, xp):
+    """Resolve JAX's documented default fill value when one is not supplied."""
+    if fill_value is not None:
+        return fill_value
+    dt = np.dtype(dtype)
+    if dt.kind == "f" or dt.kind == "c":
+        return np.nan
+    if dt.kind == "i":
+        return np.iinfo(dt).min
+    if dt.kind == "u":
+        return np.iinfo(dt).max
+    if dt.kind == "b":
+        return True
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# PyTorch
+# ---------------------------------------------------------------------------
+
+def _scatter_torch(mantissa, index, value, op: str, *, mode, fill_value):
+    import torch  # type: ignore
+
+    if op == "get":
+        return _scatter_torch_get(mantissa, index, mode=mode, fill_value=fill_value)
+
+    # Normalize index: convert numpy/jax arrays of integers to torch tensors
+    t_index = _torch_normalize_index(index, mantissa, mode, op)
+
+    if op == "apply":
+        out = mantissa.clone()
+        out[t_index] = value(out[t_index])
+        return out
+
+    if op == "power":
+        if not isinstance(value, (int, np.integer)):
+            raise TypeError(f"power exponent must be an integer, but got {type(value).__name__}")
+        out = mantissa.clone()
+        out[t_index] = out[t_index] ** value
+        return out
+
+    out = mantissa.clone()
+
+    # `add` with repeated-index accumulation: use index_put_ + accumulate=True
+    # when the index is expressible as a tuple of integer tensors.
+    if op == "add":
+        idx_tuple = _torch_index_to_tuple(t_index, out.shape)
+        if idx_tuple is not None:
+            v = _torch_value_as_tensor(value, out, expected_shape=None)
+            out.index_put_(idx_tuple, v, accumulate=True)
+            return out
+        # Fallback: native assignment (no accumulation for repeated idx)
+        cur = out[t_index]
+        v = _torch_value_as_tensor(value, out, expected_shape=cur.shape)
+        out[t_index] = cur + v
+        return out
+
+    if op == "set":
+        v = _torch_value_as_tensor(value, out, expected_shape=None)
+        out[t_index] = v
+        return out
+
+    if op == "multiply":
+        cur = out[t_index]
+        v = _torch_value_as_tensor(value, out, expected_shape=cur.shape)
+        out[t_index] = cur * v
+        return out
+
+    if op == "divide":
+        cur = out[t_index]
+        v = _torch_value_as_tensor(value, out, expected_shape=cur.shape)
+        out[t_index] = cur / v
+        return out
+
+    if op == "min":
+        cur = out[t_index]
+        v = _torch_value_as_tensor(value, out, expected_shape=cur.shape)
+        out[t_index] = torch.minimum(cur, v)
+        return out
+
+    if op == "max":
+        cur = out[t_index]
+        v = _torch_value_as_tensor(value, out, expected_shape=cur.shape)
+        out[t_index] = torch.maximum(cur, v)
+        return out
+
+    raise AssertionError(f"unreachable: {op!r}")
+
+
+def _torch_normalize_index(index, mantissa, mode, op):
+    """Convert ``index`` into something torch's ``__getitem__`` accepts.
+
+    Also applies mode emulation for scalar-int and 1D-int-array indices when
+    the backend can't naturally honor JAX's drop/clip semantics.
+    """
+    import torch  # type: ignore
+
+    # Scalar int — torch happily accepts Python ints
+    if isinstance(index, (int, np.integer)):
+        n = mantissa.shape[0]
+        if mode == "clip":
+            safe = max(0, min(n - 1, index if index >= 0 else index + n))
+            return safe
+        # default / drop / fill / promise_in_bounds — if OOB, the caller will
+        # handle dropping via _torch_value_as_tensor masking; clip silently here
+        if mode in (None, "promise_in_bounds", "drop", "fill") and op != "get":
+            in_bounds = -n <= index < n
+            if not in_bounds:
+                # Signal "drop entirely" via a no-op index using `slice(0, 0)`
+                # — assigning to an empty slice is a no-op for set/add/etc.
+                return slice(0, 0)
+            return int(index) % n
+        return int(index)
+
+    # 1D int array (numpy, jax, etc.) — convert
+    if isinstance(index, np.ndarray) and index.ndim == 1 and index.dtype.kind in ("i", "u"):
+        n = mantissa.shape[0]
+        if mode == "clip":
+            arr = np.where(index < 0, np.maximum(0, index + n), np.minimum(n - 1, index))
+            return torch.as_tensor(arr, dtype=torch.long, device=mantissa.device)
+        valid = (index >= -n) & (index < n)
+        safe = np.where(valid, index % n, 0)
+        if not valid.all():
+            # Subset to in-bounds only — caller paths use this for set/add etc.
+            sub = safe[valid]
+            return torch.as_tensor(sub, dtype=torch.long, device=mantissa.device)
+        return torch.as_tensor(safe, dtype=torch.long, device=mantissa.device)
+
+    # jax/torch tensor index — convert to torch.long
+    if hasattr(index, "__array__") and not isinstance(index, torch.Tensor):
+        try:
+            arr = np.asarray(index)
+        except Exception:
+            return index
+        if arr.dtype.kind in ("i", "u"):
+            return torch.as_tensor(arr, dtype=torch.long, device=mantissa.device)
+        if arr.dtype.kind == "b":
+            return torch.as_tensor(arr, dtype=torch.bool, device=mantissa.device)
+        return arr
+
+    return index
+
+
+def _torch_index_to_tuple(t_index, shape):
+    """Return a tuple of torch.long tensors suitable for ``index_put_`` if
+    possible, else ``None`` (caller should fall back).
+    """
+    import torch  # type: ignore
+
+    if isinstance(t_index, slice):
+        return None
+    if isinstance(t_index, int):
+        return (torch.tensor([t_index], dtype=torch.long),)
+    if isinstance(t_index, torch.Tensor):
+        if t_index.dtype == torch.bool:
+            return None
+        if t_index.ndim == 1:
+            return (t_index,)
+        return None
+    return None
+
+
+def _torch_value_as_tensor(value, mantissa, expected_shape):
+    """Coerce ``value`` to a torch tensor matching mantissa's dtype/device."""
+    import torch  # type: ignore
+
+    if isinstance(value, torch.Tensor):
+        v = value.to(dtype=mantissa.dtype, device=mantissa.device)
+    elif isinstance(value, (int, float, complex, bool, np.number)):
+        v = torch.tensor(value, dtype=mantissa.dtype, device=mantissa.device)
+    else:
+        v = torch.as_tensor(
+            np.asarray(value), dtype=mantissa.dtype, device=mantissa.device
+        )
+    if expected_shape is not None and v.shape != tuple(expected_shape):
+        # Allow broadcast — torch handles scalar broadcast naturally
+        if v.ndim == 0 or v.numel() == 1:
+            return v
+    return v
+
+
+def _scatter_torch_get(mantissa, index, *, mode, fill_value):
+    import torch  # type: ignore
+
+    if isinstance(index, (int, np.integer)):
+        n = mantissa.shape[0]
+        if mode in (None, "promise_in_bounds", "clip"):
+            safe = max(0, min(n - 1, index if index >= 0 else index + n))
+            return mantissa[safe]
+        if mode in ("drop", "fill"):
+            if -n <= index < n:
+                return mantissa[int(index) % n]
+            fill = _resolve_fill_value(
+                fill_value, np.dtype(_torch_dtype_to_numpy(mantissa.dtype)), np
+            )
+            return torch.tensor(fill, dtype=mantissa.dtype, device=mantissa.device)
+
+    if isinstance(index, np.ndarray) and index.ndim == 1 and index.dtype.kind in ("i", "u"):
+        n = mantissa.shape[0]
+        valid = (index >= -n) & (index < n)
+        safe = np.where(valid, index % n, 0)
+        result = mantissa[torch.as_tensor(safe, dtype=torch.long, device=mantissa.device)]
+        if mode in ("drop", "fill") and not valid.all():
+            fill = _resolve_fill_value(
+                fill_value, np.dtype(_torch_dtype_to_numpy(mantissa.dtype)), np
+            )
+            valid_t = torch.as_tensor(valid, dtype=torch.bool, device=mantissa.device)
+            fill_t = torch.full_like(result, fill)
+            return torch.where(valid_t, result, fill_t)
+        return result
+
+    # Other index types — pass through
+    return mantissa[index]
+
+
+def _torch_dtype_to_numpy(dt):
+    """Map a torch dtype to a numpy dtype string for fill-value resolution."""
+    s = str(dt).replace("torch.", "")
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Dask — keep the graph lazy
+# ---------------------------------------------------------------------------
+
+_DASK_HINT = (
+    "Use a boolean mask of the source shape, a slice, an int, or a 1D int "
+    "array; or call .to_numpy() to materialize the array first."
+)
+
+
+def _scatter_dask(mantissa, index, value, op: str, *, mode, fill_value):
+    import dask.array as da  # type: ignore
+
+    if op == "get":
+        return _scatter_dask_get(mantissa, index, mode=mode, fill_value=fill_value)
+
+    # Boolean mask of same shape → da.where
+    if isinstance(index, np.ndarray) and index.dtype == bool and index.shape == mantissa.shape:
+        mask = da.from_array(index, chunks=mantissa.chunks)
+        return _dask_apply_with_mask(mantissa, mask, value, op)
+    if isinstance(index, da.Array) and index.dtype == bool and index.shape == mantissa.shape:
+        return _dask_apply_with_mask(mantissa, index, value, op)
+
+    # Slice / ellipsis / int / 1D int array → build a positional mask
+    mask, idx_meta = _dask_index_to_mask(mantissa, index, mode)
+    if mask is None:
+        raise NotImplementedError(
+            f"Quantity.at on dask backend does not support index type "
+            f"{type(index).__name__!r} for op {op!r}. {_DASK_HINT}"
+        )
+    return _dask_apply_with_mask(mantissa, mask, value, op)
+
+
+def _dask_apply_with_mask(mantissa, mask, value, op: str):
+    """Apply an op at positions selected by a same-shape boolean mask."""
+    import dask.array as da  # type: ignore
+
+    if op == "set":
+        return da.where(mask, value, mantissa)
+    if op == "add":
+        return da.where(mask, mantissa + value, mantissa)
+    if op == "multiply":
+        return da.where(mask, mantissa * value, mantissa)
+    if op == "divide":
+        return da.where(mask, mantissa / value, mantissa)
+    if op == "min":
+        return da.where(mask, da.minimum(mantissa, value), mantissa)
+    if op == "max":
+        return da.where(mask, da.maximum(mantissa, value), mantissa)
+    if op == "power":
+        if not isinstance(value, (int, np.integer)):
+            raise TypeError(f"power exponent must be an integer, but got {type(value).__name__}")
+        return da.where(mask, mantissa ** value, mantissa)
+    if op == "apply":
+        return da.where(mask, value(mantissa), mantissa)
+    raise AssertionError(f"unreachable: {op!r}")
+
+
+def _dask_index_to_mask(mantissa, index, mode):
+    """Convert simple-shape index expressions into a same-shape bool mask.
+
+    Returns ``(mask, meta)`` or ``(None, None)`` if the index can't be
+    represented this way in this release.
+    """
+    import dask.array as da  # type: ignore
+
+    shape = mantissa.shape
+
+    # Ellipsis or full slice → all-True mask
+    if index is Ellipsis:
+        return da.ones(shape, chunks=mantissa.chunks, dtype=bool), None
+
+    if isinstance(index, slice):
+        if mantissa.ndim != 1:
+            return None, None
+        idx = np.zeros(shape[0], dtype=bool)
+        idx[index] = True
+        return da.from_array(idx, chunks=mantissa.chunks), None
+
+    if isinstance(index, (int, np.integer)):
+        if mantissa.ndim != 1:
+            return None, None
+        n = shape[0]
+        if not (-n <= int(index) < n):
+            if mode in (None, "promise_in_bounds", "drop", "fill"):
+                return da.zeros(shape, chunks=mantissa.chunks, dtype=bool), None
+            if mode == "clip":
+                safe = max(0, min(n - 1, int(index) if int(index) >= 0 else int(index) + n))
+                mask = np.zeros(n, dtype=bool)
+                mask[safe] = True
+                return da.from_array(mask, chunks=mantissa.chunks), None
+            return None, None
+        pos = int(index) % n
+        mask = np.zeros(n, dtype=bool)
+        mask[pos] = True
+        return da.from_array(mask, chunks=mantissa.chunks), None
+
+    if isinstance(index, np.ndarray) and index.ndim == 1 and index.dtype.kind in ("i", "u"):
+        if mantissa.ndim != 1:
+            return None, None
+        n = shape[0]
+        valid = (index >= -n) & (index < n)
+        if mode == "clip":
+            safe_idx = np.where(index < 0, np.maximum(0, index + n), np.minimum(n - 1, index))
+        else:
+            safe_idx = index[valid] % n
+        mask = np.zeros(n, dtype=bool)
+        mask[safe_idx] = True
+        return da.from_array(mask, chunks=mantissa.chunks), None
+
+    return None, None
+
+
+def _scatter_dask_get(mantissa, index, *, mode, fill_value):
+    import dask.array as da  # type: ignore
+
+    # Native dask indexing handles slice, bool mask, int, 1D int array.
+    if isinstance(index, (slice, type(...), int, np.integer)):
+        return mantissa[index]
+    if isinstance(index, np.ndarray):
+        if index.dtype == bool:
+            return mantissa[da.from_array(index, chunks=mantissa.chunks)]
+        if index.ndim == 1 and index.dtype.kind in ("i", "u"):
+            n = mantissa.shape[0]
+            if mode in ("drop", "fill"):
+                valid = (index >= -n) & (index < n)
+                if not valid.all():
+                    safe = np.where(valid, index % n, 0)
+                    result = mantissa[da.from_array(safe, chunks=min(len(safe), 1024))]
+                    fill = _resolve_fill_value(fill_value, mantissa.dtype, np)
+                    return da.where(
+                        da.from_array(valid, chunks=result.chunks),
+                        result,
+                        da.from_array(np.full(len(safe), fill, dtype=mantissa.dtype),
+                                      chunks=result.chunks),
+                    )
+            return mantissa[da.from_array(index, chunks=min(len(index), 1024))]
+    if isinstance(index, da.Array):
+        return mantissa[index]
+    raise NotImplementedError(
+        f"Quantity.at[..].get on dask backend does not support index type "
+        f"{type(index).__name__!r}. {_DASK_HINT}"
+    )

--- a/saiunit/_scatter_test.py
+++ b/saiunit/_scatter_test.py
@@ -1,0 +1,427 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Multi-backend tests for ``Quantity.at[...].<op>(...)``.
+
+Each test consumes the ``backend`` fixture from the project-level
+``conftest.py`` and runs once per installed backend. Skips automatically when
+a backend's library isn't installed.
+
+ndonnx is covered separately: indexed updates raise ``BackendError`` there
+because the symbolic graph has no notion of in-place update.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import saiunit as u
+from saiunit import BackendError, Quantity, meter, mV
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _to_numpy(q: Quantity) -> np.ndarray:
+    """Return mantissa as a numpy array regardless of backend."""
+    m = q.mantissa
+    if hasattr(m, "compute"):  # dask
+        m = m.compute()
+    if hasattr(m, "detach"):  # torch
+        m = m.detach().cpu().numpy()
+    if hasattr(m, "unwrap_numpy"):  # ndonnx
+        m = m.unwrap_numpy()
+    return np.asarray(m)
+
+
+def _make_quantity(values, unit, backend_name: str) -> Quantity:
+    """Build a Quantity whose mantissa lives on ``backend_name``."""
+    arr_np = np.asarray(values, dtype=np.float64)
+    if backend_name == "numpy":
+        return Quantity(arr_np, unit=unit)
+    if backend_name == "jax":
+        import jax.numpy as jnp
+        return Quantity(jnp.asarray(arr_np), unit=unit)
+    if backend_name == "cupy":
+        import cupy as cp
+        return Quantity(cp.asarray(arr_np), unit=unit)
+    if backend_name == "torch":
+        import torch
+        return Quantity(torch.as_tensor(arr_np), unit=unit)
+    if backend_name == "dask":
+        import dask.array as da
+        return Quantity(da.from_array(arr_np, chunks=2), unit=unit)
+    if backend_name == "ndonnx":
+        import ndonnx
+        return Quantity(ndonnx.asarray(arr_np), unit=unit)
+    raise AssertionError(f"unknown backend {backend_name!r}")
+
+
+# ---------------------------------------------------------------------------
+# ndonnx: every op raises BackendError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "op",
+    ["set", "add", "multiply", "divide", "power", "min", "max"],
+)
+def test_ndonnx_at_raises(op):
+    pytest.importorskip("ndonnx")
+    q = _make_quantity([1.0, 2.0, 3.0], mV, "ndonnx")
+    with pytest.raises(BackendError, match="ndonnx"):
+        ref = q.at[0]
+        if op == "power":
+            ref.power(2)
+        elif op == "multiply":
+            ref.multiply(2.0)
+        elif op == "divide":
+            ref.divide(2.0)
+        elif op == "min":
+            ref.min(0.5 * mV)
+        elif op == "max":
+            ref.max(10.0 * mV)
+        else:
+            getattr(ref, op)(5.0 * mV)
+
+
+def test_ndonnx_at_get_raises():
+    pytest.importorskip("ndonnx")
+    q = _make_quantity([1.0, 2.0, 3.0], mV, "ndonnx")
+    with pytest.raises(BackendError, match="ndonnx"):
+        q.at[0].get()
+
+
+# ---------------------------------------------------------------------------
+# set
+# ---------------------------------------------------------------------------
+
+def test_set_scalar_idx(backend):
+    if backend == "ndonnx":
+        pytest.skip("ndonnx covered by test_ndonnx_at_raises")
+    q = _make_quantity([1.0, 2.0, 3.0, 4.0], mV, backend)
+    r = q.at[1].set(99.0 * mV)
+    assert r.unit == mV
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 99.0, 3.0, 4.0])
+
+
+def test_set_int_array_idx(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([0.0, 0.0, 0.0, 0.0], mV, backend)
+    idx = np.asarray([0, 2])
+    r = q.at[idx].set(7.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [7.0, 0.0, 7.0, 0.0])
+
+
+def test_set_does_not_mutate_original(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    _ = q.at[0].set(99.0 * mV)
+    np.testing.assert_allclose(_to_numpy(q), [1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# add — repeated-index accumulation (must match JAX semantics on jax/numpy/cupy/torch)
+# ---------------------------------------------------------------------------
+
+def test_add_scalar(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([0.0, 0.0, 0.0], mV, backend)
+    r = q.at[1].add(5.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [0.0, 5.0, 0.0])
+
+
+def test_add_repeated_indices_accumulates(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    if backend == "dask":
+        pytest.skip("dask uses bool-mask scatter; repeated-index 1D-int idx accumulation differs by design")
+    q = _make_quantity([0.0, 0.0, 0.0, 0.0], mV, backend)
+    idx = np.asarray([0, 0, 1])
+    val = np.asarray([1.0, 2.0, 5.0])
+    r = q.at[idx].add(val * mV)
+    np.testing.assert_allclose(_to_numpy(r), [3.0, 5.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# multiply / divide
+# ---------------------------------------------------------------------------
+
+def test_multiply_scalar(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([2.0, 4.0, 8.0], mV, backend)
+    r = q.at[1].multiply(0.5)
+    np.testing.assert_allclose(_to_numpy(r), [2.0, 2.0, 8.0])
+    assert r.unit == mV
+
+
+def test_divide_scalar(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([2.0, 4.0, 8.0], mV, backend)
+    r = q.at[2].divide(2.0)
+    np.testing.assert_allclose(_to_numpy(r), [2.0, 4.0, 4.0])
+
+
+# ---------------------------------------------------------------------------
+# min / max
+# ---------------------------------------------------------------------------
+
+def test_min(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([3.0, 3.0, 3.0], mV, backend)
+    r = q.at[0].min(1.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 3.0, 3.0])
+
+
+def test_max(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 1.0, 1.0], mV, backend)
+    r = q.at[2].max(5.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 1.0, 5.0])
+
+
+# ---------------------------------------------------------------------------
+# power
+# ---------------------------------------------------------------------------
+
+def test_power_integer(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([2.0, 3.0, 4.0], meter, backend)
+    r = q.at[1].power(2)
+    np.testing.assert_allclose(_to_numpy(r), [2.0, 9.0, 4.0])
+    # Quantity.at.power changes the unit on the entire array (this matches JAX's
+    # behavior — repeated multiplication of unit). We assert that the unit
+    # dimension is squared:
+    assert r.unit == meter ** 2
+
+
+def test_power_non_integer_raises(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([2.0, 3.0], meter, backend)
+    with pytest.raises(TypeError):
+        q.at[0].power(2.5)
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+def test_apply(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 4.0, 9.0], mV, backend)
+    r = q.at[1].apply(lambda x: x * 2)
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 8.0, 9.0])
+    assert r.unit == mV
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+def test_get_scalar(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([10.0, 20.0, 30.0], mV, backend)
+    r = q.at[1].get()
+    assert r.unit == mV
+    np.testing.assert_allclose(_to_numpy(r), 20.0)
+
+
+def test_get_array_idx(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([10.0, 20.0, 30.0, 40.0], mV, backend)
+    idx = np.asarray([0, 2])
+    r = q.at[idx].get()
+    np.testing.assert_allclose(_to_numpy(r), [10.0, 30.0])
+
+
+# ---------------------------------------------------------------------------
+# OOB mode emulation (numpy/cupy/torch/jax — dask handles OOB via mask)
+# ---------------------------------------------------------------------------
+
+def test_set_oob_drop_default(backend):
+    """Default ``mode=None`` drops out-of-bounds updates (JAX semantics)."""
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    # idx 10 is out of bounds → dropped → no change
+    r = q.at[10].add(5.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 2.0, 3.0])
+
+
+def test_set_oob_clip_mode(backend):
+    """mode='clip' clamps the index to the valid range."""
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    # idx 20 clipped to 2 (last position) → adds 5 there
+    r = q.at[20].add(5.0 * mV, mode="clip")
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 2.0, 8.0])
+
+
+def test_get_oob_clip(backend):
+    """get with OOB and default mode returns clipped value (JAX semantics)."""
+    if backend == "ndonnx":
+        pytest.skip()
+    if backend == "dask":
+        pytest.skip("dask uses native indexing for get and raises on OOB ints")
+    q = _make_quantity([10.0, 20.0, 30.0], mV, backend)
+    r = q.at[20].get()
+    np.testing.assert_allclose(_to_numpy(r), 30.0)
+
+
+def test_get_oob_fill_default(backend):
+    """get(mode='fill') with no fill_value uses dtype-specific default (NaN for float)."""
+    if backend == "ndonnx":
+        pytest.skip()
+    if backend == "dask":
+        pytest.skip("dask not exercised for fill mode in v0.3.0")
+    q = _make_quantity([10.0, 20.0, 30.0], mV, backend)
+    r = q.at[20].get(mode="fill")
+    val = _to_numpy(r)
+    assert np.isnan(val)
+
+
+def test_get_oob_fill_with_quantity_fill_value(backend):
+    """fill_value must be unit-compatible; its mantissa is used at OOB positions."""
+    if backend == "ndonnx":
+        pytest.skip()
+    if backend == "dask":
+        pytest.skip("dask not exercised for fill mode in v0.3.0")
+    q = _make_quantity([10.0, 20.0, 30.0], mV, backend)
+    r = q.at[20].get(mode="fill", fill_value=-1.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), -1.0)
+
+
+def test_get_oob_fill_value_dim_mismatch_raises(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    if backend == "dask":
+        pytest.skip()
+    q = _make_quantity([10.0, 20.0, 30.0], mV, backend)
+    with pytest.raises(u.UnitMismatchError):
+        q.at[20].get(mode="fill", fill_value=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Unit checks (backend-agnostic — must hold across every backend)
+# ---------------------------------------------------------------------------
+
+def test_set_requires_compatible_unit(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    with pytest.raises(u.UnitMismatchError):
+        q.at[0].set(5.0 * meter)
+
+
+def test_add_requires_compatible_unit(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    with pytest.raises(u.UnitMismatchError):
+        q.at[0].add(5.0)  # plain number, but quantity is not unitless
+
+
+def test_multiply_changes_unit(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([2.0, 4.0, 8.0], mV, backend)
+    r = q.at[1].multiply(3.0 * meter)
+    # Unit of the whole array becomes mV*m (JAX semantics)
+    assert r.unit == mV * meter
+
+
+# ---------------------------------------------------------------------------
+# Backend-preserving (mantissa stays in the original backend)
+# ---------------------------------------------------------------------------
+
+def test_set_preserves_backend(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    r = q.at[0].set(99.0 * mV)
+    assert r.backend == backend
+
+
+# ---------------------------------------------------------------------------
+# Dask-specific: laziness preserved
+# ---------------------------------------------------------------------------
+
+def test_dask_at_stays_lazy():
+    da = pytest.importorskip("dask.array")
+    q = _make_quantity([1.0, 2.0, 3.0, 4.0], mV, "dask")
+    r = q.at[1].set(99.0 * mV)
+    # The mantissa should still be a dask array (i.e., we haven't materialized)
+    assert isinstance(r.mantissa, da.Array)
+    np.testing.assert_allclose(r.mantissa.compute(), [1.0, 99.0, 3.0, 4.0])
+
+
+def test_dask_bool_mask_set():
+    pytest.importorskip("dask.array")
+    q = _make_quantity([1.0, 2.0, 3.0, 4.0], mV, "dask")
+    mask = np.array([True, False, True, False])
+    r = q.at[mask].set(0.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [0.0, 2.0, 0.0, 4.0])
+
+
+def test_dask_multidim_fancy_idx_not_implemented():
+    da = pytest.importorskip("dask.array")
+    arr = da.from_array(np.zeros((3, 3)), chunks=(2, 2))
+    q = Quantity(arr, unit=mV)
+    # 2D fancy integer indexing isn't supported in v0.3.0 for dask
+    with pytest.raises(NotImplementedError):
+        q.at[np.array([[0, 1]])].set(5.0 * mV)
+
+
+# ---------------------------------------------------------------------------
+# Scatter methods (Quantity.__setitem__, scatter_add/mul/div/max/min)
+# also route through the new dispatch — smoke-test them per backend.
+# ---------------------------------------------------------------------------
+
+def test_scatter_add_method(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    r = q.scatter_add(0, 10.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [11.0, 2.0, 3.0])
+
+
+def test_scatter_mul_method(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    r = q.scatter_mul(2, 10.0)
+    np.testing.assert_allclose(_to_numpy(r), [1.0, 2.0, 30.0])
+
+
+def test_scatter_max_method(backend):
+    if backend == "ndonnx":
+        pytest.skip()
+    q = _make_quantity([1.0, 2.0, 3.0], mV, backend)
+    r = q.scatter_max(0, 10.0 * mV)
+    np.testing.assert_allclose(_to_numpy(r), [10.0, 2.0, 3.0])

--- a/saiunit/_version.py
+++ b/saiunit/_version.py
@@ -15,5 +15,5 @@
 
 """Project version information."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/saiunit/custom_array.py
+++ b/saiunit/custom_array.py
@@ -235,9 +235,11 @@ class CustomArray:
         if isinstance(data, np.ndarray):
             data = math.asarray(data)
 
-        # update
-        self_data = math.asarray(self.data)
-        self.data = self_data.at[index].set(data)
+        # Route through the unified scatter dispatcher so this works across
+        # every supported backend (numpy/jax/cupy/torch/dask) rather than
+        # assuming JAX-style ``.at[...]``.
+        from saiunit._scatter import scatter as _scatter_dispatch
+        self.data = _scatter_dispatch(self.data, index, data, "set")
 
     # ---------- #
     # operations #

--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -450,7 +450,7 @@ def fftn(
         >>> X = sufft.fftn(x)
         >>> x_back = sufft.ifftn(X)
     """
-    input_ndim = a.ndim if hasattr(a, 'ndim') else jnp.asarray(a, **kwargs).ndim
+    input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u * (second ** n)
     # TODO: may cause computation overhead?
@@ -504,7 +504,7 @@ def rfftn(
         >>> x = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) * u.meter
         >>> X = sufft.rfftn(x)
     """
-    input_ndim = a.ndim if hasattr(a, 'ndim') else jnp.asarray(a, **kwargs).ndim
+    input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u * (second ** n)
     # TODO: may cause computation overhead?
@@ -663,7 +663,7 @@ def ifftn(
         >>> X = sufft.fftn(x)
         >>> x_back = sufft.ifftn(X)
     """
-    input_ndim = a.ndim if hasattr(a, 'ndim') else jnp.asarray(a, **kwargs).ndim
+    input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u / (second ** n)
     # TODO: may cause computation overhead?
@@ -719,7 +719,7 @@ def irfftn(
         >>> X = sufft.rfftn(x)
         >>> x_back = sufft.irfftn(X)
     """
-    input_ndim = a.ndim if hasattr(a, 'ndim') else jnp.asarray(a, **kwargs).ndim
+    input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u / (second ** n)
     # TODO: may cause computation overhead?

--- a/saiunit/math/_activation.py
+++ b/saiunit/math/_activation.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 from saiunit._jax_compat import HAS_JAX, jax, require_jax
+from saiunit._jax_guard import require_jax_backend
 
 if HAS_JAX:
     from jax import nn
@@ -84,6 +85,7 @@ def relu(
         >>> q = u.Quantity(jnp.array([-1., 0., 1.]), unit=u.meter)
         >>> sumath.relu(q)  # units are preserved
     """
+    require_jax_backend("saiunit.math.relu", x)
     return _fun_keep_unit_unary(nn.relu, x)
 
 
@@ -131,6 +133,7 @@ def relu6(
         >>> sumath.relu6(jnp.array([-1., 0., 3., 7.]))
         Array([0., 0., 3., 6.], dtype=float32)
     """
+    require_jax_backend("saiunit.math.relu6", x)
     return _fun_accept_unitless_unary(nn.relu6, x, unit_to_scale=unit_to_scale)
 
 
@@ -168,6 +171,7 @@ def sigmoid(
         >>> sumath.sigmoid(jnp.array([-2., 0., 2.]))
         Array([0.11920292, 0.5       , 0.8807971 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.sigmoid", x)
     return _fun_accept_unitless_unary(nn.sigmoid, x, unit_to_scale=unit_to_scale)
 
 
@@ -205,6 +209,7 @@ def softplus(
         >>> sumath.softplus(jnp.array([-2., 0., 2.]))
         Array([0.12692805, 0.6931472 , 2.126928  ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.softplus", x)
     return _fun_accept_unitless_unary(nn.softplus, x, unit_to_scale=unit_to_scale)
 
 
@@ -252,6 +257,7 @@ def sparse_plus(
         >>> sumath.sparse_plus(jnp.array([-2., 0., 2.]))
         Array([0.  , 0.25, 2.  ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.sparse_plus", x)
     return _fun_accept_unitless_unary(nn.sparse_plus, x, unit_to_scale=unit_to_scale)
 
 
@@ -301,6 +307,7 @@ def sparse_sigmoid(
         >>> sumath.sparse_sigmoid(jnp.array([-2., 0., 2.]))
         Array([0. , 0.5, 1. ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.sparse_sigmoid", x)
     return _fun_accept_unitless_unary(nn.sparse_sigmoid, x, unit_to_scale=unit_to_scale)
 
 
@@ -338,6 +345,7 @@ def soft_sign(
         >>> sumath.soft_sign(jnp.array([-2., 0., 2.]))
         Array([-0.6666667,  0.       ,  0.6666667], dtype=float32)
     """
+    require_jax_backend("saiunit.math.soft_sign", x)
     return _fun_accept_unitless_unary(nn.soft_sign, x, unit_to_scale=unit_to_scale)
 
 
@@ -377,6 +385,7 @@ def silu(
         >>> sumath.silu(jnp.array([-2., 0., 2.]))
         Array([-0.23840584,  0.        ,  1.7615942 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.silu", x)
     return _fun_accept_unitless_unary(nn.silu, x, unit_to_scale=unit_to_scale)
 
 
@@ -416,6 +425,7 @@ def swish(
         >>> sumath.swish(jnp.array([-2., 0., 2.]))
         Array([-0.23840584,  0.        ,  1.7615942 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.swish", x)
     return _fun_accept_unitless_unary(nn.silu, x, unit_to_scale=unit_to_scale)
 
 
@@ -453,6 +463,7 @@ def log_sigmoid(
         >>> sumath.log_sigmoid(jnp.array([-2., 0., 2.]))
         Array([-2.126928  , -0.6931472 , -0.12692805], dtype=float32)
     """
+    require_jax_backend("saiunit.math.log_sigmoid", x)
     return _fun_accept_unitless_unary(nn.log_sigmoid, x, unit_to_scale=unit_to_scale)
 
 
@@ -536,6 +547,7 @@ def hard_sigmoid(
         >>> sumath.hard_sigmoid(jnp.array([-4., 0., 4.]))
         Array([0. , 0.5, 1. ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.hard_sigmoid", x)
     return _fun_accept_unitless_unary(nn.hard_sigmoid, x, unit_to_scale=unit_to_scale)
 
 
@@ -576,6 +588,7 @@ def hard_silu(
         >>> sumath.hard_silu(jnp.array([-4., 0., 4.]))
         Array([-0.,  0.,  4.], dtype=float32)
     """
+    require_jax_backend("saiunit.math.hard_silu", x)
     return _fun_accept_unitless_unary(nn.hard_silu, x, unit_to_scale=unit_to_scale)
 
 
@@ -620,6 +633,7 @@ def hard_tanh(
         >>> sumath.hard_tanh(jnp.array([-2., -0.5, 0., 0.5, 2.]))
         Array([-1. , -0.5,  0. ,  0.5,  1. ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.hard_tanh", x)
     return _fun_accept_unitless_unary(nn.hard_tanh, x, unit_to_scale=unit_to_scale)
 
 
@@ -665,6 +679,7 @@ def elu(
         >>> sumath.elu(jnp.array([-1., 1.]), alpha=2.0)
         Array([-1.2642411,  1.       ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.elu", x)
     return _fun_accept_unitless_unary(nn.elu, x, alpha=alpha, unit_to_scale=unit_to_scale)
 
 
@@ -712,6 +727,7 @@ def celu(
         >>> sumath.celu(jnp.array([-2., 0., 2.]))
         Array([-0.86466473,  0.        ,  2.        ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.celu", x)
     return _fun_accept_unitless_unary(nn.celu, x, alpha=alpha, unit_to_scale=unit_to_scale)
 
 
@@ -759,6 +775,7 @@ def selu(
         >>> sumath.selu(jnp.array([-2., 0., 2.]))
         Array([-1.5201665,  0.       ,  2.1014020], dtype=float32)
     """
+    require_jax_backend("saiunit.math.selu", x)
     return _fun_accept_unitless_unary(nn.selu, x, unit_to_scale=unit_to_scale)
 
 
@@ -809,6 +826,7 @@ def gelu(
         >>> sumath.gelu(jnp.array([-2., 0., 2.]))
         Array([-0.04540231,  0.        ,  1.9545977 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.gelu", x)
     return _fun_accept_unitless_unary(nn.gelu, x, approximate=approximate, unit_to_scale=unit_to_scale)
 
 
@@ -856,6 +874,7 @@ def glu(
         >>> sumath.glu(x)
         Array([[0.95257413, 1.9640275 ]], dtype=float32)
     """
+    require_jax_backend("saiunit.math.glu", x)
     return _fun_accept_unitless_unary(nn.glu, x, axis=axis, unit_to_scale=unit_to_scale)
 
 
@@ -898,6 +917,7 @@ def squareplus(
         >>> sumath.squareplus(jnp.array([-2., 0., 2.]))
         Array([0.23606798, 1.        , 2.2360680 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.squareplus", x)
     return _fun_accept_unitless_unary(nn.squareplus, x, b=b, unit_to_scale=unit_to_scale)
 
 
@@ -939,4 +959,5 @@ def mish(
         >>> sumath.mish(jnp.array([-2., 0., 2.]))
         Array([-0.25250152,  0.        ,  1.9439590 ], dtype=float32)
     """
+    require_jax_backend("saiunit.math.mish", x)
     return _fun_accept_unitless_unary(nn.mish, x, unit_to_scale=unit_to_scale)


### PR DESCRIPTION
## Summary

- **Multi-backend `Quantity.at`.** All nine indexed-update ops (`get`, `set`, `add`, `multiply`/`mul`, `divide`/`div`, `power`, `min`, `max`, `apply`) now work across numpy/jax/cupy/torch/dask. Dispatch is unified in a new `saiunit._scatter` module. `ndonnx` raises `BackendError` (symbolic graphs can't represent in-place updates).
- **Closed silent JAX-coercion paths** across `Quantity.__init__`, `Quantity.mantissa` setter, `_check_units_and_collect_values`, `saiunit.fft.{fftn,ifftn,rfftn,irfftn}`, and `CustomArray.__setitem__`. These used to silently lift torch/cupy/dask/ndonnx mantissas to JAX.
- **Replaced raw `AttributeError`s with `BackendError`** in `saiunit.math` activation functions (relu/sigmoid/softplus/gelu/…) via per-function `require_jax_backend` guards. `leaky_relu` remains backend-agnostic.
- **Guarded lazy materialization** on `Quantity.strides/.flat/.T/.mT` so dask graphs / ndonnx symbolic arrays no longer silently `.compute()` / `.unwrap_numpy()`.
- **Version bumped to 0.3.0**; `changelog.md` and `Quantity.at` docstring updated with a per-backend repeated-index semantics table.

## Test plan

- [x] `pytest saiunit/_scatter_test.py` — 114 passed (new multi-backend scatter coverage)
- [x] `pytest saiunit/_base_quantity_test.py` — 164 passed
- [x] `pytest saiunit/_backend_test.py saiunit/_backend_parametrize_test.py` — 95 passed
- [x] `pytest saiunit/ --ignore=saiunit/{sparse,lax,autograd}` — **2750 passed**
- [ ] Verify on a JAX-less install: `pip uninstall jax jaxlib && pytest saiunit/_scatter_test.py saiunit/_base_quantity_test.py`
- [ ] Spot-check `saiunit.math.relu(torch_quantity)` now raises `BackendError` (not `AttributeError`)
- [ ] Spot-check `Quantity(torch_tensor, dtype=torch.float32)` actually honors the dtype