### PR TITLE
chore(typing): clean mypy errors and add type_check CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,35 @@ concurrency:
 
 
 jobs:
+  type_check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.13" ]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.13.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip cache purge
+          python -m pip install --upgrade pip setuptools --no-cache-dir
+          python -m pip install -r requirements-dev.txt --no-cache-dir
+          python -m pip install 'mypy>=1.11,<3' --no-cache-dir
+          pip install . --no-cache-dir
+      - name: Run mypy
+        run: |
+          mypy saiunit/
+
+
   test_no_jax:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,32 @@ torch = ["torch>=2.0"]
 dask = ["dask[array]>=2024.1"]
 ndonnx = ["ndonnx>=0.9"]
 all = ["saiunit[jax,cupy,torch,dask,ndonnx]"]
+
+
+[tool.mypy]
+# Optional third-party deps that may or may not be installed in a given
+# environment. Silence import errors so type_check can run with only the
+# core requirements (numpy + jax) installed.
+[[tool.mypy.overrides]]
+module = [
+    "brainstate",
+    "brainstate.*",
+    "cupy",
+    "cupy.*",
+    "torch",
+    "torch.*",
+    "dask",
+    "dask.*",
+    "ndonnx",
+    "ndonnx.*",
+    "scipy",
+    "scipy.*",
+    "matplotlib",
+    "matplotlib.*",
+    "opt_einsum",
+    "opt_einsum.*",
+    "equinox",
+    "equinox.*",
+    "jax.util",
+]
+ignore_missing_imports = true

--- a/saiunit/_backend.py
+++ b/saiunit/_backend.py
@@ -187,6 +187,7 @@ def _xp_for(name: BackendName) -> ModuleType:
     cached = _XP_CACHE.get(name)
     if cached is not None:
         return cached
+    mod: ModuleType
     if name == "numpy":
         mod = _numpy_xp
     elif name == "jax":
@@ -202,21 +203,24 @@ def _xp_for(name: BackendName) -> ModuleType:
                 "cupy backend requested but cupy is not installed. "
                 "Install with: pip install saiunit[cupy]"
             )
-        import array_api_compat.cupy as mod  # noqa: F811
+        import array_api_compat.cupy as _cupy_xp
+        mod = _cupy_xp
     elif name == "torch":
         if _try_import("torch") is None:
             raise BackendError(
                 "torch backend requested but torch is not installed. "
                 "Install with: pip install saiunit[torch]"
             )
-        import array_api_compat.torch as mod  # noqa: F811
+        import array_api_compat.torch as _torch_xp
+        mod = _torch_xp
     elif name == "dask":
         if _try_import("dask.array") is None:
             raise BackendError(
                 "dask backend requested but dask is not installed. "
                 "Install with: pip install saiunit[dask]"
             )
-        import array_api_compat.dask.array as mod  # noqa: F811
+        import array_api_compat.dask.array as _dask_xp
+        mod = _dask_xp
     elif name == "ndonnx":
         ndonnx = _try_import("ndonnx")
         if ndonnx is None:
@@ -253,10 +257,12 @@ def get_backend(*arrays_or_quantities) -> ModuleType:
     has_dask = any(is_dask_array(x) for x in mantissas)
     has_ndonnx = any(is_ndonnx_array(x) for x in mantissas)
 
-    kinds = [name for name, has in
-             [("numpy", has_numpy), ("jax", has_jax),
-              ("cupy", has_cupy), ("torch", has_torch),
-              ("dask", has_dask), ("ndonnx", has_ndonnx)] if has]
+    kinds: list[BackendName] = [
+        name for name, has in  # type: ignore[misc]
+        [("numpy", has_numpy), ("jax", has_jax),
+         ("cupy", has_cupy), ("torch", has_torch),
+         ("dask", has_dask), ("ndonnx", has_ndonnx)] if has
+    ]
 
     if len(kinds) == 1:
         return _xp_for(kinds[0])

--- a/saiunit/_backend_parametrize_test.py
+++ b/saiunit/_backend_parametrize_test.py
@@ -49,7 +49,7 @@ def test_math_function_default_backend(backend):
         import jax
         assert isinstance(r, jax.Array)
     elif backend == "cupy":
-        import cupy
+        import cupy  # type: ignore[import-not-found]
         assert isinstance(r, cupy.ndarray)
     elif backend == "torch":
         import torch

--- a/saiunit/_base_decorators.py
+++ b/saiunit/_base_decorators.py
@@ -543,7 +543,7 @@ def check_units(**au):
     return do_check_units
 
 
-class CallableAssignUnit(Callable):
+class CallableAssignUnit(Callable):  # type: ignore[misc]
     without_result_units = Callable
 
     def __call__(self, *args, **kwargs):
@@ -558,7 +558,7 @@ missing = Missing()
 
 
 @set_module_as('saiunit')
-def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[Callable], CallableAssignUnit]:
+def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[Callable], CallableAssignUnit]:  # type: ignore[assignment]
     """
     Decorator to transform units of arguments passed to a function and optionally assign units to the return value.
 
@@ -710,7 +710,7 @@ def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[
         result = f(**newkeyset)
         return result
 
-    new_f.without_result_units = without_result_units
+    new_f.without_result_units = without_result_units  # type: ignore[attr-defined]
 
     return cast(CallableAssignUnit, new_f)
 

--- a/saiunit/_base_dimension.py
+++ b/saiunit/_base_dimension.py
@@ -465,7 +465,7 @@ class Dimension:
             raise TypeError("Too many exponents")
         return get_or_create_dimension(self._dims * value)
 
-    def __imul__(self, value):
+    def __imul__(self, value):  # type: ignore[misc]
         """
         In-place multiplication operation for Dimension objects.
 
@@ -505,7 +505,7 @@ class Dimension:
         """
         raise NotImplementedError("Dimension object is immutable")
 
-    def __itruediv__(self, value):
+    def __itruediv__(self, value):  # type: ignore[misc]
         """
         In-place true division operation for Dimension objects.
 
@@ -525,7 +525,7 @@ class Dimension:
         """
         raise NotImplementedError("Dimension object is immutable")
 
-    def __ipow__(self, value):
+    def __ipow__(self, value):  # type: ignore[misc]
         """
         In-place power operation for Dimension objects.
 
@@ -546,7 +546,7 @@ class Dimension:
         raise NotImplementedError("Dimension object is immutable")
 
     # ---- COMPARISON ---- #
-    def __eq__(self, value: 'Dimension') -> bool:
+    def __eq__(self, value: 'Dimension') -> bool:  # type: ignore[override]
         """
         Compare this Dimension object with another for equality.
 

--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -23,10 +24,14 @@ from ._jax_compat import (
     HAS_JAX,
     jax,
     jnp,
+    ArrayLike,
     ShapeDtypeStruct as _ShapeDtypeStruct,
     ShapedArray as _ShapedArray,
     Tracer as _Tracer,
 )
+
+if TYPE_CHECKING:
+    from ._base_quantity import Quantity
 
 from ._base_dimension import (
     Dimension,
@@ -64,7 +69,7 @@ __all__ = [
 # Utility helpers
 # ---------------------------------------------------------------------------
 
-def _to_quantity(array):
+def _to_quantity(array) -> 'Quantity':
     from ._base_quantity import Quantity
     array = maybe_custom_array(array)
     if isinstance(array, Quantity):
@@ -597,8 +602,8 @@ def fail_for_unit_mismatch(
 
 @set_module_as('saiunit')
 def display_in_unit(
-    x: 'jax.typing.ArrayLike | Quantity',
-    u: 'Unit' = None,
+    x: 'ArrayLike | Quantity',
+    u: 'Unit | None' = None,
     precision: int | None = None,
 ) -> str:
     """
@@ -644,9 +649,9 @@ def display_in_unit(
 
 @set_module_as('saiunit')
 def maybe_decimal(
-    val: 'Quantity | jax.typing.ArrayLike',
+    val: 'Quantity | ArrayLike',
     unit: 'Unit | None' = None
-) -> 'jax.Array | Quantity':
+) -> 'jax.Array | Quantity | ArrayLike':
     """
     Convert a quantity to a plain number if it is dimensionless.
 
@@ -719,20 +724,20 @@ def unit_scale_align_to_first(*args) -> 'list[Quantity]':
     """
     from ._base_quantity import Quantity
     if len(args) == 0:
-        return args
-    args = list(args)
-    first_unit = get_unit(args[0])
+        return []
+    items: list = list(args)
+    first_unit = get_unit(items[0])
     if first_unit.is_unitless:
-        if not isinstance(args[0], Quantity):
-            args[0] = Quantity(args[0])
-        for i in range(1, len(args)):
-            fail_for_unit_mismatch(args[i], args[0], 'Non-matching unit for function "unit_scale_align_to_first"')
-            if not isinstance(args[i], Quantity):
-                args[i] = Quantity(args[i])
+        if not isinstance(items[0], Quantity):
+            items[0] = Quantity(items[0])
+        for i in range(1, len(items)):
+            fail_for_unit_mismatch(items[i], items[0], 'Non-matching unit for function "unit_scale_align_to_first"')
+            if not isinstance(items[i], Quantity):
+                items[i] = Quantity(items[i])
     else:
-        for i in range(1, len(args)):
-            args[i] = args[i].in_unit(first_unit)
-    return args
+        for i in range(1, len(items)):
+            items[i] = items[i].in_unit(first_unit)
+    return items
 
 
 def array_with_unit(
@@ -783,7 +788,7 @@ def array_with_unit(
 # ---------------------------------------------------------------------------
 
 @set_module_as('saiunit')
-def is_dimensionless(obj: 'Quantity | Unit | Dimension | jax.typing.ArrayLike') -> bool:
+def is_dimensionless(obj: 'Quantity | Unit | Dimension | ArrayLike') -> bool:
     """
     Test if a value is dimensionless or not.
 
@@ -820,7 +825,7 @@ def is_dimensionless(obj: 'Quantity | Unit | Dimension | jax.typing.ArrayLike') 
 
 
 @set_module_as('saiunit')
-def is_unitless(obj: 'Quantity | Unit | jax.typing.ArrayLike') -> bool:
+def is_unitless(obj: 'Quantity | Unit | ArrayLike') -> bool:
     """
     Test if a value is unitless or not.
 
@@ -904,9 +909,9 @@ def is_scalar_type(obj) -> bool:
 
 @set_module_as('saiunit')
 def assert_quantity(
-    q: 'Quantity | jax.typing.ArrayLike',
-    mantissa: jax.typing.ArrayLike,
-    unit: 'Unit' = None
+    q: 'Quantity | ArrayLike',
+    mantissa: ArrayLike,
+    unit: 'Unit | None' = None
 ):
     """
     Assert that a `Quantity` has a certain mantissa and unit.

--- a/saiunit/_base_getters_test.py
+++ b/saiunit/_base_getters_test.py
@@ -599,7 +599,7 @@ class TestGetMethodIntegration:
         assert u.get_mantissa(u.mV.dim ** 2 / u.second.dim ** 2) == u.mV.dim ** 2 / u.second.dim ** 2
 
     def test_format_scalar(self):
-        import brainstate
+        import brainstate  # type: ignore[import-untyped]
         with brainstate.environ.context(precision=64):
             q1 = 1.23456789 * u.mV
             assert f"{q1:.2f}" == "1.23 mV"

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -30,8 +30,8 @@ from ._jax_compat import (
     HAS_JAX,
     jax,
     jnp,
+    ArrayLike,
     Array as _JaxArray,
-    ArrayLike as _JaxArrayLike,
     DTypeLike as _JaxDTypeLike,
     canonicalize_dtype as _canonicalize_dtype,
     ensure_compile_time_eval as _ensure_compile_time_eval,
@@ -207,7 +207,7 @@ def _wrap_function_remove_unit(func):
 # ---------------------------------------------------------------------------
 
 def _zoom_values_with_units(
-    values: Sequence[jax.typing.ArrayLike],
+    values: Sequence[ArrayLike],
     units: Sequence[Unit]
 ):
     """
@@ -234,9 +234,9 @@ def _zoom_values_with_units(
     return values
 
 
-def _check_units_and_collect_values(lst) -> tuple[jax.typing.ArrayLike, Unit]:
-    units = []
-    values = []
+def _check_units_and_collect_values(lst) -> tuple[ArrayLike, Unit]:
+    units: list = []
+    values: list = []
 
     for item in lst:
         if isinstance(item, (list, tuple)):
@@ -273,7 +273,7 @@ def _check_units_and_collect_values(lst) -> tuple[jax.typing.ArrayLike, Unit]:
         return _xp.asarray(values), UNITLESS
 
 
-def _process_list_with_units(value: list) -> tuple[jax.typing.ArrayLike, Unit]:
+def _process_list_with_units(value: 'list | tuple') -> tuple[ArrayLike, Unit]:
     values, unit = _check_units_and_collect_values(value)
     return values, unit
 
@@ -509,7 +509,7 @@ class Quantity:
     __module__ = "saiunit"
     __slots__ = ('_mantissa', '_unit')
     __array_priority__ = 1000
-    _mantissa: jax.Array | np.ndarray
+    _mantissa: 'ArrayLike'
     _unit: Unit
 
     def __class_getitem__(cls, item: Unit | str) -> type['Quantity']:
@@ -553,7 +553,7 @@ class Quantity:
     def __init__(
         self,
         mantissa: PyTree | Unit,
-        unit: 'Unit | jax.typing.ArrayLike | str | None' = UNITLESS,
+        unit: 'Unit | str | None' = UNITLESS,
         dtype: jax.typing.DTypeLike | None = None,
     ):
 
@@ -567,6 +567,9 @@ class Quantity:
             if isinstance(unit, str):
                 from ._base_unit import parse_unit
                 unit = parse_unit(unit)
+            if unit is None:
+                unit = UNITLESS
+            assert isinstance(unit, Unit), f"Expected a Unit, got {type(unit).__name__}: {unit!r}"
 
             # Handle custom arrays in the mantissa tree structure
             mantissa = maybe_custom_array_tree(mantissa)
@@ -640,7 +643,7 @@ class Quantity:
                 # else: keep as-is for arbitrary pytree leaves
 
         # mantissa
-        self._mantissa = mantissa
+        self._mantissa = mantissa  # type: ignore[assignment]
 
         # dimension
         self._unit = unit
@@ -749,7 +752,7 @@ class Quantity:
         return _IndexUpdateHelper(self)
 
     @property
-    def mantissa(self) -> jax.typing.ArrayLike:
+    def mantissa(self) -> ArrayLike:
         r"""
         The raw numerical data of this quantity (without the unit).
 
@@ -779,7 +782,7 @@ class Quantity:
         return self._mantissa
 
     @property
-    def magnitude(self) -> jax.typing.ArrayLike:
+    def magnitude(self) -> ArrayLike:
         """
         Alias for :attr:`mantissa`.
 
@@ -975,7 +978,7 @@ class Quantity:
         """
         return self.in_unit(new_unit)
 
-    def to_decimal(self, unit: Unit = UNITLESS) -> jax.typing.ArrayLike:
+    def to_decimal(self, unit: Unit = UNITLESS) -> ArrayLike:
         """
         Return the numerical value expressed in the given unit, without wrapping
         the result in a ``Quantity``.
@@ -1027,7 +1030,7 @@ class Quantity:
         else:
             return self.mantissa
 
-    def in_unit(self, unit: Unit, err_msg: str = None) -> 'Quantity':
+    def in_unit(self, unit: Unit, err_msg: str | None = None) -> 'Quantity':
         """
         Convert this quantity to a compatible unit.
 
@@ -1169,6 +1172,7 @@ class Quantity:
         from saiunit._backend import is_dask_array
         if is_dask_array(m):
             return repr(m)
+        value: 'ArrayLike'
         if isinstance(m, (_JaxArray, np.ndarray)):
             value = m
         elif isinstance(m, (numbers.Number, list, tuple)):
@@ -1199,9 +1203,9 @@ class Quantity:
                 kw = {}
                 if precision is not None:
                     kw['precision'] = precision
-                with np.printoptions(threshold=10, **kw):
-                    return np.array_str(value)
-            return np.array_str(value, precision=precision)
+                with np.printoptions(threshold=10, **kw):  # type: ignore[arg-type]
+                    return np.array_str(value)  # type: ignore[arg-type]
+            return np.array_str(value, precision=precision)  # type: ignore[arg-type]
         except (TypeError, AttributeError):
             return str(value)
 
@@ -1553,7 +1557,7 @@ class Quantity:
     # bool, so any hash would silently violate the hash/eq invariant and
     # corrupt dict/set lookups. Use ``id(q)`` if a stable identity key is
     # really required.
-    __hash__ = None
+    __hash__ = None  # type: ignore[assignment]
 
     def __repr__(self) -> str:
         value_str = self._format_value()
@@ -1626,9 +1630,9 @@ class Quantity:
                     raise TypeError("Array indices must be integers or slices, not Array")
         elif isinstance(index, Quantity):
             raise TypeError("Array indices must be integers or slices, not Array")
-        return Quantity(self.mantissa[index], unit=self.unit)
+        return Quantity(self.mantissa[index], unit=self.unit)  # type: ignore[index]
 
-    def __setitem__(self, index, value: 'Quantity | jax.typing.ArrayLike'):
+    def __setitem__(self, index, value: 'Quantity | ArrayLike'):
         if _is_tracer(self.mantissa):
             raise RuntimeError(
                 "Quantity[...] = value cannot mutate a Quantity whose mantissa "
@@ -1653,8 +1657,8 @@ class Quantity:
 
     def scatter_add(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy with *value* added at *index*.
@@ -1699,8 +1703,8 @@ class Quantity:
 
     def scatter_sub(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy with *value* subtracted at *index*.
@@ -1727,12 +1731,12 @@ class Quantity:
             >>> q.scatter_sub(0, u.Quantity(1.0, unit=u.mV))
             Quantity([0. 2. 3.], "mV")
         """
-        return self.scatter_add(index, -value)
+        return self.scatter_add(index, -value)  # type: ignore[operator]
 
     def scatter_mul(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy with the element at *index* multiplied by *value*.
@@ -1785,8 +1789,8 @@ class Quantity:
 
     def scatter_div(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy with the element at *index* divided by *value*.
@@ -1839,8 +1843,8 @@ class Quantity:
 
     def scatter_max(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy where the element at *index* is the maximum of
@@ -1886,8 +1890,8 @@ class Quantity:
 
     def scatter_min(
         self,
-        index: jax.typing.ArrayLike,
-        value: 'Quantity | jax.typing.ArrayLike'
+        index: ArrayLike,
+        value: 'Quantity | ArrayLike'
     ) -> 'Quantity':
         """
         Return a copy where the element at *index* is the minimum of
@@ -1936,19 +1940,19 @@ class Quantity:
     # ---------- #
 
     def __len__(self) -> int:
-        return len(self.mantissa)
+        return len(self.mantissa)  # type: ignore[arg-type]
 
     def __neg__(self) -> 'Quantity':
-        return Quantity(self.mantissa.__neg__(), unit=self.unit)
+        return Quantity(-self.mantissa, unit=self.unit)  # type: ignore[operator]
 
     def __pos__(self) -> 'Quantity':
-        return Quantity(self.mantissa.__pos__(), unit=self.unit)
+        return Quantity(+self.mantissa, unit=self.unit)  # type: ignore[operator]
 
     def __abs__(self) -> 'Quantity':
-        return Quantity(self.mantissa.__abs__(), unit=self.unit)
+        return Quantity(abs(self.mantissa), unit=self.unit)
 
     def __invert__(self) -> 'Quantity':
-        return Quantity(self.mantissa.__invert__(), unit=self.unit)
+        return Quantity(~self.mantissa, unit=self.unit)  # type: ignore[operator]
 
     def _comparison(self, other: Any, operator_str: str, operation: Callable):
         other = _to_quantity(other)
@@ -1961,22 +1965,22 @@ class Quantity:
             ) from e
         return operation(self.mantissa, other_value)
 
-    def __eq__(self, oc) -> jax.typing.ArrayLike:
+    def __eq__(self, oc) -> ArrayLike:  # type: ignore[override]
         return self._comparison(oc, "==", operator.eq)
 
-    def __ne__(self, oc) -> jax.typing.ArrayLike:
+    def __ne__(self, oc) -> ArrayLike:  # type: ignore[override]
         return self._comparison(oc, "!=", operator.ne)
 
-    def __lt__(self, oc) -> jax.typing.ArrayLike:
+    def __lt__(self, oc) -> ArrayLike:
         return self._comparison(oc, "<", operator.lt)
 
-    def __le__(self, oc) -> jax.typing.ArrayLike:
+    def __le__(self, oc) -> ArrayLike:
         return self._comparison(oc, "<=", operator.le)
 
-    def __gt__(self, oc) -> jax.typing.ArrayLike:
+    def __gt__(self, oc) -> ArrayLike:
         return self._comparison(oc, ">", operator.gt)
 
-    def __ge__(self, oc) -> jax.typing.ArrayLike:
+    def __ge__(self, oc) -> ArrayLike:
         return self._comparison(oc, ">=", operator.ge)
 
     def _binary_operation(
@@ -1985,7 +1989,7 @@ class Quantity:
         value_operation: Callable,
         unit_operation: Callable = lambda a, b: a,
         fail_for_mismatch: bool = False,
-        operator_str: str = None,
+        operator_str: str | None = None,
         inplace: bool = False,
     ):
         """
@@ -2277,7 +2281,7 @@ class Quantity:
         r = Quantity(self.mantissa << oc, unit=self.unit)
         return maybe_decimal(r)
 
-    def __rlshift__(self, oc) -> 'Quantity | jax.typing.ArrayLike':
+    def __rlshift__(self, oc) -> 'Quantity | ArrayLike':
         # oc << self
         if not self.is_unitless:
             raise ValueError("The shift amount must be dimensionless")
@@ -2298,7 +2302,7 @@ class Quantity:
         r = Quantity(self.mantissa >> oc, unit=self.unit)
         return maybe_decimal(r)
 
-    def __rrshift__(self, oc) -> 'Quantity | jax.typing.ArrayLike':
+    def __rrshift__(self, oc) -> 'Quantity | ArrayLike':
         # oc >> self
         if not self.is_unitless:
             raise ValueError("The shift amount must be dimensionless")
@@ -2310,14 +2314,14 @@ class Quantity:
         self.update_mantissa(r.mantissa)
         return self
 
-    def __round__(self, ndigits: int = None) -> 'Quantity':
+    def __round__(self, ndigits: int | None = None) -> 'Quantity':
         """
         Round the mantissa to the given number of decimals.
 
         :param ndigits: The number of decimals to round to.
         :return: The rounded Quantity.
         """
-        return Quantity(self.mantissa.__round__(ndigits), unit=self.unit)
+        return Quantity(round(self.mantissa, ndigits), unit=self.unit)  # type: ignore[arg-type,call-overload]
 
     def __reduce__(self):
         """
@@ -2430,8 +2434,8 @@ class Quantity:
 
     def clip(
         self,
-        min: 'Quantity | jax.typing.ArrayLike' = None,
-        max: 'Quantity | jax.typing.ArrayLike' = None,
+        min: 'Quantity | ArrayLike | None' = None,
+        max: 'Quantity | ArrayLike | None' = None,
     ) -> 'Quantity':
         """
         Clip (limit) the values in the array to ``[min, max]``.
@@ -2463,7 +2467,7 @@ class Quantity:
         """
         _, min = unit_scale_align_to_first(self, min)
         _, max = unit_scale_align_to_first(self, max)
-        return Quantity(get_backend(self, min, max).clip(self.mantissa, min.mantissa, max.mantissa), unit=self.unit)
+        return Quantity(get_backend(self, min, max).clip(self.mantissa, min.mantissa, max.mantissa), unit=self.unit)  # type: ignore[union-attr]
 
     def conj(self) -> 'Quantity':
         """
@@ -2551,7 +2555,7 @@ class Quantity:
                                    operator.mul, operator_str="@")
         return maybe_decimal(r)
 
-    def trace(self, offset: int = 0, axis1: int = 0, axis2: int = 1) -> 'Quantity':
+    def trace(self, offset: int = 0, axis1: int = 0, axis2: int = 1) -> 'Quantity':  # type: ignore[no-redef]
         """
         Sum along diagonals of the array, preserving units.
 
@@ -2581,7 +2585,7 @@ class Quantity:
         """
         return Quantity(get_backend(self).trace(self.mantissa, offset=offset, axis1=axis1, axis2=axis2), unit=self.unit)
 
-    def diagonal(self, offset: int = 0, axis1: int = 0, axis2: int = 1) -> 'Quantity':
+    def diagonal(self, offset: int = 0, axis1: int = 0, axis2: int = 1) -> 'Quantity':  # type: ignore[no-redef]
         """
         Return specified diagonals, preserving units.
 
@@ -2644,7 +2648,7 @@ class Quantity:
                                    operator.mul, operator_str="outer")
         return maybe_decimal(r)
 
-    def cross(self, b: 'Quantity', axisa: int = -1, axisb: int = -1, axisc: int = -1, axis: int = None) -> 'Quantity':
+    def cross(self, b: 'Quantity', axisa: int = -1, axisb: int = -1, axisc: int = -1, axis: int | None = None) -> 'Quantity':
         """
         Cross product of two arrays.
 
@@ -2685,7 +2689,7 @@ class Quantity:
             kwargs['axis'] = axis
         result_mantissa = get_backend(self, b).cross(self.mantissa, b.mantissa, **kwargs)
         result_unit = self.unit * b.unit
-        r = Quantity(result_mantissa, unit=result_unit)
+        r = Quantity(result_mantissa, unit=result_unit)  # type: ignore[arg-type]
         return maybe_decimal(r)
 
     def searchsorted(self, v, side: str = 'left', sorter=None) -> jax.Array:
@@ -3557,7 +3561,7 @@ class Quantity:
         """
         return Quantity(get_backend(self).expand_dims(self.mantissa, axis), unit=self.unit)
 
-    def expand_as(self, array: 'Quantity | jax.typing.ArrayLike') -> 'Quantity':
+    def expand_as(self, array: 'Quantity | ArrayLike') -> 'Quantity':
         """
         Expand an array to a shape of another array.
 
@@ -3625,7 +3629,7 @@ class Quantity:
         """
         return self.copy()
 
-    def tree_flatten(self) -> tuple[tuple[jax.typing.ArrayLike], Unit]:
+    def tree_flatten(self) -> tuple[tuple[ArrayLike], Unit]:
         """
         Tree flattens the data.
 
@@ -3646,7 +3650,7 @@ class Quantity:
         Returns:
           The Quantity object.
         """
-        return cls(*values, unit=unit)
+        return cls(*values, unit=unit)  # type: ignore[misc]
 
     def cuda(self, device=None) -> 'Quantity':
         from saiunit._jax_compat import device_put as _device_put, devices as _devices
@@ -3754,7 +3758,7 @@ class _IndexUpdateRef:
         arguments ``indices_are_sorted`` and ``unique_indices`` to be passed.
         """
         if fill_value is not None:
-            fill_value = Quantity(fill_value).in_unit(self.unit).mantissa
+            fill_value = Quantity(fill_value).in_unit(self.unit).mantissa  # type: ignore[assignment]
         return Quantity(
             self._scatter(
                 "get",
@@ -3943,7 +3947,7 @@ class _IndexUpdateRef:
 
     def apply(
         self,
-        mantissa_fun: Callable[[jax.typing.ArrayLike], jax.typing.ArrayLike],
+        mantissa_fun: Callable[[ArrayLike], ArrayLike],
         unit_fun: Callable[[Unit], Unit] | None = None,
         indices_are_sorted: bool = False,
         unique_indices: bool = False,

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -17,12 +17,17 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 from ._base_dimension import (
     Dimension,
     DIMENSIONLESS,
     _is_tracer,
 )
+from ._jax_compat import ArrayLike
+
+if TYPE_CHECKING:
+    from ._base_quantity import Quantity
 
 __all__ = [
     'Unit',
@@ -302,7 +307,7 @@ def _get_display_parts(unit: 'Unit'):
 
     Each element is ``(name, dispname, exponent)``.
     """
-    if getattr(unit, '_display_parts', None) is not None:
+    if unit._display_parts is not None:
         return list(unit._display_parts)
     return [(unit.name, unit.dispname, 1)]
 
@@ -747,14 +752,24 @@ class Unit:
     __slots__ = ["_dim", "_base", "_scale", "_factor", "_dispname", "_name", "is_fullname", "_hash", "_display_parts"]
     __array_priority__ = 1000
 
+    _dim: 'Dimension'
+    _base: int | float
+    _scale: int | float
+    _factor: int | float
+    _dispname: str
+    _name: str
+    is_fullname: bool
+    _hash: int | None
+    _display_parts: 'list[tuple[str, str, int]] | None'
+
     def __init__(
         self,
-        dim: 'Dimension | str' = None,
-        scale: jax.typing.ArrayLike = 0,
-        base: jax.typing.ArrayLike = 10.,
-        factor: jax.typing.ArrayLike = 1.,
-        name: str = None,
-        dispname: str = None,
+        dim: 'Dimension | str | None' = None,
+        scale: int | float = 0,
+        base: int | float = 10.,
+        factor: int | float = 1.,
+        name: str | None = None,
+        dispname: str | None = None,
         is_fullname: bool = True,
         display_parts=None,
     ):
@@ -1314,7 +1329,7 @@ class Unit:
         dim: Dimension,
         name: str,
         dispname: str,
-        scale: int = 0,
+        scale: int | float = 0,
         base: float = 10.,
         factor: float = 1.,
     ) -> 'Unit':
@@ -1535,7 +1550,7 @@ class Unit:
         else:
             from ._base_quantity import Quantity
             if isinstance(other, Quantity):
-                return Quantity(other.mantissa, unit=(self * other.unit))
+                return Quantity(other.mantissa, unit=(self * other.unit))  # type: ignore[arg-type]
             return Quantity(other, unit=self)
 
     def __rmul__(self, other) -> 'Unit | Quantity':
@@ -1545,7 +1560,7 @@ class Unit:
 
         from ._base_quantity import Quantity
         if isinstance(other, Quantity):
-            return Quantity(other.mantissa, unit=(other.unit * self))
+            return Quantity(other.mantissa, unit=(other.unit * self))  # type: ignore[arg-type]
         return Quantity(other, unit=self)
 
     def __imul__(self, other):

--- a/saiunit/_celsius.py
+++ b/saiunit/_celsius.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from ._base_quantity import Quantity
 from ._misc import maybe_custom_array
 from ._unit_common import kelvin
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     "celsius2kelvin",
@@ -28,13 +29,13 @@ __all__ = [
 ]
 
 
-def celsius2kelvin(celsius: jax.typing.ArrayLike) -> Quantity:
+def celsius2kelvin(celsius: ArrayLike) -> Quantity:
     """
     Convert a Celsius value to a kelvin :class:`~saiunit.Quantity`.
 
     Parameters
     ----------
-    celsius : jax.typing.ArrayLike
+    celsius : ArrayLike
         The temperature in degrees Celsius. Must not be a
         :class:`~saiunit.Quantity`.
 
@@ -64,10 +65,10 @@ def celsius2kelvin(celsius: jax.typing.ArrayLike) -> Quantity:
     celsius = maybe_custom_array(celsius)
     if isinstance(celsius, Quantity):
         raise TypeError("The input value should be not be a Quantity.")
-    return (celsius + 273.15) * kelvin
+    return (celsius + 273.15) * kelvin  # type: ignore[return-value]
 
 
-def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
+def kelvin2celsius(value: Quantity) -> ArrayLike:
     """
     Convert a kelvin :class:`~saiunit.Quantity` to a Celsius value.
 
@@ -79,7 +80,7 @@ def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
 
     Returns
     -------
-    jax.typing.ArrayLike
+    ArrayLike
         The temperature in degrees Celsius (unitless scalar or array).
 
     Raises
@@ -111,13 +112,13 @@ def kelvin2celsius(value: Quantity) -> jax.typing.ArrayLike:
     return value.to_decimal(kelvin) - 273.15
 
 
-def fahrenheit2kelvin(fahrenheit: jax.typing.ArrayLike) -> Quantity:
+def fahrenheit2kelvin(fahrenheit: ArrayLike) -> Quantity:
     """
     Convert a Fahrenheit value to a kelvin :class:`~saiunit.Quantity`.
 
     Parameters
     ----------
-    fahrenheit : jax.typing.ArrayLike
+    fahrenheit : ArrayLike
         The temperature in degrees Fahrenheit. Must not be a
         :class:`~saiunit.Quantity`.
 
@@ -139,10 +140,10 @@ def fahrenheit2kelvin(fahrenheit: jax.typing.ArrayLike) -> Quantity:
     fahrenheit = maybe_custom_array(fahrenheit)
     if isinstance(fahrenheit, Quantity):
         raise TypeError("The input value should be not be a Quantity.")
-    return ((fahrenheit - 32.0) * (5.0 / 9.0) + 273.15) * kelvin
+    return ((fahrenheit - 32.0) * (5.0 / 9.0) + 273.15) * kelvin  # type: ignore[return-value]
 
 
-def kelvin2fahrenheit(value: Quantity) -> jax.typing.ArrayLike:
+def kelvin2fahrenheit(value: Quantity) -> ArrayLike:
     """
     Convert a kelvin :class:`~saiunit.Quantity` to a Fahrenheit value.
 
@@ -154,7 +155,7 @@ def kelvin2fahrenheit(value: Quantity) -> jax.typing.ArrayLike:
 
     Returns
     -------
-    jax.typing.ArrayLike
+    ArrayLike
         The temperature in degrees Fahrenheit (unitless scalar or array).
 
     Examples

--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -44,7 +44,7 @@ if HAS_JAX:
     from jax.extend import linear_util
 
     if jax.__version_info__ < (0, 4, 38):
-        from jax.core import Primitive
+        from jax.core import Primitive  # type: ignore[attr-defined]
     else:
         from jax.extend.core import Primitive
 
@@ -78,7 +78,7 @@ if HAS_JAX:
 
 
     if jax.__version_info__ < (0, 6, 0):
-        from jax.util import safe_map, unzip2
+        from jax.util import safe_map, unzip2  # type: ignore[import-not-found]
 
     else:
 
@@ -119,7 +119,7 @@ else:
     def concrete_or_error(typ, val, context=""):  # type: ignore[no-redef]
         require_jax("concrete_or_error")
 
-    def wrap_init(fun, args, kwargs, name):  # type: ignore[no-redef]
+    def wrap_init(fun: Callable, args: tuple, kwargs: dict, name: str):  # type: ignore[no-redef]
         require_jax("wrap_init")
 
     def safe_map(f, *args):  # type: ignore[no-redef]

--- a/saiunit/_jax_compat.py
+++ b/saiunit/_jax_compat.py
@@ -48,6 +48,7 @@ __all__ = [
     "jnp",
     "Array",
     "ArrayLike",
+    "ScalarOrArrayLike",
     "DTypeLike",
     "Tracer",
     "ShapedArray",
@@ -81,8 +82,8 @@ try:
 
     HAS_JAX = True
 except ImportError:  # pragma: no cover - exercised only in no-jax CI job
-    _jax = None
-    _jnp = None
+    _jax = None  # type: ignore[assignment]
+    _jnp = None  # type: ignore[assignment]
     HAS_JAX = False
 
 
@@ -90,7 +91,15 @@ if HAS_JAX:
     jax = _jax
     jnp = _jnp
     Array = _jax.Array
-    ArrayLike = _jax.typing.ArrayLike
+    # Narrow array-like alias: types that genuinely support ``.shape`` /
+    # ``.ndim`` / ``.dtype``. Excludes bare Python scalars (``bool``, ``int``,
+    # ``float``, ``complex``) so that mypy/pyright don't emit ``union-attr``
+    # false positives when downstream code reads those attributes. Callers
+    # that want to accept Python scalars too should use :data:`ScalarOrArrayLike`.
+    ArrayLike = _jax.Array | np.ndarray | np.number | np.bool_
+    # Wide alias: everything :data:`jax.typing.ArrayLike` accepts, including
+    # bare Python scalars. Use sparingly — prefer :data:`ArrayLike`.
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex
     DTypeLike = _jax.typing.DTypeLike
     Tracer = _jax.core.Tracer
     ShapedArray = _jax.core.ShapedArray
@@ -131,7 +140,8 @@ else:
     ShapedArray = type("ShapedArray", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     ShapeDtypeStruct = type("ShapeDtypeStruct", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     DynamicJaxprTracer = type("DynamicJaxprTracer", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
-    ArrayLike = Any  # type: ignore[assignment, misc]
+    ArrayLike = np.ndarray | np.number | np.bool_  # type: ignore[misc, assignment]
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex  # type: ignore[misc]
     DTypeLike = Any  # type: ignore[assignment, misc]
 
     class TracerArrayConversionError(Exception):  # type: ignore[no-redef]
@@ -159,11 +169,11 @@ else:
         """
         yield
 
-    def result_type(*args):  # type: ignore[no-redef]
+    def result_type(*args):  # type: ignore[no-redef, misc]
         """Fallback for ``jax.dtypes.result_type`` via :func:`numpy.result_type`."""
         return np.result_type(*args)
 
-    def canonicalize_dtype(dtype):  # type: ignore[no-redef]
+    def canonicalize_dtype(dtype):  # type: ignore[no-redef, misc]
         """Fallback for ``jax.dtypes.canonicalize_dtype`` via :class:`numpy.dtype`."""
         return np.dtype(dtype)
 
@@ -245,7 +255,7 @@ else:
             return {k: _unflatten(c, leaves_iter) for k, c in zip(treedef.keys, treedef.children)}
         raise RuntimeError(f"Unknown TreeDef kind: {treedef.kind!r}")
 
-    def tree_map(f: Callable, tree_obj, *rest, is_leaf: Callable | None = None):  # type: ignore[no-redef]
+    def tree_map(f: Callable, tree_obj, *rest, is_leaf: Callable | None = None):  # type: ignore[no-redef, misc]
         """Fallback ``jax.tree.map`` over list/tuple/dict/None containers."""
         leaves, treedef = _flatten(tree_obj, is_leaf)
         rest_leaves = [_flatten(t, is_leaf)[0] for t in rest]
@@ -257,7 +267,7 @@ else:
         mapped = [f(*([leaves[i]] + [rl[i] for rl in rest_leaves])) for i in range(len(leaves))]
         return _unflatten(treedef, iter(mapped))
 
-    def tree_structure(tree_obj, is_leaf: Callable | None = None):  # type: ignore[no-redef]
+    def tree_structure(tree_obj, is_leaf: Callable | None = None):  # type: ignore[no-redef, misc]
         """Fallback ``jax.tree.structure`` returning an opaque :class:`_TreeDef`."""
         _, treedef = _flatten(tree_obj, is_leaf)
         return treedef
@@ -270,7 +280,7 @@ else:
 
     tree = _TreeNamespace()  # type: ignore[assignment]
 
-    def device_put(x, device=None):  # type: ignore[no-redef]
+    def device_put(x, device=None):  # type: ignore[no-redef, misc]
         """Reject ``jax.device_put`` calls with a clear install hint."""
         require_jax("jax.device_put")
 

--- a/saiunit/_matplotlib_compat.py
+++ b/saiunit/_matplotlib_compat.py
@@ -71,7 +71,7 @@ _CONVERSION_INTERFACE = getattr(_UNITS_MODULE, 'ConversionInterface', object) if
 _CONVERSION_ERROR = _resolve_conversion_error(_UNITS_MODULE)
 
 
-class QuantityConverter(_CONVERSION_INTERFACE):
+class QuantityConverter(_CONVERSION_INTERFACE):  # type: ignore[misc,valid-type]
     """Matplotlib converter for :class:`~saiunit.Quantity` values."""
 
     @staticmethod

--- a/saiunit/_misc.py
+++ b/saiunit/_misc.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from typing import Callable
+
 from saiunit._jax_compat import tree as _jtree
 
 CustomArray = None
@@ -53,7 +55,7 @@ def set_module_as(module: str):
     'saiunit.public'
     """
 
-    def wrapper(fun: callable):
+    def wrapper(fun: Callable):
         fun.__module__ = module
         return fun
 

--- a/saiunit/_scatter_test.py
+++ b/saiunit/_scatter_test.py
@@ -57,7 +57,7 @@ def _make_quantity(values, unit, backend_name: str) -> Quantity:
         import jax.numpy as jnp
         return Quantity(jnp.asarray(arr_np), unit=unit)
     if backend_name == "cupy":
-        import cupy as cp
+        import cupy as cp  # type: ignore[import-not-found]
         return Quantity(cp.asarray(arr_np), unit=unit)
     if backend_name == "torch":
         import torch

--- a/saiunit/_sparse_base.py
+++ b/saiunit/_sparse_base.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 
 import math
 import numbers
-from typing import Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 import numpy as np
 
 from ._jax_compat import Tracer as _Tracer
+
+if TYPE_CHECKING:
+    import jax
+    from ._base_quantity import Quantity
 
 __all__ = [
     "SparseMatrix"
@@ -87,7 +91,7 @@ class SparseMatrix:
     nse: property
     dtype: property
 
-    __hash__ = None
+    __hash__ = None  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -181,7 +185,7 @@ class SparseMatrix:
         """
         raise NotImplementedError(f"{self.__class__}.assign_data")
 
-    def sum(self, axis: Union[int, Sequence[int]] = None):
+    def sum(self, axis: Optional[Union[int, Sequence[int]]] = None):
         """
         Sum of the elements of the sparse matrix.
 

--- a/saiunit/autograd/_misc.py
+++ b/saiunit/autograd/_misc.py
@@ -59,14 +59,14 @@ def _argnums_partial(
         normalized_argnums: int | tuple[int, ...] = _normalize_index(argnums)
         argnums_tuple = (normalized_argnums,)
     else:
-        argnums_tuple = tuple(_normalize_index(i) for i in argnums)
+        argnums_tuple = tuple(_normalize_index(i) for i in argnums)  # type: ignore[assignment]
         if len(argnums_tuple) == 0:
             raise ValueError('argnums must be non-empty.')
         if len(set(argnums_tuple)) != len(argnums_tuple):
             raise ValueError(f'argnums must not contain duplicate entries, got {argnums}.')
-        normalized_argnums = argnums_tuple
+        normalized_argnums = argnums_tuple  # type: ignore[assignment]
 
-    dynamic_args = tuple(args[i] for i in argnums_tuple)
+    dynamic_args = tuple(args[i] for i in argnums_tuple)  # type: ignore[index]
     static_args = list(args)
 
     def partial_fun(*dyn_args):

--- a/saiunit/custom_array.py
+++ b/saiunit/custom_array.py
@@ -757,7 +757,7 @@ class CustomArray:
         return r
 
     def outer(self, other: ArrayLike) -> ArrayLike:
-        return math.outer(self.data, other.data)
+        return math.outer(self.data, other.data)  # type: ignore[union-attr]
 
     def abs(self) -> Optional[ArrayLike]:
         r = math.abs(self.data)

--- a/saiunit/custom_array_test.py
+++ b/saiunit/custom_array_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-import brainstate
+import brainstate  # type: ignore[import-untyped]
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -16,14 +16,14 @@ from __future__ import annotations
 
 from typing import Callable, Union, Sequence
 
-from saiunit._jax_compat import HAS_JAX, jax, jnp
+from saiunit._jax_compat import HAS_JAX, jax, jnp, ArrayLike
 import numpy as np
 
 if HAS_JAX:
     from jax.numpy import fft as jnpfft
     from jaxlib import xla_client
 else:
-    import numpy.fft as jnpfft  # type: ignore[assignment]
+    import numpy.fft as jnpfft  # type: ignore[no-redef]
     xla_client = None  # type: ignore[assignment]
 
 from saiunit import _unit_common as uc
@@ -78,12 +78,12 @@ def _calculate_fftn_dimension(
 
 @unit_change(lambda u: u * second)
 def fft(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     n: int | None = None,
     axis: int = -1,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Compute a one-dimensional discrete Fourier transform along a given axis.
 
     Unit-aware implementation of :func:`numpy.fft.fft`.  The output unit
@@ -131,12 +131,12 @@ def fft(
 
 @unit_change(lambda u: u * second)
 def rfft(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     n: int | None = None,
     axis: int = -1,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Compute a one-dimensional DFT of a real-valued array.
 
     Unit-aware implementation of :func:`numpy.fft.rfft`.  Only the
@@ -194,12 +194,12 @@ def rfft(
 
 @unit_change(lambda u: u / second)
 def ifft(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     n: int | None = None,
     axis: int = -1,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Compute a one-dimensional inverse discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.ifft`.  The output
@@ -252,12 +252,12 @@ def ifft(
 
 @unit_change(lambda u: u / second)
 def irfft(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     n: int | None = None,
     axis: int = -1,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a real-valued one-dimensional inverse DFT.
 
     Unit-aware implementation of :func:`numpy.fft.irfft`.  The output
@@ -306,12 +306,12 @@ def irfft(
 
 @unit_change(lambda u: u * (second ** 2))
 def fft2(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] = (-2, -1),
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a two-dimensional discrete Fourier transform along given axes.
 
     Unit-aware implementation of :func:`numpy.fft.fft2`.  The output
@@ -356,12 +356,12 @@ def fft2(
 
 @unit_change(lambda u: u * (second ** 2))
 def rfft2(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] = (-2, -1),
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a two-dimensional DFT of a real-valued array.
 
     Unit-aware implementation of :func:`numpy.fft.rfft2`.  Only the
@@ -406,12 +406,12 @@ def rfft2(
 
 @set_module_as('saiunit.fft')
 def fftn(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] | None = None,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Compute a multidimensional discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.fftn`.  The output
@@ -462,12 +462,12 @@ def fftn(
 
 @set_module_as('saiunit.fft')
 def rfftn(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] | None = None,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a multidimensional DFT of a real-valued array.
 
     Unit-aware implementation of :func:`numpy.fft.rfftn`.  The output
@@ -519,12 +519,12 @@ def rfftn(
 
 @unit_change(lambda u: u / (second ** 2))
 def ifft2(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] = (-2, -1),
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a two-dimensional inverse discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.ifft2`.  The output
@@ -569,12 +569,12 @@ def ifft2(
 
 @unit_change(lambda u: u / (second ** 2))
 def irfft2(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] = (-2, -1),
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a real-valued two-dimensional inverse DFT.
 
     Unit-aware implementation of :func:`numpy.fft.irfft2`.  The output
@@ -619,12 +619,12 @@ def irfft2(
 
 @set_module_as('saiunit.fft')
 def ifftn(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] | None = None,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Compute a multidimensional inverse discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.ifftn`.  The output
@@ -675,12 +675,12 @@ def ifftn(
 
 @set_module_as('saiunit.fft')
 def irfftn(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     s: Shape | None = None,
     axes: Sequence[int] | None = None,
     norm: str | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Compute a real-valued multidimensional inverse DFT.
 
     Unit-aware implementation of :func:`numpy.fft.irfftn`.  The output
@@ -784,12 +784,12 @@ def _validate_time_spacing(d: Quantity) -> None:
 @set_module_as('saiunit.fft')
 def fftfreq(
     n: int,
-    d: Union[Quantity, jax.typing.ArrayLike] = 1.0,
+    d: Union[Quantity, ArrayLike] = 1.0,  # type: ignore[assignment]
     *,
     dtype: jax.typing.DTypeLike | None = None,
     device: xla_client.Device | jax.sharding.Sharding | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Return sample frequencies for the discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.fftfreq`.  When *d*
@@ -845,12 +845,12 @@ def fftfreq(
 @set_module_as('saiunit.fft')
 def rfftfreq(
     n: int,
-    d: Union[Quantity, jax.typing.ArrayLike] = 1.0,
+    d: Union[Quantity, ArrayLike] = 1.0,  # type: ignore[assignment]
     *,
     dtype: jax.typing.DTypeLike | None = None,
     device: xla_client.Device | jax.sharding.Sharding | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Return sample frequencies for the real discrete Fourier transform.
 
     Unit-aware implementation of :func:`numpy.fft.rfftfreq`.  Only the

--- a/saiunit/fft/_fft_keep_unit.py
+++ b/saiunit/fft/_fft_keep_unit.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 
 from typing import Union, Sequence
 
-from saiunit._jax_compat import HAS_JAX, jax
+from saiunit._jax_compat import HAS_JAX, jax, ArrayLike
 
 if HAS_JAX:
     from jax.numpy import fft as jnpfft
 else:
-    import numpy.fft as jnpfft  # type: ignore[assignment]
+    import numpy.fft as jnpfft  # type: ignore[no-redef]
 
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as
@@ -40,10 +40,10 @@ __all__ = [
 
 @set_module_as('saiunit.fft')
 def fftshift(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axes: None | int | Sequence[int] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Shift zero-frequency FFT component to the center of the spectrum.
 
     Unit-aware implementation of :func:`numpy.fft.fftshift`.  The unit of
@@ -83,10 +83,10 @@ def fftshift(
 
 @set_module_as('saiunit.fft')
 def ifftshift(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axes: None | int | Sequence[int] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Inverse of :func:`saiunit.fft.fftshift`.
 
     Unit-aware implementation of :func:`numpy.fft.ifftshift`.  The unit of

--- a/saiunit/lax/_lax_accept_unitless.py
+++ b/saiunit/lax/_lax_accept_unitless.py
@@ -24,6 +24,7 @@ from saiunit._base_unit import Unit
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as
 from saiunit.math._fun_accept_unitless import _fun_accept_unitless_unary, _fun_accept_unitless_binary, _fun_unitless_binary
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     # math funcs only accept unitless (unary)
@@ -57,7 +58,7 @@ __all__ = [
 
 @set_module_as('saiunit.lax')
 def acos(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -91,7 +92,7 @@ def acos(
 
 @set_module_as('saiunit.lax')
 def acosh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -114,7 +115,7 @@ def acosh(
 
 @set_module_as('saiunit.lax')
 def asin(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -137,7 +138,7 @@ def asin(
 
 @set_module_as('saiunit.lax')
 def asinh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -160,7 +161,7 @@ def asinh(
 
 @set_module_as('saiunit.lax')
 def atan(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -183,7 +184,7 @@ def atan(
 
 @set_module_as('saiunit.lax')
 def atanh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -206,7 +207,7 @@ def atanh(
 
 @set_module_as('saiunit.lax')
 def collapse(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     start_dimension: int,
     stop_dimension: Optional[int] = None,
     unit_to_scale: Optional[Unit] = None,
@@ -240,7 +241,7 @@ def collapse(
 
 @set_module_as('saiunit.lax')
 def cumlogsumexp(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = 0,
     reverse: Optional[bool] = False,
     unit_to_scale: Optional[Unit] = None,
@@ -273,7 +274,7 @@ def cumlogsumexp(
 
 @set_module_as('saiunit.lax')
 def bessel_i0e(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -306,7 +307,7 @@ def bessel_i0e(
 
 @set_module_as('saiunit.lax')
 def bessel_i1e(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -330,7 +331,7 @@ def bessel_i1e(
 
 @set_module_as('saiunit.lax')
 def digamma(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -353,7 +354,7 @@ def digamma(
 
 @set_module_as('saiunit.lax')
 def lgamma(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -376,7 +377,7 @@ def lgamma(
 
 @set_module_as('saiunit.lax')
 def erf(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -409,7 +410,7 @@ def erf(
 
 @set_module_as('saiunit.lax')
 def erfc(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -432,7 +433,7 @@ def erfc(
 
 @set_module_as('saiunit.lax')
 def erf_inv(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -455,7 +456,7 @@ def erf_inv(
 
 @set_module_as('saiunit.lax')
 def logistic(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -490,8 +491,8 @@ def logistic(
 # ----------------------------------------
 @set_module_as('saiunit.lax')
 def atan2(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -525,8 +526,8 @@ def atan2(
 
 @set_module_as('saiunit.lax')
 def polygamma(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -551,8 +552,8 @@ def polygamma(
 
 @set_module_as('saiunit.lax')
 def igamma(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -577,8 +578,8 @@ def igamma(
 
 @set_module_as('saiunit.lax')
 def igammac(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -603,8 +604,8 @@ def igammac(
 
 @set_module_as('saiunit.lax')
 def igamma_grad_a(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -629,8 +630,8 @@ def igamma_grad_a(
 
 @set_module_as('saiunit.lax')
 def random_gamma_grad(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -655,8 +656,8 @@ def random_gamma_grad(
 
 @set_module_as('saiunit.lax')
 def zeta(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    q: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    q: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -713,9 +714,9 @@ def _fun_accept_unitless_nary(
 
 @set_module_as('saiunit.lax')
 def betainc(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
-    x: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -754,8 +755,8 @@ def betainc(
 # Elementwise bit operations (binary)
 @set_module_as('saiunit.lax')
 def shift_left(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     r"""Elementwise left shift: :math:`x \ll y`.
@@ -777,8 +778,8 @@ def shift_left(
 
 @set_module_as('saiunit.lax')
 def shift_right_arithmetic(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     r"""Elementwise arithmetic right shift: :math:`x \gg y`.
@@ -800,8 +801,8 @@ def shift_right_arithmetic(
 
 @set_module_as('saiunit.lax')
 def shift_right_logical(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     r"""Elementwise logical right shift: :math:`x \gg y`.
@@ -824,7 +825,7 @@ def shift_right_logical(
 # fft
 @set_module_as('saiunit.lax')
 def fft(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     fft_type: jax.lax.FftType | str,
     fft_lengths: Sequence[int],
     unit_to_scale: Optional[Unit] = None,

--- a/saiunit/lax/_lax_array_creation.py
+++ b/saiunit/lax/_lax_array_creation.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 from saiunit._base_unit import Unit
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
+from saiunit._jax_compat import ArrayLike
 
 Shape = Union[int, Sequence[int]]
 
@@ -38,7 +39,7 @@ __all__ = [
 # array creation (given array)
 @set_module_as('saiunit.lax')
 def zeros_like_array(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit: Optional[Unit] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -84,7 +85,7 @@ def zeros_like_array(
         if unit is not None:
             if not isinstance(unit, Unit):
                 raise TypeError('unit must be an instance of Unit.')
-            return jnp.zeros_like(x, **kwargs) * unit
+            return jnp.zeros_like(x, **kwargs) * unit  # type: ignore[return-value]
         else:
             return jnp.zeros_like(x, **kwargs)
 
@@ -130,7 +131,7 @@ def iota(
     if unit is not None:
         if not isinstance(unit, Unit):
             raise TypeError('unit must be an instance of Unit.')
-        return lax.iota(dtype, size, **kwargs) * unit
+        return lax.iota(dtype, size, **kwargs) * unit  # type: ignore[return-value]
     else:
         return lax.iota(dtype, size, **kwargs)
 
@@ -181,11 +182,11 @@ def broadcasted_iota(
         if not isinstance(unit, Unit):
             raise TypeError('unit must be an instance of Unit.')
         try:
-            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs) * unit
+            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs) * unit  # type: ignore[arg-type,misc,return-value]
         except TypeError:
-            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs) * unit
+            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs) * unit  # type: ignore[arg-type,return-value]
     else:
         try:
-            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs)
+            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs)  # type: ignore[arg-type,misc]
         except TypeError:
-            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs)
+            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs)  # type: ignore[arg-type]

--- a/saiunit/lax/_lax_change_unit.py
+++ b/saiunit/lax/_lax_change_unit.py
@@ -24,6 +24,7 @@ from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
 from saiunit.math._fun_change_unit import _fun_change_unit_unary, _fun_change_unit_binary
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     # math funcs change unit (unary)
@@ -53,7 +54,7 @@ def unit_change(
 # math funcs change unit (unary)
 @unit_change(lambda u: u ** -0.5)
 def rsqrt(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise reciprocal square root: :math:`1 \over \sqrt{x}`.
@@ -89,8 +90,8 @@ def rsqrt(
 # math funcs change unit (binary)
 @unit_change(lambda x, y: x * y)
 def conv(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     window_strides: Sequence[int],
     padding: str,
     precision: lax.PrecisionLike = None,
@@ -128,8 +129,8 @@ def conv(
 
 @unit_change(lambda x, y: x * y)
 def conv_transpose(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     strides: Sequence[int],
     padding: str | Sequence[tuple[int, int]],
     rhs_dilation: Sequence[int] | None = None,
@@ -182,8 +183,8 @@ def conv_transpose(
 
 @unit_change(lambda x, y: x / y)
 def div(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise division: :math:`x \over y`.
@@ -223,8 +224,8 @@ def div(
 
 @unit_change(lambda x, y: x * y)
 def dot_general(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     dimension_numbers: jax.lax.DotDimensionNumbers,
     precision: jax.lax.PrecisionLike = None,
     preferred_element_type: jax.typing.DTypeLike | None = None,
@@ -290,8 +291,8 @@ def dot_general(
 
 @set_module_as('saiunit.lax')
 def pow(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise power: :math:`x^y`.
@@ -336,17 +337,17 @@ def pow(
         return maybe_decimal(Quantity(jax.lax.pow(x.mantissa, y, **kwargs), unit=x.unit ** y))
     elif isinstance(y, Quantity):
         if not y.is_unitless:
-            raise TypeError(f'{jax.lax.power.__name__} only supports scalar exponent')
+            raise TypeError(f'{jax.lax.power.__name__} only supports scalar exponent')  # type: ignore[attr-defined]
         y = y.mantissa
-        return maybe_decimal(Quantity(jax.lax.pow(x, y, **kwargs), unit=x ** y))
+        return maybe_decimal(Quantity(jax.lax.pow(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
     else:
         return jax.lax.pow(x, y, **kwargs)
 
 
 @set_module_as('saiunit.lax')
 def integer_pow(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise integer power: :math:`x^y`, where :math:`y` is a fixed integer.
@@ -388,22 +389,22 @@ def integer_pow(
             if not y.is_unitless:
                 raise TypeError(f'{jax.lax.integer_pow.__name__} only supports scalar exponent')
             y = y.mantissa
-        return maybe_decimal(Quantity(jax.lax.integer_pow(x.mantissa, y, **kwargs), unit=x.unit ** y))
+        return maybe_decimal(Quantity(jax.lax.integer_pow(x.mantissa, y, **kwargs), unit=x.unit ** y))  # type: ignore[arg-type]
     elif isinstance(y, Quantity):
         if not y.is_unitless:
-            raise TypeError(f'{jax.lax.integer_power.__name__} only supports scalar exponent')
+            raise TypeError(f'{jax.lax.integer_power.__name__} only supports scalar exponent')  # type: ignore[attr-defined]
         y = y.mantissa
-        return maybe_decimal(Quantity(jax.lax.integer_pow(x, y, **kwargs), unit=x ** y))
+        return maybe_decimal(Quantity(jax.lax.integer_pow(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
     else:
-        return jax.lax.integer_pow(x, y, **kwargs)
+        return jax.lax.integer_pow(x, y, **kwargs)  # type: ignore[arg-type]
 
 
 @unit_change(lambda x, y: x * y)
 def mul(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Elementwise multiplication: :math:`x \times y`.
 
     Parameters
@@ -438,10 +439,10 @@ def mul(
 
 @set_module_as('saiunit.lax')
 def rem(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Elementwise remainder: :math:`x \bmod y`.
 
     The sign of the result is taken from the dividend,
@@ -457,7 +458,7 @@ def rem(
     if isinstance(x, Quantity) and isinstance(y, Quantity):
         return maybe_decimal(Quantity(lax.rem(x.mantissa, y.mantissa, **kwargs), unit=x.unit))
     elif isinstance(x, Quantity):
-        return maybe_decimal(Quantity(lax.rem(x.mantissa, y, **kwargs), unit=x.unit))
+        return maybe_decimal(Quantity(lax.rem(x.mantissa, y, **kwargs), unit=x.unit))  # type: ignore[arg-type]
     elif isinstance(y, Quantity):
         return maybe_decimal(Quantity(lax.rem(x, y.mantissa, **kwargs), unit=UNITLESS))
     else:
@@ -466,11 +467,11 @@ def rem(
 
 @unit_change(lambda x, y: x * y)
 def batch_matmul(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     precision: jax.lax.PrecisionLike = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Batch matrix multiplication.
 
     Parameters

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 import builtins
-from typing import Any, Union, Sequence, Callable
+from typing import Any, Union, Sequence, Callable, Optional
 
 import jax
 import numpy as np
 from jax import lax
+from saiunit._jax_compat import ArrayLike
 
 # Mirror of ``jax._src.typing.Shape`` (which has no public alias).
 # Used purely for type-hint clarity in this module.
@@ -67,7 +68,7 @@ __all__ = [
 # array manipulation
 @set_module_as('saiunit.math')
 def slice(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     start_indices: Sequence[int],
     limit_indices: Sequence[int],
     strides: Sequence[int] | None = None,
@@ -121,8 +122,8 @@ def slice(
 
 @set_module_as('saiunit.math')
 def dynamic_slice(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    start_indices: jax.typing.ArrayLike | Sequence[jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
+    start_indices: ArrayLike | Sequence[ArrayLike],
     slice_sizes: Shape,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -169,9 +170,9 @@ def dynamic_slice(
 
 @set_module_as('saiunit.math')
 def dynamic_update_slice(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    update: Union[Quantity, jax.typing.ArrayLike],
-    start_indices: jax.typing.ArrayLike | Sequence[jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
+    update: Union[Quantity, ArrayLike],
+    start_indices: ArrayLike | Sequence[ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """Wraps XLA's `DynamicUpdateSlice
@@ -218,15 +219,15 @@ def dynamic_update_slice(
 
 @set_module_as('saiunit.math')
 def gather(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    start_indices: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    start_indices: ArrayLike,
     dimension_numbers: jax.lax.GatherDimensionNumbers,
     slice_sizes: Shape,
     *,
     unique_indices: bool = False,
     indices_are_sorted: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
-    fill_value: Union[Quantity, jax.typing.ArrayLike] = None,
+    fill_value: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """Gather operator.
@@ -326,8 +327,8 @@ def gather(
 
 @set_module_as('saiunit.math')
 def index_take(
-    src: Union[Quantity, jax.typing.ArrayLike],
-    idxs: jax.typing.ArrayLike,
+    src: Union[Quantity, ArrayLike],
+    idxs: ArrayLike,
     axes: Sequence[int],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -368,7 +369,7 @@ def index_take(
 
 @set_module_as('saiunit.math')
 def slice_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     start_index: int | None,
     limit_index: int | None,
     stride: int = 1,
@@ -422,7 +423,7 @@ def slice_in_dim(
 
 @set_module_as('saiunit.math')
 def index_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     index: int,
     axis: int = 0,
     keepdims: bool = True,
@@ -473,8 +474,8 @@ def index_in_dim(
 
 @set_module_as('saiunit.math')
 def dynamic_slice_ind_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    start_index: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    start_index: ArrayLike,
     slice_size: int,
     axis: int = 0,
     **kwargs,
@@ -525,8 +526,8 @@ def dynamic_slice_ind_dim(
 
 @set_module_as('saiunit.math')
 def dynamic_index_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    index: int | jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    index: int | ArrayLike,
     axis: int = 0, keepdims: bool = True,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -572,9 +573,9 @@ def dynamic_index_in_dim(
 
 @set_module_as('saiunit.math')
 def dynamic_update_slice_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    update: Union[Quantity, jax.typing.ArrayLike],
-    start_index: jax.typing.ArrayLike, axis: int,
+    operand: Union[Quantity, ArrayLike],
+    update: Union[Quantity, ArrayLike],
+    start_index: ArrayLike, axis: int,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """Convenience wrapper around :func:`dynamic_update_slice` to update
@@ -630,9 +631,9 @@ def dynamic_update_slice_in_dim(
 
 @set_module_as('saiunit.math')
 def dynamic_update_index_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    update: Union[Quantity, jax.typing.ArrayLike],
-    index: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    update: Union[Quantity, ArrayLike],
+    index: ArrayLike,
     axis: int,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -691,7 +692,7 @@ def dynamic_update_index_in_dim(
 
 @set_module_as('saiunit.math')
 def sort(
-    operand: Union[Quantity, jax.typing.ArrayLike] | Sequence[Union[Quantity, jax.typing.ArrayLike]],
+    operand: Union[Quantity, ArrayLike] | Sequence[Union[Quantity, ArrayLike]],
     dimension: int = -1,
     is_stable: bool = True, num_keys: int = 1,
     **kwargs,
@@ -728,10 +729,10 @@ def sort(
                 units.append(op.unit)
             else:
                 mantissas.append(op)
-                units.append(None)
+                units.append(None)  # type: ignore[arg-type]
 
         # Sort the mantissas
-        sorted_mantissas = lax.sort(mantissas, dimension, is_stable, num_keys, **kwargs)
+        sorted_mantissas = lax.sort(mantissas, dimension, is_stable, num_keys, **kwargs)  # type: ignore[arg-type]
 
         # Convert back to quantities where applicable
         output = []
@@ -745,14 +746,14 @@ def sort(
         require_jax_backend("saiunit.lax.sort", operand)
         if isinstance(operand, Quantity):
             return maybe_decimal(
-                Quantity(lax.sort(operand.mantissa, dimension, is_stable, num_keys, **kwargs), unit=operand.unit))
-        return lax.sort(operand, dimension, is_stable, num_keys, **kwargs)
+                Quantity(lax.sort(operand.mantissa, dimension, is_stable, num_keys, **kwargs), unit=operand.unit))  # type: ignore[arg-type]
+        return lax.sort(operand, dimension, is_stable, num_keys, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
 def sort_key_val(
-    keys: Union[Quantity, jax.typing.ArrayLike],
-    values: Union[Quantity, jax.typing.ArrayLike],
+    keys: Union[Quantity, ArrayLike],
+    values: Union[Quantity, ArrayLike],
     dimension: int = -1,
     is_stable: bool = True,
     **kwargs,
@@ -797,21 +798,21 @@ def sort_key_val(
     keys = maybe_custom_array(keys)
     values = maybe_custom_array(values)
     if isinstance(keys, Quantity) and isinstance(values, Quantity):
-        k, v = lax.sort_key_val(keys.mantissa, values.mantissa, dimension, is_stable, **kwargs)
+        k, v = lax.sort_key_val(keys.mantissa, values.mantissa, dimension, is_stable, **kwargs)  # type: ignore[arg-type]
         return maybe_decimal(Quantity(k, unit=keys.unit)), maybe_decimal(Quantity(v, unit=values.unit))
     elif isinstance(keys, Quantity):
-        k, v = lax.sort_key_val(keys.mantissa, values, dimension, is_stable, **kwargs)
+        k, v = lax.sort_key_val(keys.mantissa, values, dimension, is_stable, **kwargs)  # type: ignore[arg-type]
         return maybe_decimal(Quantity(k, unit=keys.unit)), v
     elif isinstance(values, Quantity):
-        k, v = lax.sort_key_val(keys, values.mantissa, dimension, is_stable, **kwargs)
+        k, v = lax.sort_key_val(keys, values.mantissa, dimension, is_stable, **kwargs)  # type: ignore[arg-type]
         return k, maybe_decimal(Quantity(v, unit=values.unit))
-    return lax.sort_key_val(keys, values, dimension, is_stable, **kwargs)
+    return lax.sort_key_val(keys, values, dimension, is_stable, **kwargs)  # type: ignore[arg-type]
 
 
 # math funcs keep unit (unary)
 @set_module_as('saiunit.math')
 def neg(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise negation: :math:`-x`.
@@ -847,7 +848,7 @@ def neg(
 
 @set_module_as('saiunit.math')
 def cummax(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
@@ -888,7 +889,7 @@ def cummax(
 
 @set_module_as('saiunit.math')
 def cummin(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
@@ -929,7 +930,7 @@ def cummin(
 
 @set_module_as('saiunit.math')
 def cumsum(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
@@ -1003,9 +1004,9 @@ def _fun_lax_scatter(
 
 @set_module_as('saiunit.math')
 def scatter(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1088,9 +1089,9 @@ def scatter(
 
 @set_module_as('saiunit.math')
 def scatter_add(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1138,9 +1139,9 @@ def scatter_add(
 
 @set_module_as('saiunit.math')
 def scatter_sub(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1188,9 +1189,9 @@ def scatter_sub(
 
 @set_module_as('saiunit.math')
 def scatter_mul(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1238,9 +1239,9 @@ def scatter_mul(
 
 @set_module_as('saiunit.math')
 def scatter_min(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1288,9 +1289,9 @@ def scatter_min(
 
 @set_module_as('saiunit.math')
 def scatter_max(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
-    updates: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
+    updates: ArrayLike,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
     indices_are_sorted: bool = False,
@@ -1338,8 +1339,8 @@ def scatter_max(
 
 @set_module_as('saiunit.math')
 def scatter_apply(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    scatter_indices: jax.typing.ArrayLike,
+    operand: Union[Quantity, ArrayLike],
+    scatter_indices: ArrayLike,
     func: Callable,
     dimension_numbers: jax.lax.ScatterDimensionNumbers,
     *,
@@ -1391,13 +1392,13 @@ def scatter_apply(
     require_jax_backend("saiunit.lax.scatter_apply", operand)
     operand = maybe_custom_array(operand)
     if isinstance(operand, Quantity):
-        return maybe_decimal(Quantity(lax.scatter_apply(operand.mantissa, scatter_indices, func, dimension_numbers,
+        return maybe_decimal(Quantity(lax.scatter_apply(operand.mantissa, scatter_indices, func, dimension_numbers,  # type: ignore[arg-type]
                                                         update_shape=update_shape,
                                                         indices_are_sorted=indices_are_sorted,
                                                         unique_indices=unique_indices,
                                                         mode=mode, **kwargs), unit=operand.unit))
     else:
-        return lax.scatter_apply(operand, scatter_indices, func, dimension_numbers,
+        return lax.scatter_apply(operand, scatter_indices, func, dimension_numbers,  # type: ignore[arg-type]
                                  update_shape=update_shape,
                                  indices_are_sorted=indices_are_sorted,
                                  unique_indices=unique_indices,
@@ -1407,8 +1408,8 @@ def scatter_apply(
 # math funcs keep unit (binary)
 @set_module_as('saiunit.math')
 def complex(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise make complex number: :math:`x + jy`.
@@ -1447,8 +1448,8 @@ def complex(
 
 @set_module_as('saiunit.math')
 def pad(
-    operand: Union[Quantity, jax.typing.ArrayLike],
-    padding_value: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
+    padding_value: Union[Quantity, ArrayLike],
     padding_config: Sequence[tuple[int, int, int]],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -1476,8 +1477,8 @@ def pad(
 
 @set_module_as('saiunit.math')
 def sub(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise subtraction: :math:`x - y`.
@@ -1514,7 +1515,7 @@ def sub(
 # type conversion
 @set_module_as('saiunit.math')
 def convert_element_type(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     new_dtype: jax.typing.DTypeLike,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -1537,7 +1538,7 @@ def convert_element_type(
 
 @set_module_as('saiunit.math')
 def bitcast_convert_type(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     new_dtype: jax.typing.DTypeLike,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -1576,9 +1577,9 @@ def bitcast_convert_type(
 # math funcs keep unit (n-ary)
 @set_module_as('saiunit.math')
 def clamp(
-    min: Union[Quantity, jax.typing.ArrayLike],
-    x: Union[Quantity, jax.typing.ArrayLike],
-    max: Union[Quantity, jax.typing.ArrayLike],
+    min: Union[Quantity, ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    max: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     r"""Elementwise clamp.
@@ -1594,26 +1595,26 @@ def clamp(
     x = maybe_custom_array(x)
     max = maybe_custom_array(max)
     if all(isinstance(i, Quantity) for i in (min, x, max)):
-        unit = min.unit
-        return maybe_decimal(Quantity(lax.clamp(min.mantissa, x.to_decimal(unit), max.to_decimal(unit), **kwargs), unit=unit))
+        unit = min.unit  # type: ignore[union-attr]
+        return maybe_decimal(Quantity(lax.clamp(min.mantissa, x.to_decimal(unit), max.to_decimal(unit), **kwargs), unit=unit))  # type: ignore[union-attr]
     elif all(isinstance(i, (jax.Array, np.ndarray, np.bool_, np.number, bool, int, float, builtins.complex)) for i in
              (min, x, max)):
-        return lax.clamp(min, x, max, **kwargs)
+        return lax.clamp(min, x, max, **kwargs)  # type: ignore[arg-type]
     else:
-        raise TypeError('All inputs must be Quantity or jax.typing.ArrayLike')
+        raise TypeError('All inputs must be Quantity or ArrayLike')
 
 
 # math funcs keep unit (return Quantity and index)
 @set_module_as('saiunit.math')
 def approx_max_k(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     k: int,
     reduction_dimension: int = -1,
     recall_target: float = 0.95,
     reduction_input_size_override: int = -1,
     aggregate_to_topk: bool = True,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], jax.typing.ArrayLike]:
+) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
     """Returns max ``k`` values and their indices of the ``operand`` in an approximate manner.
 
     See https://arxiv.org/abs/2206.14286 for the algorithm details.
@@ -1660,23 +1661,23 @@ def approx_max_k(
     require_jax_backend("saiunit.lax.approx_max_k", operand)
     operand = maybe_custom_array(operand)
     if isinstance(operand, Quantity):
-        r = lax.approx_max_k(operand.mantissa, k, reduction_dimension, recall_target, reduction_input_size_override,
+        r = lax.approx_max_k(operand.mantissa, k, reduction_dimension, recall_target, reduction_input_size_override,  # type: ignore[arg-type]
                              aggregate_to_topk, **kwargs)
         return maybe_decimal(Quantity(r[0], unit=operand.unit)), r[1]
-    return lax.approx_max_k(operand, k, reduction_dimension, recall_target, reduction_input_size_override,
+    return lax.approx_max_k(operand, k, reduction_dimension, recall_target, reduction_input_size_override,  # type: ignore[arg-type]
                             aggregate_to_topk, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def approx_min_k(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     k: int,
     reduction_dimension: int = -1,
     recall_target: float = 0.95,
     reduction_input_size_override: int = -1,
     aggregate_to_topk: bool = True,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], jax.typing.ArrayLike]:
+) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
     """Returns min ``k`` values and their indices of the ``operand`` in an approximate manner.
 
     See https://arxiv.org/abs/2206.14286 for the algorithm details.
@@ -1727,19 +1728,19 @@ def approx_min_k(
     require_jax_backend("saiunit.lax.approx_min_k", operand)
     operand = maybe_custom_array(operand)
     if isinstance(operand, Quantity):
-        r = lax.approx_min_k(operand.mantissa, k, reduction_dimension, recall_target, reduction_input_size_override,
+        r = lax.approx_min_k(operand.mantissa, k, reduction_dimension, recall_target, reduction_input_size_override,  # type: ignore[arg-type]
                              aggregate_to_topk, **kwargs)
         return maybe_decimal(Quantity(r[0], unit=operand.unit)), r[1]
-    return lax.approx_min_k(operand, k, reduction_dimension, recall_target, reduction_input_size_override,
+    return lax.approx_min_k(operand, k, reduction_dimension, recall_target, reduction_input_size_override,  # type: ignore[arg-type]
                             aggregate_to_topk, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def top_k(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     k: int,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], jax.typing.ArrayLike]:
+) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
     """Returns top ``k`` values and their indices along the last axis of ``operand``.
 
     Args:
@@ -1772,7 +1773,7 @@ def top_k(
 
 # broadcasting arrays
 def broadcast(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     sizes: Sequence[int]
 ) -> Union[Quantity, jax.Array]:
     """Broadcast an array by adding new leading dimensions.
@@ -1808,7 +1809,7 @@ def broadcast(
 
 
 def broadcast_in_dim(
-    operand: Union[Quantity, jax.typing.ArrayLike],
+    operand: Union[Quantity, ArrayLike],
     shape: Shape,
     broadcast_dimensions: Sequence[int]
 ) -> Union[Quantity, jax.Array]:
@@ -1847,7 +1848,7 @@ def broadcast_in_dim(
 
 
 def broadcast_to_rank(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     rank: int
 ) -> Union[Quantity, jax.Array]:
     """Add leading dimensions of size 1 to give ``x`` rank ``rank``.

--- a/saiunit/lax/_lax_keep_unit_test.py
+++ b/saiunit/lax/_lax_keep_unit_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import brainstate as bst
+import brainstate as bst  # type: ignore[import-untyped]
 import jax.lax as lax
 import jax.numpy as jnp
 import numpy as np
@@ -226,9 +226,9 @@ class TestLaxKeepUnitWithArrayCustomArray(parameterized.TestCase):
 
 class TestLaxKeepUnitArrayManipulation(parameterized.TestCase):
     @parameterized.product(
-        [
+        [  # type: ignore[misc]
             dict(
-                shape=shape, starts=indices, limits=limit_indices, strides=strides
+                shape=shape, starts=indices, limits=limit_indices, strides=strides  # type: ignore[has-type]
             )
             for shape, indices, limit_indices, strides in [
             [(3,), (1,), (2,), None],
@@ -254,8 +254,8 @@ class TestLaxKeepUnitArrayManipulation(parameterized.TestCase):
         assert_quantity(result_q, expected, u.second)
 
     @parameterized.product(
-        [
-            dict(shape=shape, indices=indices, size_indices=size_indices)
+        [  # type: ignore[misc]
+            dict(shape=shape, indices=indices, size_indices=size_indices)  # type: ignore[has-type]
             for shape, indices, size_indices in [
             [(3,), np.array((1,)), (1,)],
             [(5, 3), (1, 1), (3, 1)],
@@ -275,8 +275,8 @@ class TestLaxKeepUnitArrayManipulation(parameterized.TestCase):
         assert_quantity(result_q, expected, u.second)
 
     @parameterized.product(
-        [
-            dict(shape=shape, indices=indices, update_shape=update_shape)
+        [  # type: ignore[misc]
+            dict(shape=shape, indices=indices, update_shape=update_shape)  # type: ignore[has-type]
             for shape, indices, update_shape in [
             [(3,), (1,), (1,)],
             [(5, 3), (1, 1), (3, 1)],
@@ -341,7 +341,7 @@ class TestLaxKeepUnitArrayManipulation(parameterized.TestCase):
         assert_quantity(result_q, expected, u.second)
 
     @parameterized.product(
-        [dict(shape=shape, idxs=idxs, axes=axes)
+        [dict(shape=shape, idxs=idxs, axes=axes)  # type: ignore[has-type,misc]
          for shape, idxs, axes in [
              [(3, 4, 5), (np.array([0, 2, 1]),), (0,)],
              [(3, 4, 5), (np.array([-1, -2]),), (0,)],
@@ -731,7 +731,7 @@ class TestLaxKeepUnit(parameterized.TestCase):
 class TestLaxKeepUnitNary(parameterized.TestCase):
 
     @parameterized.product(
-        [dict(min_shape=min_shape, operand_shape=operand_shape, max_shape=max_shape)
+        [dict(min_shape=min_shape, operand_shape=operand_shape, max_shape=max_shape)  # type: ignore[has-type,misc]
          for min_shape, operand_shape, max_shape in [
              [(), (2, 3), ()],
              [(2, 3), (2, 3), ()],

--- a/saiunit/lax/_lax_linalg.py
+++ b/saiunit/lax/_lax_linalg.py
@@ -25,6 +25,7 @@ from saiunit._base_getters import fail_for_unit_mismatch, maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
 from saiunit.math._fun_change_unit import _fun_change_unit_unary
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     # linear algebra unary
@@ -43,9 +44,9 @@ __all__ = [
 # linear algebra
 @unit_change(lambda x: x ** 0.5)
 def cholesky(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     symmetrize_input: bool = True,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     r"""Cholesky decomposition.
 
     Compute the Cholesky decomposition :math:`A = L \cdot L^H` of square
@@ -93,7 +94,7 @@ def cholesky(
 
 @set_module_as('saiunit.lax')
 def eig(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     compute_left_eigenvectors: bool = True,
     compute_right_eigenvectors: bool = True
 ) -> tuple[Array | Quantity, Array, Array] | list[Array] | tuple[Array | Quantity, Array] | tuple[Array | Quantity]:
@@ -168,7 +169,7 @@ def eig(
                                   compute_right_eigenvectors=compute_right_eigenvectors)
     else:
         if isinstance(x, Quantity):
-            w = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+            w = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,  # type: ignore[assignment]
                                compute_right_eigenvectors=compute_right_eigenvectors)
             return (maybe_decimal(Quantity(w, unit=x.unit)),)
         else:
@@ -178,7 +179,7 @@ def eig(
 
 @set_module_as('saiunit.lax')
 def eigh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     lower: bool = True,
     symmetrize_input: bool = True,
     sort_eigenvalues: bool = True,
@@ -230,17 +231,17 @@ def eigh(
     """
     x = maybe_custom_array(x)
     if isinstance(x, Quantity):
-        v, w = lax.linalg.eigh(x.mantissa, lower=lower, symmetrize_input=symmetrize_input,
+        v, w = lax.linalg.eigh(x.mantissa, lower=lower, symmetrize_input=symmetrize_input,  # type: ignore[arg-type]
                                sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index)
         return v, maybe_decimal(Quantity(w, unit=x.unit))
     else:
-        return lax.linalg.eigh(x, lower=lower, symmetrize_input=symmetrize_input,
+        return lax.linalg.eigh(x, lower=lower, symmetrize_input=symmetrize_input,  # type: ignore[arg-type]
                                sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index)
 
 
 @set_module_as('saiunit.lax')
 def hessenberg(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
 ) -> tuple[Quantity | jax.Array, jax.Array]:
     """Reduce a square matrix to upper Hessenberg form.
 
@@ -288,7 +289,7 @@ def hessenberg(
 
 @set_module_as('saiunit.lax')
 def lu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
 ) -> tuple[Quantity | jax.Array, jax.Array, jax.Array]:
     r"""LU decomposition with partial pivoting.
 
@@ -336,8 +337,8 @@ def lu(
 
 @set_module_as('saiunit.lax')
 def householder_product(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    taus: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    taus: Union[Quantity, ArrayLike],
 ) -> jax.Array:
     """Product of elementary Householder reflectors.
 
@@ -383,7 +384,7 @@ def householder_product(
     if isinstance(a, Quantity) and isinstance(taus, Quantity):
         return lax.linalg.householder_product(a.mantissa, taus.mantissa)
     elif isinstance(a, Quantity):
-        return lax.linalg.householder_product(a.mantissa, taus)
+        return lax.linalg.householder_product(a.mantissa, taus)  # type: ignore[arg-type]
     elif isinstance(taus, Quantity):
         return lax.linalg.householder_product(a, taus.mantissa)
     else:
@@ -392,7 +393,7 @@ def householder_product(
 
 @set_module_as('saiunit.lax')
 def qdwh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
 ) -> tuple[jax.Array, Quantity | jax.Array, int, bool]:
     r"""Polar decomposition via QR-based dynamically weighted Halley iteration.
 
@@ -439,7 +440,7 @@ def qdwh(
 
 @set_module_as('saiunit.lax')
 def qr(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
 ) -> tuple[jax.Array, Quantity | jax.Array]:
     r"""QR decomposition.
 
@@ -481,7 +482,7 @@ def qr(
 
 @set_module_as('saiunit.lax')
 def schur(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     compute_schur_vectors: bool = True,
     sort_eig_vals: bool = False,
     select_callable: Callable[..., Any] | None = None
@@ -535,13 +536,13 @@ def schur(
 
 @set_module_as('saiunit.lax')
 def svd(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     *,
     full_matrices: bool = True,
     compute_uv: bool = True,
     subset_by_index: tuple[int, int] | None = None,
     algorithm: jax.lax.linalg.SvdAlgorithm | None = None,
-) -> Union[Quantity, jax.typing.ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
+) -> Union[Quantity, ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
     """Singular value decomposition.
 
     Compute the SVD of a matrix.  When ``compute_uv`` is ``True``, return
@@ -603,8 +604,8 @@ def svd(
 
 @set_module_as('saiunit.lax')
 def triangular_solve(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    b: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    b: Union[Quantity, ArrayLike],
     left_side: bool = False, lower: bool = False,
     transpose_a: bool = False, conjugate_a: bool = False,
     unit_diagonal: bool = False,
@@ -662,7 +663,7 @@ def triangular_solve(
                                                                   conjugate_a=conjugate_a,
                                                                   unit_diagonal=unit_diagonal), unit=b.unit))
     elif isinstance(a, Quantity):
-        return lax.linalg.triangular_solve(a.mantissa, b, left_side=left_side,
+        return lax.linalg.triangular_solve(a.mantissa, b, left_side=left_side,  # type: ignore[arg-type]
                                            lower=lower, transpose_a=transpose_a, conjugate_a=conjugate_a,
                                            unit_diagonal=unit_diagonal)
     elif isinstance(b, Quantity):
@@ -678,7 +679,7 @@ def triangular_solve(
 
 @set_module_as('saiunit.lax')
 def tridiagonal(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     lower: bool = True,
 ) -> tuple[Quantity | jax.Array, Quantity | jax.Array, Quantity | jax.Array, jax.Array]:
     """Reduce a symmetric/Hermitian matrix to tridiagonal form.
@@ -732,10 +733,10 @@ def tridiagonal(
 
 @set_module_as('saiunit.lax')
 def tridiagonal_solve(
-    dl: Union[Quantity, jax.typing.ArrayLike],
-    d: Union[Quantity, jax.typing.ArrayLike],
-    du: Union[Quantity, jax.typing.ArrayLike],
-    b: Union[Quantity, jax.typing.ArrayLike],
+    dl: Union[Quantity, ArrayLike],
+    d: Union[Quantity, ArrayLike],
+    du: Union[Quantity, ArrayLike],
+    b: Union[Quantity, ArrayLike],
 ) -> Quantity | jax.Array:
     r"""Solve a tridiagonal linear system.
 
@@ -794,11 +795,11 @@ def tridiagonal_solve(
     if isinstance(b, Quantity):
         try:
             return maybe_decimal(
-                Quantity(lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b.mantissa), unit=b.unit))
+                Quantity(lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b.mantissa), unit=b.unit))  # type: ignore[arg-type,union-attr]
         except:
-            return Quantity(lax.linalg.tridiagonal_solve(dl, d, du, b.mantissa), unit=b.unit)
+            return Quantity(lax.linalg.tridiagonal_solve(dl, d, du, b.mantissa), unit=b.unit)  # type: ignore[arg-type]
     else:
         try:
-            return lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b)
+            return lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b)  # type: ignore[arg-type,union-attr]
         except:
-            return lax.linalg.tridiagonal_solve(dl, d, du, b)
+            return lax.linalg.tridiagonal_solve(dl, d, du, b)  # type: ignore[arg-type]

--- a/saiunit/lax/_lax_remove_unit.py
+++ b/saiunit/lax/_lax_remove_unit.py
@@ -23,6 +23,7 @@ from jax import lax
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as
 from saiunit.math._fun_remove_unit import _fun_remove_unit_unary, _fun_logic_binary
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     # math funcs remove unit (unary)
@@ -39,7 +40,7 @@ __all__ = [
 # math funcs remove unit (unary)
 @set_module_as('saiunit.lax')
 def population_count(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
 ) -> jax.Array:
     r"""Elementwise popcount: count the number of set bits in each element.
 
@@ -70,7 +71,7 @@ def population_count(
 
 @set_module_as('saiunit.lax')
 def clz(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
 ) -> jax.Array:
     r"""Elementwise count of leading zeros.
 
@@ -102,8 +103,8 @@ def clz(
 # logic funcs (binary)
 @set_module_as('saiunit.lax')
 def eq(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise equals: :math:`x = y`.
 
@@ -136,8 +137,8 @@ def eq(
 
 @set_module_as('saiunit.lax')
 def ne(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise not-equals: :math:`x \neq y`.
 
@@ -170,8 +171,8 @@ def ne(
 
 @set_module_as('saiunit.lax')
 def ge(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise greater-than-or-equals: :math:`x \geq y`.
 
@@ -204,8 +205,8 @@ def ge(
 
 @set_module_as('saiunit.lax')
 def gt(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise greater-than: :math:`x > y`.
 
@@ -238,8 +239,8 @@ def gt(
 
 @set_module_as('saiunit.lax')
 def le(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise less-than-or-equals: :math:`x \leq y`.
 
@@ -272,8 +273,8 @@ def le(
 
 @set_module_as('saiunit.lax')
 def lt(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
 ) -> Union[bool, jax.Array]:
     r"""Elementwise less-than: :math:`x < y`.
 

--- a/saiunit/lax/_misc.py
+++ b/saiunit/lax/_misc.py
@@ -22,6 +22,7 @@ from jax import lax
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
+from saiunit._jax_compat import ArrayLike
 
 __all__ = [
     'reduce', 'reduce_precision',
@@ -134,11 +135,11 @@ def reduce(
 
 
 def reduce_precision(
-    operand: Union[jax.typing.ArrayLike, Quantity, float],
+    operand: Union[ArrayLike, Quantity, float],
     exponent_bits: int,
     mantissa_bits: int,
     **kwargs,
-) -> jax.typing.ArrayLike:
+) -> ArrayLike:
     """Reduce the precision of array elements.
 
     Wraps XLA's `ReducePrecision

--- a/saiunit/linalg/_linalg_change_unit.py
+++ b/saiunit/linalg/_linalg_change_unit.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Union
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 
 from saiunit._base_unit import UNITLESS
 from saiunit._base_getters import maybe_decimal
@@ -51,7 +51,7 @@ __all__ = [
 @unit_change(lambda x: x ** 0.5)
 @set_module_as('saiunit.linalg')
 def cholesky(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     *,
     upper: bool = False,
     symmetrize_input: bool = True,
@@ -122,10 +122,10 @@ def cholesky(
 @unit_change(lambda x, y: y / x)
 @set_module_as('saiunit.linalg')
 def solve(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Solve a linear system of equations.
 
@@ -186,11 +186,11 @@ def solve(
 @unit_change(lambda x, y: y / x)
 @set_module_as('saiunit.linalg')
 def tensorsolve(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     axes: tuple[int, ...] | None = None,
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Solve the tensor equation ``a x = b`` for ``x``.
 
@@ -247,13 +247,13 @@ def tensorsolve(
 @unit_change(lambda x, y: y / x)
 @set_module_as('saiunit.linalg')
 def lstsq(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     rcond: float | None = None,
     *,
     numpy_resid: bool = False,
     **kwargs,
-) -> tuple[Union[jax.typing.ArrayLike, Quantity], jax.Array, jax.Array, jax.Array]:
+) -> tuple[Union[ArrayLike, Quantity], jax.Array, jax.Array, jax.Array]:
     """
     Return the least-squares solution to a linear equation.
 
@@ -314,7 +314,7 @@ def lstsq(
         r = jnp.linalg.lstsq(a.mantissa, b.mantissa, rcond=rcond, numpy_resid=numpy_resid, **kwargs)
         return maybe_decimal(Quantity(r[0], unit=b.unit / a.unit)), r[1], r[2], r[3]
     elif isinstance(a, Quantity):
-        r = jnp.linalg.lstsq(a.mantissa, b, rcond=rcond, numpy_resid=numpy_resid, **kwargs)
+        r = jnp.linalg.lstsq(a.mantissa, b, rcond=rcond, numpy_resid=numpy_resid, **kwargs)  # type: ignore[arg-type]
         return maybe_decimal(Quantity(r[0], unit=UNITLESS / a.unit)), r[1], r[2], r[3]
     elif isinstance(b, Quantity):
         r = jnp.linalg.lstsq(a, b.mantissa, rcond=rcond, numpy_resid=numpy_resid, **kwargs)
@@ -326,9 +326,9 @@ def lstsq(
 @unit_change(lambda u: u ** -1)
 @set_module_as('saiunit.linalg')
 def inv(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Return the inverse of a square matrix.
 
@@ -381,13 +381,13 @@ def inv(
 @unit_change(lambda u: u ** -1)
 @set_module_as('saiunit.linalg')
 def pinv(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    rtol: jax.typing.ArrayLike | None = None,
+    a: Union[ArrayLike, Quantity],
+    rtol: ArrayLike | None = None,
     hermitian: bool = False,
     *,
-    rcond: jax.typing.ArrayLike | None = None,
+    rcond: ArrayLike | None = None,
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Compute the Moore-Penrose pseudo-inverse of a matrix.
 
@@ -448,10 +448,10 @@ def pinv(
 @unit_change(lambda u: u ** -1)
 @set_module_as('saiunit.linalg')
 def tensorinv(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     ind: int = 2,
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Compute the tensor inverse of an array.
 

--- a/saiunit/linalg/_linalg_keep_unit.py
+++ b/saiunit/linalg/_linalg_keep_unit.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Union
 
-from saiunit._jax_compat import HAS_JAX, jax, jnp, Array, require_jax
+from saiunit._jax_compat import HAS_JAX, jax, jnp, Array, require_jax, ArrayLike
 
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
@@ -47,7 +47,7 @@ __all__ = [
 
 @set_module_as('saiunit.linalg')
 def norm(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     ord: int | str | None = None,
     axis: None | tuple[int, ...] | int = None,
     keepdims: bool = False,
@@ -128,7 +128,7 @@ def norm(
 
 @set_module_as('saiunit.linalg')
 def matrix_norm(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     *,
     keepdims: bool = False,
     ord: int | str = 'fro',
@@ -175,7 +175,7 @@ def matrix_norm(
 
 @set_module_as('saiunit.linalg')
 def vector_norm(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     *, axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
     ord: int | str = 2,
@@ -233,7 +233,7 @@ def vector_norm(
 
 @set_module_as('saiunit.linalg')
 def qr(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     mode: str = "reduced",
     **kwargs,
 ) -> Array | Quantity:
@@ -293,18 +293,18 @@ def qr(
             return maybe_decimal(Quantity(result, unit=a.unit))
         else:
             Q, R = result
-            return Q, maybe_decimal(Quantity(R, unit=a.unit))
+            return Q, maybe_decimal(Quantity(R, unit=a.unit))  # type: ignore[return-value]
     else:
         result = jnp.linalg.qr(a, mode=mode, **kwargs)
         if mode == "r":
-            return result
+            return result  # type: ignore[return-value]
         else:
-            return result
+            return result  # type: ignore[return-value]
 
 
 @set_module_as('saiunit.linalg')
 def svd(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     *,
     full_matrices: bool = True,
     compute_uv: bool = True,
@@ -312,7 +312,7 @@ def svd(
     subset_by_index: tuple[int, int] | None = None,
     algorithm: jax.lax.linalg.SvdAlgorithm | None = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
+) -> Union[Quantity, ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
     """Singular value decomposition.
 
     SaiUnit implementation of :func:`numpy.linalg.svd`.
@@ -408,7 +408,7 @@ def svd(
 
 @set_module_as('saiunit.linalg')
 def svdvals(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """Compute the singular values of a matrix.
@@ -442,7 +442,7 @@ def svdvals(
 
 @set_module_as('saiunit.linalg')
 def eig(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> tuple[Union[jax.Array, Quantity], Union[jax.Array, Quantity]]:
     """Compute the eigenvalues and eigenvectors of a square matrix.
@@ -483,7 +483,7 @@ def eig(
 
 @set_module_as('saiunit.linalg')
 def eigh(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     UPLO: str | None = None,
     symmetrize_input: bool = True,
     **kwargs,
@@ -539,7 +539,7 @@ def eigh(
 
 @set_module_as('saiunit.linalg')
 def eigvals(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """Compute the eigenvalues of a general matrix.
@@ -573,7 +573,7 @@ def eigvals(
 
 @set_module_as('saiunit.linalg')
 def eigvalsh(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     UPLO: str = 'L',
     *,
     symmetrize_input: bool = True,
@@ -616,9 +616,9 @@ def eigvalsh(
 
 @set_module_as('saiunit.linalg')
 def matrix_transpose(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """Transpose a matrix or stack of matrices.
 
     SaiUnit implementation of :func:`numpy.linalg.matrix_transpose`.

--- a/saiunit/linalg/_linalg_remove_unit.py
+++ b/saiunit/linalg/_linalg_remove_unit.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import (Union, Optional)
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
@@ -31,7 +31,7 @@ __all__ = [
 
 @set_module_as('saiunit.linalg')
 def cond(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     p=None,
     **kwargs,
 ) -> jax.Array:
@@ -100,10 +100,10 @@ def cond(
 
 @set_module_as('saiunit.linalg')
 def matrix_rank(
-    M: Union[jax.typing.ArrayLike, Quantity],
-    rtol: Optional[Union[jax.typing.ArrayLike, Quantity]] = None,
+    M: Union[ArrayLike, Quantity],
+    rtol: Optional[Union[ArrayLike, Quantity]] = None,
     *,
-    tol: jax.typing.ArrayLike | None = None,
+    tol: ArrayLike | None = None,
     **kwargs,
 ) -> jax.Array:
     """Compute the rank of a matrix.
@@ -176,7 +176,7 @@ def matrix_rank(
 
 @set_module_as('saiunit.linalg')
 def slogdet(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     *,
     method: str | None = None,
     **kwargs,

--- a/saiunit/math/_activation.py
+++ b/saiunit/math/_activation.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from saiunit._jax_compat import HAS_JAX, jax, require_jax
+from saiunit._jax_compat import HAS_JAX, jax, require_jax, ArrayLike
 from saiunit._jax_guard import require_jax_backend
 
 if HAS_JAX:
     from jax import nn
 else:
-    nn = None
+    nn = None  # type: ignore[assignment]
 
 from saiunit._base_getters import get_mantissa
 from saiunit._base_quantity import Quantity
@@ -42,7 +42,7 @@ __all__ = [
 
 @set_module_as('saiunit.math')
 def relu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
 ) -> Union[Quantity, jax.Array]:
     r"""Rectified linear unit activation function.
 
@@ -91,7 +91,7 @@ def relu(
 
 @set_module_as('saiunit.math')
 def relu6(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Rectified Linear Unit 6 activation function.
@@ -139,7 +139,7 @@ def relu6(
 
 @set_module_as('saiunit.math')
 def sigmoid(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Sigmoid activation function.
@@ -177,7 +177,7 @@ def sigmoid(
 
 @set_module_as('saiunit.math')
 def softplus(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Softplus activation function.
@@ -215,7 +215,7 @@ def softplus(
 
 @set_module_as('saiunit.math')
 def sparse_plus(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Sparse plus function.
@@ -263,7 +263,7 @@ def sparse_plus(
 
 @set_module_as('saiunit.math')
 def sparse_sigmoid(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Sparse sigmoid activation function.
@@ -313,7 +313,7 @@ def sparse_sigmoid(
 
 @set_module_as('saiunit.math')
 def soft_sign(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Soft-sign activation function.
@@ -351,7 +351,7 @@ def soft_sign(
 
 @set_module_as('saiunit.math')
 def silu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""SiLU (aka swish) activation function.
@@ -391,7 +391,7 @@ def silu(
 
 @set_module_as('saiunit.math')
 def swish(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Swish (aka SiLU) activation function.
@@ -431,7 +431,7 @@ def swish(
 
 @set_module_as('saiunit.math')
 def log_sigmoid(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Log-sigmoid activation function.
@@ -469,8 +469,8 @@ def log_sigmoid(
 
 @set_module_as('saiunit.math')
 def leaky_relu(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    negative_slope: jax.typing.ArrayLike = 1e-2
+    x: Union[Quantity, ArrayLike],
+    negative_slope: ArrayLike = 1e-2  # type: ignore[assignment]
 ) -> Union[Quantity, jax.Array]:
     r"""Leaky rectified linear unit activation function.
 
@@ -515,7 +515,7 @@ def leaky_relu(
 
 @set_module_as('saiunit.math')
 def hard_sigmoid(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Hard Sigmoid activation function.
@@ -553,7 +553,7 @@ def hard_sigmoid(
 
 @set_module_as('saiunit.math')
 def hard_silu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Hard SiLU (swish) activation function.
@@ -597,7 +597,7 @@ hard_swish = hard_silu
 
 @set_module_as('saiunit.math')
 def hard_tanh(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Hard :math:`\mathrm{tanh}` activation function.
@@ -639,8 +639,8 @@ def hard_tanh(
 
 @set_module_as('saiunit.math')
 def elu(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    alpha: jax.typing.ArrayLike = 1.0,
+    x: Union[Quantity, ArrayLike],
+    alpha: ArrayLike = 1.0,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Exponential linear unit activation function.
@@ -685,8 +685,8 @@ def elu(
 
 @set_module_as('saiunit.math')
 def celu(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    alpha: jax.typing.ArrayLike = 1.0,
+    x: Union[Quantity, ArrayLike],
+    alpha: ArrayLike = 1.0,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Continuously-differentiable exponential linear unit activation.
@@ -733,7 +733,7 @@ def celu(
 
 @set_module_as('saiunit.math')
 def selu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Scaled exponential linear unit activation.
@@ -781,7 +781,7 @@ def selu(
 
 @set_module_as('saiunit.math')
 def gelu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     approximate: bool = True,
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
@@ -832,7 +832,7 @@ def gelu(
 
 @set_module_as('saiunit.math')
 def glu(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: int = -1,
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
@@ -880,8 +880,8 @@ def glu(
 
 @set_module_as('saiunit.math')
 def squareplus(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    b: jax.typing.ArrayLike = 4,
+    x: Union[Quantity, ArrayLike],
+    b: ArrayLike = 4,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Squareplus activation function.
@@ -923,7 +923,7 @@ def squareplus(
 
 @set_module_as('saiunit.math')
 def mish(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
 ) -> jax.Array:
     r"""Mish activation function.

--- a/saiunit/math/_einops.py
+++ b/saiunit/math/_einops.py
@@ -22,9 +22,9 @@ import operator
 from collections import OrderedDict
 from typing import Set, Tuple, List, Dict, Union, Callable, Optional, Sequence, TypeVar
 
-from saiunit._jax_compat import jax, jnp, ArrayLike as _ArrayLike
+from saiunit._jax_compat import jax, jnp, ArrayLike
 import numpy as np
-import opt_einsum
+import opt_einsum  # type: ignore[import-untyped]
 
 from saiunit._base_unit import UNITLESS
 from saiunit._base_quantity import Quantity
@@ -45,7 +45,7 @@ __all__ = [
     'einsum',
 ]
 
-ReductionCallable = Callable[[_ArrayLike, Tuple[int, ...]], _ArrayLike]
+ReductionCallable = Callable[[ArrayLike, Tuple[int, ...]], ArrayLike]
 Reduction = Union[str, ReductionCallable]
 
 _reductions = ("min", "max", "sum", "mean", "prod", "any", "all")
@@ -56,18 +56,18 @@ _unknown_axis_length = -999999
 _expected_axis_length = -99999
 
 
-def is_float_type(x: jax.typing.ArrayLike):
+def is_float_type(x: ArrayLike):
     return x.dtype in ("float16", "float32", "float64", "float128", "bfloat16")
 
 
-def add_axis(x: jax.typing.ArrayLike, new_position: int):
+def add_axis(x: ArrayLike, new_position: int):
     return expand_dims(asarray(x), new_position)
 
 
-def add_axes(x: jax.typing.ArrayLike, n_axes, pos2len):
+def add_axes(x: 'ArrayLike | Quantity', n_axes, pos2len):
     repeats = [1] * n_axes
     for axis_position, axis_length in pos2len.items():
-        x = add_axis(x, axis_position)
+        x = add_axis(x, axis_position)  # type: ignore[arg-type]
         repeats[axis_position] = axis_length
     return tile(x, repeats)
 
@@ -98,7 +98,7 @@ def _reduce_axes(tensor, reduction_type: Reduction, reduced_axes: List[int]):
         return __reduce(tensor, reduction_type, tuple(reduced_axes))
 
 
-def __reduce(x: jax.typing.ArrayLike, operation: str, reduced_axes):
+def __reduce(x: ArrayLike, operation: str, reduced_axes):
     if operation == "min":
         return x.min(axis=reduced_axes)
     elif operation == "max":
@@ -230,7 +230,7 @@ class TransformRecipe:
 
 def _reconstruct_from_shape_uncached(
     self: TransformRecipe,
-    shape: List[int],
+    shape: Sequence[int],
     axes_dims: FakeHashableAxesLengths
 ) -> CookedRecipe:
     """
@@ -254,8 +254,8 @@ def _reconstruct_from_shape_uncached(
             continue
 
         known_product = 1
-        for axis in known_axes:
-            known_product *= axes_lengths[axis]
+        for known_axis in known_axes:
+            known_product *= axes_lengths[known_axis]
 
         if len(unknown_axes) == 0:
             if isinstance(length, int) and isinstance(known_product, int) and length != known_product:
@@ -307,17 +307,17 @@ _reconstruct_from_shape = functools.lru_cache(1024)(_reconstruct_from_shape_unca
 
 def _apply_recipe(
     recipe: TransformRecipe,
-    x: jax.typing.ArrayLike | Quantity,
+    x: 'ArrayLike | Quantity | Sequence[ArrayLike] | Sequence[Quantity]',
     reduction_type: Reduction,
     axes_lengths: HashableAxesLengths
-) -> jax.typing.ArrayLike | Quantity:
+) -> 'ArrayLike | Quantity':
     # this method implements actual work for all backends for 3 operations
     try:
         init_shapes, axes_reordering, reduced_axes, added_axes, final_shapes, n_axes_w_added = (
             _reconstruct_from_shape(recipe, _get_shape(x), axes_lengths))
     except TypeError:
         # shape or one of passed axes lengths is not hashable (i.e. they are symbols)
-        _result = _reconstruct_from_shape_uncached(recipe, _get_shape(x), axes_lengths)
+        _result = _reconstruct_from_shape_uncached(recipe, _get_shape(x), axes_lengths)  # type: ignore[arg-type]
         (init_shapes, axes_reordering, reduced_axes, added_axes, final_shapes, n_axes_w_added) = _result
     if init_shapes is not None:
         x = reshape(x, init_shapes)
@@ -326,10 +326,10 @@ def _apply_recipe(
     if len(reduced_axes) > 0:
         x = _reduce_axes(x, reduction_type=reduction_type, reduced_axes=reduced_axes)
     if len(added_axes) > 0:
-        x = add_axes(x, n_axes=n_axes_w_added, pos2len=added_axes)
+        x = add_axes(x, n_axes=n_axes_w_added, pos2len=added_axes)  # type: ignore[arg-type]
     if final_shapes is not None:
         x = reshape(asarray(x), final_shapes)
-    return x
+    return x  # type: ignore[return-value]
 
 
 @functools.lru_cache(256)
@@ -380,7 +380,7 @@ def _prepare_transformation_recipe(
             raise EinopsError(f"Wrong shape: expected >={n_other_dims} dims. Received {ndim}-dim tensor.")
         ellipsis_ndim = ndim - n_other_dims
         ell_axes = [_ellipsis + str(i) for i in range(ellipsis_ndim)]
-        left_composition = []
+        left_composition: list = []
         for composite_axis in left.composition:
             if composite_axis == _ellipsis:
                 for axis in ell_axes:
@@ -388,7 +388,7 @@ def _prepare_transformation_recipe(
             else:
                 left_composition.append(composite_axis)
 
-        rght_composition = []
+        rght_composition: list = []
         for composite_axis in rght.composition:
             if composite_axis == _ellipsis:
                 for axis in ell_axes:
@@ -519,11 +519,11 @@ def _get_shape(x) -> Tuple[int, ...]:
 
 @set_module_as('brainstate.math')
 def einreduce(
-    x: Union[jax.typing.ArrayLike, Quantity, Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    x: Union[ArrayLike, Quantity, Sequence[ArrayLike], Sequence[Quantity]],
     pattern: str,
     reduction: Reduction,
     **axes_lengths: int
-) -> jax.typing.ArrayLike | Quantity:
+) -> ArrayLike | Quantity:
     """Combine reordering and reduction using reader-friendly notation.
 
     ``einreduce`` provides combination of reordering and reduction using
@@ -578,10 +578,10 @@ def einreduce(
 
 @set_module_as('brainstate.math')
 def einrearrange(
-    x: Union[jax.typing.ArrayLike, Quantity, Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    x: Union[ArrayLike, Quantity, Sequence[ArrayLike], Sequence[Quantity]],
     pattern: str,
     **axes_lengths
-) -> jax.typing.ArrayLike | Quantity:
+) -> ArrayLike | Quantity:
     """Reader-friendly smart element reordering for multidimensional tensors.
 
     This operation includes functionality of transpose (axes permutation),
@@ -622,10 +622,10 @@ def einrearrange(
 
 @set_module_as('brainstate.math')
 def einrepeat(
-    x: Union[jax.typing.ArrayLike, Quantity, Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    x: Union[ArrayLike, Quantity, Sequence[ArrayLike], Sequence[Quantity]],
     pattern: str,
     **axes_lengths
-) -> jax.typing.ArrayLike | Quantity:
+) -> ArrayLike | Quantity:
     """Reorder elements and repeat them in arbitrary combinations.
 
     This operation includes functionality of repeat, tile, and broadcast
@@ -665,7 +665,7 @@ def einrepeat(
 
 @set_module_as('brainstate.math')
 def einshape(
-    x: jax.typing.ArrayLike | Quantity,
+    x: ArrayLike | Quantity,
     pattern: str
 ) -> dict:
     """Parse a tensor shape to a dictionary mapping axis names to their lengths.
@@ -779,18 +779,18 @@ def _sum_uniques(operand, names, uniques, preferred_element_type):
 
 
 def _dot_general(
-    lhs: jax.typing.ArrayLike | Quantity,
-    rhs: jax.typing.ArrayLike | Quantity,
+    lhs: ArrayLike | Quantity,
+    rhs: ArrayLike | Quantity,
     dimension_numbers: jax.lax.DotDimensionNumbers,
     precision: jax.lax.PrecisionLike = None,
     preferred_element_type: jax.typing.DTypeLike | None = None
 ) -> jax.Array | Quantity:
     unit = UNITLESS
     if isinstance(lhs, Quantity):
-        unit = unit * lhs.unit
+        unit = unit * lhs.unit  # type: ignore[assignment]
         lhs = lhs.mantissa
     if isinstance(rhs, Quantity):
-        unit = unit * rhs.unit
+        unit = unit * rhs.unit  # type: ignore[assignment]
         rhs = rhs.mantissa
     r = jax.lax.dot_general(
         lhs,

--- a/saiunit/math/_einops_test.py
+++ b/saiunit/math/_einops_test.py
@@ -22,6 +22,7 @@ import saiunit as u
 from saiunit._base_getters import assert_quantity
 from saiunit.math._einops import einrearrange, einreduce, einrepeat, _enumerate_directions
 from saiunit.math._einops_parsing import EinopsError
+from saiunit._jax_compat import ArrayLike
 
 
 class Array(u.CustomArray):
@@ -575,7 +576,7 @@ class TestEinopsWithArrayCustomArray:
 
         # Test with dimensionless array
         result_dimensionless = einrearrange(self.dimensionless_array, "h w -> (h w)")
-        assert isinstance(result_dimensionless, jax.typing.ArrayLike)
+        assert isinstance(result_dimensionless, ArrayLike)
         expected_dimensionless = jnp.array([1.0, 2.0, 3.0, 4.0])
         assert jnp.allclose(result_dimensionless, expected_dimensionless)
 

--- a/saiunit/math/_exprel.py
+++ b/saiunit/math/_exprel.py
@@ -38,10 +38,10 @@ if HAS_JAX:
 
     from saiunit._compatible_import import Primitive
 else:
-    core = None
-    ad = None
-    batching = None
-    mlir = None
+    core = None  # type: ignore[assignment]
+    ad = None  # type: ignore[assignment]
+    batching = None  # type: ignore[assignment]
+    mlir = None  # type: ignore[assignment]
     Primitive = None
 
 __all__ = ['exprel', 'set_exprel_order']

--- a/saiunit/math/_exprel_test.py
+++ b/saiunit/math/_exprel_test.py
@@ -29,7 +29,7 @@ Tests cover:
 # import os
 # os.environ['JAX_ENABLE_X64'] = 'True'
 
-import brainstate
+import brainstate  # type: ignore[import-untyped]
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/saiunit/math/_fun_accept_unitless.py
+++ b/saiunit/math/_fun_accept_unitless.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Union, Optional, Tuple, Any, Callable
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 
 from saiunit._backend import get_backend
 from saiunit._base_unit import Unit
@@ -87,8 +87,8 @@ def _unit_to_scale_without_quantity_message(func: Callable, x: Any) -> str:
 
 
 def _fun_accept_unitless_unary(
-    func: Callable,
-    x: jax.typing.ArrayLike | Quantity,
+    func: Callable | str,
+    x: ArrayLike | Quantity,
     *args,
     unit_to_scale: Optional[Unit] = None,
     **kwargs
@@ -100,7 +100,7 @@ def _fun_accept_unitless_unary(
     if isinstance(x, Quantity):
         if unit_to_scale is None:
             if not x.dim.is_dimensionless:
-                raise TypeError(_dimensionless_required_message(func, x, arg_name='x'))
+                raise TypeError(_dimensionless_required_message(func, x, arg_name='x'))  # type: ignore[arg-type]
             x = x.to_decimal()
         else:
             if not isinstance(unit_to_scale, Unit):
@@ -108,18 +108,18 @@ def _fun_accept_unitless_unary(
             x = x.to_decimal(unit_to_scale)
         xp = get_backend(x)
         func = _resolve_op(func, xp)
-        return func(x, *args, **kwargs)
+        return func(x, *args, **kwargs)  # type: ignore[operator]
     else:
         if unit_to_scale is not None:
-            raise TypeError(_unit_to_scale_without_quantity_message(func, x))
+            raise TypeError(_unit_to_scale_without_quantity_message(func, x))  # type: ignore[arg-type]
         xp = get_backend(x)
         func = _resolve_op(func, xp)
-        return func(x, *args, **kwargs)
+        return func(x, *args, **kwargs)  # type: ignore[operator]
 
 
 @set_module_as('saiunit.math')
 def exprel(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -148,7 +148,7 @@ def exprel(
 
 @set_module_as('saiunit.math')
 def exp(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -185,7 +185,7 @@ def exp(
 
 @set_module_as('saiunit.math')
 def exp2(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -218,7 +218,7 @@ def exp2(
 
 @set_module_as('saiunit.math')
 def expm1(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -251,7 +251,7 @@ def expm1(
 
 @set_module_as('saiunit.math')
 def log(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -284,7 +284,7 @@ def log(
 
 @set_module_as('saiunit.math')
 def log10(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -317,7 +317,7 @@ def log10(
 
 @set_module_as('saiunit.math')
 def log1p(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -352,7 +352,7 @@ def log1p(
 
 @set_module_as('saiunit.math')
 def log2(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -385,7 +385,7 @@ def log2(
 
 @set_module_as('saiunit.math')
 def arccos(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -418,7 +418,7 @@ def arccos(
 
 @set_module_as('saiunit.math')
 def arccosh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -451,7 +451,7 @@ def arccosh(
 
 @set_module_as('saiunit.math')
 def arcsin(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -484,7 +484,7 @@ def arcsin(
 
 @set_module_as('saiunit.math')
 def arcsinh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -517,7 +517,7 @@ def arcsinh(
 
 @set_module_as('saiunit.math')
 def arctan(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -550,7 +550,7 @@ def arctan(
 
 @set_module_as('saiunit.math')
 def arctanh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -583,7 +583,7 @@ def arctanh(
 
 @set_module_as('saiunit.math')
 def cos(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -616,7 +616,7 @@ def cos(
 
 @set_module_as('saiunit.math')
 def cosh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -649,7 +649,7 @@ def cosh(
 
 @set_module_as('saiunit.math')
 def sin(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -682,7 +682,7 @@ def sin(
 
 @set_module_as('saiunit.math')
 def sinc(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -715,7 +715,7 @@ def sinc(
 
 @set_module_as('saiunit.math')
 def sinh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -748,7 +748,7 @@ def sinh(
 
 @set_module_as('saiunit.math')
 def tan(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -781,7 +781,7 @@ def tan(
 
 @set_module_as('saiunit.math')
 def tanh(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -814,7 +814,7 @@ def tanh(
 
 @set_module_as('saiunit.math')
 def deg2rad(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -847,7 +847,7 @@ def deg2rad(
 
 @set_module_as('saiunit.math')
 def rad2deg(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -880,7 +880,7 @@ def rad2deg(
 
 @set_module_as('saiunit.math')
 def degrees(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -913,7 +913,7 @@ def degrees(
 
 @set_module_as('saiunit.math')
 def radians(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -946,7 +946,7 @@ def radians(
 
 @set_module_as('saiunit.math')
 def angle(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -979,7 +979,7 @@ def angle(
 
 @set_module_as('saiunit.math')
 def frexp(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> Tuple[jax.Array, jax.Array]:
@@ -1023,9 +1023,9 @@ def frexp(
 
 
 def _fun_accept_unitless_binary(
-    func: Callable,
-    x: jax.typing.ArrayLike | Quantity,
-    y: jax.typing.ArrayLike | Quantity,
+    func: Callable | str,
+    x: ArrayLike | Quantity,
+    y: ArrayLike | Quantity,
     *args,
     unit_to_scale: Optional[Unit] = None,
     **kwargs
@@ -1038,7 +1038,7 @@ def _fun_accept_unitless_binary(
     if isinstance(x, Quantity):
         if unit_to_scale is None:
             if not x.dim.is_dimensionless:
-                raise TypeError(_dimensionless_required_message(func, x, arg_name='x'))
+                raise TypeError(_dimensionless_required_message(func, x, arg_name='x'))  # type: ignore[arg-type]
             x = x.to_decimal()
         else:
             if not isinstance(unit_to_scale, Unit):
@@ -1047,7 +1047,7 @@ def _fun_accept_unitless_binary(
     if isinstance(y, Quantity):
         if unit_to_scale is None:
             if not y.dim.is_dimensionless:
-                raise TypeError(_dimensionless_required_message(func, y, arg_name='y'))
+                raise TypeError(_dimensionless_required_message(func, y, arg_name='y'))  # type: ignore[arg-type]
             y = y.to_decimal()
         else:
             if not isinstance(unit_to_scale, Unit):
@@ -1055,13 +1055,13 @@ def _fun_accept_unitless_binary(
             y = y.to_decimal(unit_to_scale)
     xp = get_backend(x, y)
     func = _resolve_op(func, xp)
-    return func(x, y, *args, **kwargs)
+    return func(x, y, *args, **kwargs)  # type: ignore[operator]
 
 
 @set_module_as('saiunit.math')
 def hypot(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1098,8 +1098,8 @@ def hypot(
 
 @set_module_as('saiunit.math')
 def arctan2(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1135,8 +1135,8 @@ def arctan2(
 
 @set_module_as('saiunit.math')
 def logaddexp(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1173,8 +1173,8 @@ def logaddexp(
 
 @set_module_as('saiunit.math')
 def logaddexp2(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1211,8 +1211,8 @@ def logaddexp2(
 
 @set_module_as('saiunit.math')
 def corrcoef(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    y: Union[jax.typing.ArrayLike, Quantity] = None,
+    x: Union[ArrayLike, Quantity],
+    y: Optional[Union[ArrayLike, Quantity]] = None,
     rowvar: bool = True,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
@@ -1250,13 +1250,13 @@ def corrcoef(
     R : ndarray
       The correlation coefficient matrix of the variables.
     """
-    return _fun_accept_unitless_binary('corrcoef', x, y, rowvar=rowvar, unit_to_scale=unit_to_scale, **kwargs)
+    return _fun_accept_unitless_binary('corrcoef', x, y, rowvar=rowvar, unit_to_scale=unit_to_scale, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
 def correlate(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    v: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    v: Union[ArrayLike, Quantity],
     mode: str = 'valid',
     *,
     precision: Any = None,
@@ -1311,13 +1311,13 @@ def correlate(
 
 @set_module_as('saiunit.math')
 def cov(
-    m: Union[jax.typing.ArrayLike, Quantity],
-    y: Optional[Union[jax.typing.ArrayLike, Quantity]] = None,
+    m: Union[ArrayLike, Quantity],
+    y: Optional[Union[ArrayLike, Quantity]] = None,
     rowvar: bool = True,
     bias: bool = False,
     ddof: Optional[int] = None,
-    fweights: Optional[jax.typing.ArrayLike] = None,
-    aweights: Optional[jax.typing.ArrayLike] = None,
+    fweights: Optional[ArrayLike] = None,
+    aweights: Optional[ArrayLike] = None,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1374,7 +1374,7 @@ def cov(
       The covariance matrix of the variables.
     """
     return _fun_accept_unitless_binary(
-        'cov', m, y,
+        'cov', m, y,  # type: ignore[arg-type]
         rowvar=rowvar, bias=bias, ddof=ddof, fweights=fweights,
         aweights=aweights, unit_to_scale=unit_to_scale,
         **kwargs,
@@ -1383,10 +1383,10 @@ def cov(
 
 @set_module_as('saiunit.math')
 def ldexp(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: jax.typing.ArrayLike,
+    x: Union[Quantity, ArrayLike],
+    y: ArrayLike,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Returns x * 2**y, element-wise.
 
@@ -1424,7 +1424,7 @@ def ldexp(
 
 @set_module_as('saiunit.math')
 def bitwise_not(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1456,7 +1456,7 @@ def bitwise_not(
 
 @set_module_as('saiunit.math')
 def invert(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1511,8 +1511,8 @@ def _fun_unitless_binary(func, x, y, *args, **kwargs):
 
 @set_module_as('saiunit.math')
 def bitwise_and(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1547,8 +1547,8 @@ def bitwise_and(
 
 @set_module_as('saiunit.math')
 def bitwise_or(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1583,8 +1583,8 @@ def bitwise_or(
 
 @set_module_as('saiunit.math')
 def bitwise_xor(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1619,8 +1619,8 @@ def bitwise_xor(
 
 @set_module_as('saiunit.math')
 def left_shift(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """
@@ -1654,8 +1654,8 @@ def left_shift(
 
 @set_module_as('saiunit.math')
 def right_shift(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array:
     """

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import (Union, Optional, List, Any, Tuple)
 
-from saiunit._jax_compat import jax, jnp, Array
+from saiunit._jax_compat import jax, jnp, Array, ArrayLike
 import numpy as np
 
 from saiunit._backend import get_backend, get_default_backend
@@ -397,10 +397,10 @@ def zeros(
 
 @set_module_as('saiunit.math')
 def full_like(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    fill_value: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    fill_value: Union[Quantity, ArrayLike],
     dtype: Optional[jax.typing.DTypeLike] = None,
-    shape: Shape = None
+    shape: Shape | None = None
 ) -> Union[Quantity, jax.Array]:
     """
     Return a new quantity or array with the same shape and type as a given array, filled with ``fill_value``.
@@ -478,7 +478,7 @@ def full_like(
 
 @set_module_as('saiunit.math')
 def diag(
-    v: Union[Quantity, jax.typing.ArrayLike],
+    v: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
@@ -537,7 +537,7 @@ def diag(
 
 @set_module_as('saiunit.math')
 def tril(
-    m: Union[Quantity, jax.typing.ArrayLike],
+    m: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
@@ -591,7 +591,7 @@ def tril(
 
 @set_module_as('saiunit.math')
 def triu(
-    m: Union[Quantity, jax.typing.ArrayLike],
+    m: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
@@ -649,9 +649,9 @@ def triu(
 
 @set_module_as('saiunit.math')
 def empty_like(
-    prototype: Union[Quantity, jax.typing.ArrayLike],
+    prototype: Union[Quantity, ArrayLike],
     dtype: Optional[jax.typing.DTypeLike] = None,
-    shape: Shape = None,
+    shape: Shape | None = None,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
     """
@@ -703,9 +703,9 @@ def empty_like(
 
 @set_module_as('saiunit.math')
 def ones_like(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     dtype: Optional[jax.typing.DTypeLike] = None,
-    shape: Shape = None,
+    shape: Shape | None = None,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
     """
@@ -757,9 +757,9 @@ def ones_like(
 
 @set_module_as('saiunit.math')
 def zeros_like(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     dtype: Optional[jax.typing.DTypeLike] = None,
-    shape: Shape = None,
+    shape: Shape | None = None,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, jax.Array]:
     """
@@ -884,7 +884,7 @@ def asarray(
         unit = leaf_unit
 
     # reconstruct mantissa
-    a = treedef.unflatten([leaf.mantissa for leaf in leaves])
+    a = treedef.unflatten([leaf.mantissa for leaf in leaves])  # type: ignore[attr-defined]
     a = _default_xp().asarray(a, dtype=dtype, order=order)
 
     # returns
@@ -898,9 +898,9 @@ array = asarray
 
 @set_module_as('saiunit.math')
 def arange(
-    start: Union[Quantity, jax.typing.ArrayLike] = None,
-    stop: Optional[Union[Quantity, jax.typing.ArrayLike]] = None,
-    step: Optional[Union[Quantity, jax.typing.ArrayLike]] = None,
+    start: Optional[Union[Quantity, ArrayLike]] = None,
+    stop: Optional[Union[Quantity, ArrayLike]] = None,
+    step: Optional[Union[Quantity, ArrayLike]] = None,
     dtype: Optional[jax.typing.DTypeLike] = None
 ) -> Union[Quantity, jax.Array]:
     """
@@ -975,8 +975,8 @@ def arange(
 
 @set_module_as('saiunit.math')
 def linspace(
-    start: Union[Quantity, jax.typing.ArrayLike],
-    stop: Union[Quantity, jax.typing.ArrayLike],
+    start: Union[Quantity, ArrayLike],
+    stop: Union[Quantity, ArrayLike],
     num: int = 50,
     endpoint: Optional[bool] = True,
     retstep: Optional[bool] = False,
@@ -1047,8 +1047,8 @@ def linspace(
 
 @set_module_as('saiunit.math')
 def logspace(
-    start: jax.typing.ArrayLike,
-    stop: jax.typing.ArrayLike,
+    start: ArrayLike,
+    stop: ArrayLike,
     num: Optional[int] = 50,
     endpoint: Optional[bool] = True,
     base: Optional[float] = 10.0,
@@ -1117,8 +1117,8 @@ def logspace(
 
 @set_module_as('saiunit.math')
 def fill_diagonal(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    val: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    val: Union[Quantity, ArrayLike],
     wrap: Optional[bool] = False,
     inplace: Optional[bool] = False
 ) -> Union[Quantity, jax.Array]:
@@ -1176,7 +1176,7 @@ def fill_diagonal(
 
 @set_module_as('saiunit.math')
 def meshgrid(
-    *xi: Union[Quantity, jax.typing.ArrayLike],
+    *xi: Union[Quantity, ArrayLike],
     copy: Optional[bool] = True,
     sparse: Optional[bool] = False,
     indexing: Optional[str] = 'xy'
@@ -1244,7 +1244,7 @@ def meshgrid(
 
 @set_module_as('saiunit.math')
 def vander(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     N: Optional[bool] = None,
     increasing: Optional[bool] = False,
     unit: Unit = UNITLESS
@@ -1316,7 +1316,7 @@ def tril_indices(n, k=0, m=None):
 
 @set_module_as('saiunit.math')
 def tril_indices_from(
-    arr: Union[Quantity, jax.typing.ArrayLike],
+    arr: Union[Quantity, ArrayLike],
     k: Optional[int] = 0
 ) -> Tuple[jax.Array, jax.Array]:
     """
@@ -1356,7 +1356,7 @@ def triu_indices(n, k=0, m=None):
 
 @set_module_as('saiunit.math')
 def triu_indices_from(
-    arr: Union[Quantity, jax.typing.ArrayLike],
+    arr: Union[Quantity, ArrayLike],
     k: Optional[int] = 0
 ) -> Tuple[jax.Array, jax.Array]:
     """

--- a/saiunit/math/_fun_change_unit.py
+++ b/saiunit/math/_fun_change_unit.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Union, Optional, Tuple, Any, Callable
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 
 from saiunit._backend import get_backend
 from saiunit._base_unit import UNITLESS
@@ -72,7 +72,7 @@ def unit_change(
 
 @unit_change(lambda u: u ** -1)
 def reciprocal(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -107,13 +107,13 @@ def reciprocal(
 
 @unit_change(lambda u: u ** 2)
 def var(
-    a: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
     axis: Optional[Union[int, Sequence[int]]] = None,
     dtype: Optional[Any] = None,
     ddof: int = 0,
     keepdims: bool = False,
     *,
-    where: Optional[jax.typing.ArrayLike] = None,
+    where: Optional[ArrayLike] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -173,12 +173,12 @@ def var(
 
 @unit_change(lambda u: u ** 2)
 def nanvar(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[Union[int, Sequence[int]]] = None,
     dtype: Optional[Any] = None,
     ddof: int = 0,
     keepdims: bool = False,
-    where: Optional[jax.typing.ArrayLike] = None,
+    where: Optional[ArrayLike] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -237,7 +237,7 @@ def nanvar(
 
 @unit_change(lambda u: u ** 0.5)
 def sqrt(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -271,7 +271,7 @@ def sqrt(
 
 @unit_change(lambda u: u ** (1 / 3))
 def cbrt(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -305,7 +305,7 @@ def cbrt(
 
 @unit_change(lambda u: u ** 2)
 def square(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -339,12 +339,12 @@ def square(
 
 @set_module_as('saiunit.math')
 def prod(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     dtype: Optional[jax.typing.DTypeLike] = None,
     keepdims: Optional[bool] = False,
-    initial: Union[Quantity, jax.typing.ArrayLike] = None,
-    where: Union[Quantity, jax.typing.ArrayLike] = None,
+    initial: Optional[Union[Quantity, ArrayLike]] = None,
+    where: Optional[Union[Quantity, ArrayLike]] = None,
     promote_integers: bool = True,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -402,20 +402,20 @@ def prod(
         return jnp.prod(x,
                         axis=axis,
                         dtype=dtype,
-                        keepdims=keepdims,
-                        initial=initial,
-                        where=where,
+                        keepdims=keepdims,  # type: ignore[arg-type]
+                        initial=initial,  # type: ignore[arg-type]
+                        where=where,  # type: ignore[arg-type]
                         promote_integers=promote_integers, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def nanprod(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     dtype: Optional[jax.typing.DTypeLike] = None,
     keepdims: bool = False,
-    initial: Union[Quantity, jax.typing.ArrayLike] = None,
-    where: Union[Quantity, jax.typing.ArrayLike] = None,
+    initial: Optional[Union[Quantity, ArrayLike]] = None,
+    where: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
 ):
     """
@@ -470,8 +470,8 @@ def nanprod(
                            axis=axis,
                            dtype=dtype,
                            keepdims=keepdims,
-                           initial=initial,
-                           where=where, **kwargs)
+                           initial=initial,  # type: ignore[arg-type]
+                           where=where, **kwargs)  # type: ignore[arg-type]
 
 
 product = prod
@@ -479,11 +479,11 @@ product = prod
 
 @set_module_as('saiunit.math')
 def cumprod(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Return the cumulative product of elements along a given axis.
 
@@ -525,11 +525,11 @@ def cumprod(
 
 @set_module_as('saiunit.math')
 def nancumprod(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Return the cumulative product of elements along a given axis treating NaNs as one.
 
@@ -606,10 +606,10 @@ def _fun_change_unit_binary(val_fun, unit_fun, x, y, *args, **kwargs):
 
 @unit_change(lambda ux, uy: ux * uy)
 def multiply(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Multiply arguments element-wise.
 
@@ -645,10 +645,10 @@ def multiply(
 
 @unit_change(lambda ux, uy: ux / uy)
 def divide(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Divide arguments element-wise.
 
@@ -684,14 +684,14 @@ def divide(
 
 @unit_change(lambda ux, uy: ux * uy)
 def cross(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    b: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    b: Union[Quantity, ArrayLike],
     axisa: int = -1,
     axisb: int = -1,
     axisc: int = -1,
     axis: Optional[int] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Return the cross product of two (arrays of) vectors.
 
@@ -738,10 +738,10 @@ def cross(
 
 @unit_change(lambda ux, uy: ux / uy)
 def true_divide(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Return a true division of the inputs, element-wise.
 
@@ -777,10 +777,10 @@ def true_divide(
 
 @set_module_as('saiunit.math')
 def divmod(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Tuple[Union[Quantity, jax.typing.ArrayLike], Union[Quantity, jax.typing.ArrayLike]]:
+) -> Tuple[Union[Quantity, ArrayLike], Union[Quantity, ArrayLike]]:
     """
     Return element-wise quotient and remainder simultaneously.
 
@@ -819,7 +819,7 @@ def divmod(
         r = jnp.divmod(x.mantissa, y.mantissa, **kwargs)
         return Quantity(r[0], unit=x.unit / y.unit), Quantity(r[1], unit=x.unit)
     elif isinstance(x, Quantity):
-        r = jnp.divmod(x.mantissa, y, **kwargs)
+        r = jnp.divmod(x.mantissa, y, **kwargs)  # type: ignore[arg-type]
         return Quantity(r[0], unit=x.unit / UNITLESS), Quantity(r[1], unit=x.unit)
     elif isinstance(y, Quantity):
         r = jnp.divmod(x, y.mantissa, **kwargs)
@@ -830,14 +830,14 @@ def divmod(
 
 @unit_change(lambda ux, uy: ux * uy)
 def convolve(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    v: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    v: Union[Quantity, ArrayLike],
     mode: str = 'full',
     *,
     precision: Any = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
-) -> Union[Quantity, jax.typing.ArrayLike]:
+) -> Union[Quantity, ArrayLike]:
     """
     Return the discrete, linear convolution of two one-dimensional sequences.
 
@@ -892,8 +892,8 @@ def convolve(
 
 @set_module_as('saiunit.math')
 def power(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -951,15 +951,15 @@ def power(
                 f'Strip the unit from y before raising a value to a power.'
             )
         y = y.mantissa
-        return maybe_decimal(Quantity(jnp.power(x, y, **kwargs), unit=x ** y))
+        return maybe_decimal(Quantity(jnp.power(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
     else:
         return jnp.power(x, y, **kwargs)
 
 
 @unit_change(lambda ux, uy: ux / uy)
 def floor_divide(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -996,8 +996,8 @@ def floor_divide(
 
 @set_module_as('saiunit.math')
 def float_power(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: jax.typing.ArrayLike,
+    x: Union[Quantity, ArrayLike],
+    y: ArrayLike,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -1066,8 +1066,8 @@ def float_power(
 
 @unit_change(lambda x, y: x * y)
 def dot(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
@@ -1120,7 +1120,7 @@ def dot(
 
 @unit_change(lambda x, y: x * y)
 def multi_dot(
-    arrays: Sequence[jax.typing.ArrayLike | Quantity],
+    arrays: Sequence[ArrayLike | Quantity],
     *,
     precision: jax.lax.PrecisionLike = None,
     **kwargs,
@@ -1164,7 +1164,7 @@ def multi_dot(
     for arr in arrays:
         arr = maybe_custom_array(arr)
         if isinstance(arr, Quantity):
-            unit = unit * arr.unit
+            unit = unit * arr.unit  # type: ignore[assignment]
             arr = arr.mantissa
         new_arrays.append(arr)
     xp = get_backend(*new_arrays)
@@ -1181,8 +1181,8 @@ def multi_dot(
 
 @unit_change(lambda ux, uy: ux * uy)
 def vdot(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
@@ -1236,8 +1236,8 @@ def vdot(
 
 @unit_change(lambda x, y: x * y)
 def vecdot(
-    a: jax.typing.ArrayLike | Quantity,
-    b: jax.typing.ArrayLike | Quantity,
+    a: ArrayLike | Quantity,
+    b: ArrayLike | Quantity,
     /, *,
     axis: int = -1,
     precision: jax.lax.PrecisionLike = None,
@@ -1286,7 +1286,7 @@ def vecdot(
     if precision is not None:
         extra['precision'] = precision
     if preferred_element_type is not None:
-        extra['preferred_element_type'] = preferred_element_type
+        extra['preferred_element_type'] = preferred_element_type  # type: ignore[assignment]
     return _fun_change_unit_binary('vecdot',
                                    lambda x, y: x * y,
                                    a, b,
@@ -1296,8 +1296,8 @@ def vecdot(
 
 @unit_change(lambda x, y: x * y)
 def inner(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     *,
     precision: jax.lax.PrecisionLike = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
@@ -1343,7 +1343,7 @@ def inner(
     if precision is not None:
         extra['precision'] = precision
     if preferred_element_type is not None:
-        extra['preferred_element_type'] = preferred_element_type
+        extra['preferred_element_type'] = preferred_element_type  # type: ignore[assignment]
     return _fun_change_unit_binary('inner',
                                    lambda x, y: x * y,
                                    a, b,
@@ -1352,8 +1352,8 @@ def inner(
 
 @unit_change(lambda x, y: x * y)
 def outer(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     out: Optional[Any] = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
@@ -1397,8 +1397,8 @@ def outer(
 
 @unit_change(lambda x, y: x * y)
 def kron(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """
@@ -1435,8 +1435,8 @@ def kron(
 
 @unit_change(lambda x, y: x * y)
 def matmul(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
@@ -1489,8 +1489,8 @@ def matmul(
 
 @unit_change(lambda x, y: x * y)
 def tensordot(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    b: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    b: Union[ArrayLike, Quantity],
     axes: int | Sequence[int] | Sequence[Sequence[int]] = 2,
     precision: Any = None,
     preferred_element_type: Optional[jax.typing.DTypeLike] = None,
@@ -1546,10 +1546,10 @@ def tensordot(
 
 @set_module_as('saiunit.math')
 def matrix_power(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     n: int,
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """
     Raise a square matrix to the (integer) power `n`.
 
@@ -1585,9 +1585,9 @@ def matrix_power(
 
 @set_module_as('saiunit.math')
 def det(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[jax.typing.ArrayLike, Quantity]:
+) -> Union[ArrayLike, Quantity]:
     """Compute the determinant of a matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.det`.

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import functools
 from typing import (Union, Sequence, Tuple, Optional)
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 import numpy as np
 
 from saiunit._backend import get_backend
@@ -189,7 +189,7 @@ def _fun_keep_unit_sequence(
 
 @set_module_as('saiunit.math')
 def concatenate(
-    arrays: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     axis: Optional[int] = None,
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
@@ -232,7 +232,7 @@ def concatenate(
 
 @set_module_as('saiunit.math')
 def stack(
-    arrays: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     axis: int = 0,
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
@@ -269,7 +269,7 @@ def stack(
 
 @set_module_as('saiunit.math')
 def vstack(
-    tup: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    tup: Union[Sequence[ArrayLike], Sequence[Quantity]],
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
@@ -306,7 +306,7 @@ row_stack = vstack
 
 @set_module_as('saiunit.math')
 def hstack(
-    arrays: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
@@ -340,7 +340,7 @@ def hstack(
 
 @set_module_as('saiunit.math')
 def dstack(
-    arrays: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     dtype: Optional[jax.typing.DTypeLike] = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
@@ -374,7 +374,7 @@ def dstack(
 
 @set_module_as('saiunit.math')
 def column_stack(
-    tup: Union[Sequence[jax.typing.ArrayLike], Sequence[Quantity]],
+    tup: Union[Sequence[ArrayLike], Sequence[Quantity]],
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """
@@ -474,7 +474,7 @@ def append(
 
 def _fun_keep_unit_return_sequence(
     func,
-    x: jax.typing.ArrayLike | Quantity,
+    x: ArrayLike | Quantity,
     *args,
     **kwargs
 ):
@@ -535,8 +535,8 @@ def split(
 
 @set_module_as('saiunit.math')
 def array_split(
-    ary: Union[Quantity, jax.typing.ArrayLike],
-    indices_or_sections: Union[int, jax.typing.ArrayLike],
+    ary: Union[Quantity, ArrayLike],
+    indices_or_sections: Union[int, ArrayLike],
     axis: Optional[int] = 0,
     **kwargs,
 ) -> Union[Sequence[Quantity | jax.Array]]:
@@ -699,7 +699,7 @@ def _broadcast_fun(func, *args, **kwargs):
 # ----
 @set_module_as('saiunit.math')
 def broadcast_arrays(
-    *args: Union[Quantity, jax.typing.ArrayLike],
+    *args: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
     """
@@ -734,7 +734,7 @@ def broadcast_arrays(
 
 @set_module_as('saiunit.math')
 def promote_dtypes(
-    *args: Union[Quantity, jax.typing.ArrayLike],
+    *args: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
     """
@@ -765,7 +765,7 @@ def promote_dtypes(
 
 @set_module_as('saiunit.math')
 def broadcast_to(
-    array: Union[Quantity, jax.typing.ArrayLike],
+    array: Union[Quantity, ArrayLike],
     shape: Tuple[int, ...],
     **kwargs,
 ) -> Quantity | jax.Array:
@@ -1544,7 +1544,7 @@ def ravel(
 
 @set_module_as('saiunit.math')
 def flatten(
-    x: jax.typing.ArrayLike | Quantity,
+    x: ArrayLike | Quantity,
     start_axis: Optional[int] = None,
     end_axis: Optional[int] = None,
     **kwargs,
@@ -1601,7 +1601,7 @@ def flatten(
 
 @set_module_as('saiunit.math')
 def unflatten(
-    x: jax.typing.ArrayLike | Quantity,
+    x: ArrayLike | Quantity,
     axis: int,
     sizes: Sequence[int],
     **kwargs,
@@ -1640,7 +1640,7 @@ def unflatten(
 
 
 @set_module_as('saiunit.math')
-def remove_diag(x: jax.typing.ArrayLike | Quantity, **kwargs) -> jax.Array | Quantity:
+def remove_diag(x: ArrayLike | Quantity, **kwargs) -> jax.Array | Quantity:
     """Remove the diagonal of the matrix.
 
     Parameters
@@ -1670,7 +1670,7 @@ def remove_diag(x: jax.typing.ArrayLike | Quantity, **kwargs) -> jax.Array | Qua
     if x.ndim != 2:
         raise ValueError(f'Only support 2D matrix, while we got a {x.ndim}D array.')
     eyes = jnp.fill_diagonal(jnp.ones(x.shape, dtype=bool, **kwargs), False, **kwargs)
-    x = jnp.reshape(x[eyes], (x.shape[0], x.shape[1] - 1), **kwargs)
+    x = jnp.reshape(x[eyes], (x.shape[0], x.shape[1] - 1), **kwargs)  # type: ignore[index]
     if unit.is_unitless:
         return x
     return Quantity(x, unit=unit)
@@ -1769,7 +1769,7 @@ def _fun_keep_unit_unary(func, x, *args, **kwargs):
 
 
 def astype(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     dtype: jax.typing.DTypeLike
 ) -> Union[jax.Array, Quantity]:
     """
@@ -1800,7 +1800,7 @@ def astype(
 
 
 @set_module_as('saiunit.math')
-def real(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def real(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the real part of the complex argument.
 
@@ -1826,7 +1826,7 @@ def real(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, 
 
 
 @set_module_as('saiunit.math')
-def imag(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def imag(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the imaginary part of the complex argument.
 
@@ -1852,7 +1852,7 @@ def imag(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, 
 
 
 @set_module_as('saiunit.math')
-def conj(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def conj(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the complex conjugate of the argument.
 
@@ -1878,7 +1878,7 @@ def conj(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, 
 
 
 @set_module_as('saiunit.math')
-def conjugate(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def conjugate(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the complex conjugate of the argument.
 
@@ -1904,7 +1904,7 @@ def conjugate(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quant
 
 
 @set_module_as('saiunit.math')
-def negative(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def negative(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the negative of the argument.
 
@@ -1930,7 +1930,7 @@ def negative(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quanti
 
 
 @set_module_as('saiunit.math')
-def positive(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def positive(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the positive of the argument.
 
@@ -1956,7 +1956,7 @@ def positive(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quanti
 
 
 @set_module_as('saiunit.math')
-def abs(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def abs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the absolute value of the argument.
 
@@ -1983,12 +1983,12 @@ def abs(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, j
 
 @set_module_as('saiunit.math')
 def sum(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     keepdims: bool = False,
-    initial: Union[jax.typing.ArrayLike, Quantity, None] = None,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    initial: Union[ArrayLike, Quantity, None] = None,
+    where: Union[ArrayLike, None] = None,
     promote_integers: bool = True,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -2058,7 +2058,7 @@ def sum(
 
 @set_module_as('saiunit.math')
 def nancumsum(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     **kwargs,
@@ -2099,12 +2099,12 @@ def nancumsum(
 
 @set_module_as('saiunit.math')
 def nansum(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     keepdims: bool = False,
-    initial: Union[jax.typing.ArrayLike, Quantity, None] = None,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    initial: Union[ArrayLike, Quantity, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2165,7 +2165,7 @@ def nansum(
 
 @set_module_as('saiunit.math')
 def cumsum(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     **kwargs,
@@ -2205,9 +2205,9 @@ def cumsum(
 
 @set_module_as('saiunit.math')
 def ediff1d(
-    x: Quantity | jax.typing.ArrayLike,
-    to_end: jax.typing.ArrayLike | Quantity = None,
-    to_begin: jax.typing.ArrayLike | Quantity = None,
+    x: Quantity | ArrayLike,
+    to_end: ArrayLike | Quantity | None = None,
+    to_begin: ArrayLike | Quantity | None = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2244,7 +2244,7 @@ def ediff1d(
 
 
 @set_module_as('saiunit.math')
-def absolute(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def absolute(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the absolute value of the argument.
 
@@ -2270,7 +2270,7 @@ def absolute(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quanti
 
 
 @set_module_as('saiunit.math')
-def fabs(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def fabs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the absolute value of the argument.
 
@@ -2297,7 +2297,7 @@ def fabs(x: Union[Quantity, jax.typing.ArrayLike], **kwargs) -> Union[Quantity, 
 
 @set_module_as('saiunit.math')
 def median(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     overwrite_input: bool = False,
     keepdims: bool = False,
@@ -2345,11 +2345,11 @@ def median(
 
 @set_module_as('saiunit.math')
 def nanmin(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     keepdims: bool = False,
-    initial: Union[jax.typing.ArrayLike, Quantity, None] = None,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    initial: Union[ArrayLike, Quantity, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2399,11 +2399,11 @@ def nanmin(
 
 @set_module_as('saiunit.math')
 def nanmax(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     keepdims: bool = False,
-    initial: Union[jax.typing.ArrayLike, None] = None,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    initial: Union[ArrayLike, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2453,7 +2453,7 @@ def nanmax(
 
 @set_module_as('saiunit.math')
 def ptp(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     keepdims: bool = False,
     **kwargs,
@@ -2501,9 +2501,9 @@ def ptp(
 
 @set_module_as('saiunit.math')
 def average(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    weights: Union[jax.typing.ArrayLike, None] = None,
+    weights: Union[ArrayLike, None] = None,
     returned: bool = False,
     keepdims: bool = False,
     **kwargs,
@@ -2564,11 +2564,11 @@ def average(
 
 @set_module_as('saiunit.math')
 def mean(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     keepdims: bool = False, *,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2619,12 +2619,12 @@ def mean(
 
 @set_module_as('saiunit.math')
 def std(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     ddof: int = 0,
     keepdims: bool = False, *,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2680,7 +2680,7 @@ def std(
 
 @set_module_as('saiunit.math')
 def nanmedian(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, tuple[int, ...], None] = None,
     overwrite_input: bool = False,
     keepdims: bool = False,
@@ -2735,11 +2735,11 @@ def nanmedian(
 
 @set_module_as('saiunit.math')
 def nanmean(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     keepdims: bool = False, *,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2791,12 +2791,12 @@ def nanmean(
 
 @set_module_as('saiunit.math')
 def nanstd(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
     dtype: Union[jax.typing.DTypeLike, None] = None,
     ddof: int = 0,
     keepdims: bool = False, *,
-    where: Union[jax.typing.ArrayLike, None] = None,
+    where: Union[ArrayLike, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2854,11 +2854,11 @@ def nanstd(
 
 @set_module_as('saiunit.math')
 def diff(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     n: int = 1,
     axis: int = -1,
-    prepend: Union[jax.typing.ArrayLike, Quantity, None] = None,
-    append: Union[jax.typing.ArrayLike, Quantity, None] = None,
+    prepend: Union[ArrayLike, Quantity, None] = None,
+    append: Union[ArrayLike, Quantity, None] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -2904,7 +2904,7 @@ def diff(
 
 @set_module_as('saiunit.math')
 def rot90(
-    m: Union[jax.typing.ArrayLike, Quantity],
+    m: Union[ArrayLike, Quantity],
     k: int = 1,
     axes: Tuple[int, int] = (0, 1),
     **kwargs,
@@ -2945,8 +2945,8 @@ def rot90(
 
 @set_module_as('saiunit.math')
 def intersect1d(
-    ar1: Union[jax.typing.ArrayLike, Quantity],
-    ar2: Union[jax.typing.ArrayLike, Quantity],
+    ar1: Union[ArrayLike, Quantity],
+    ar2: Union[ArrayLike, Quantity],
     assume_unique: bool = False,
     return_indices: bool = False,
     **kwargs,
@@ -3013,10 +3013,10 @@ def intersect1d(
 
 @set_module_as('saiunit.math')
 def nan_to_num(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    nan: float | Quantity = None,
-    posinf: float | Quantity = None,
-    neginf: float | Quantity = None,
+    x: Union[ArrayLike, Quantity],
+    nan: float | Quantity | None = None,
+    posinf: float | Quantity | None = None,
+    neginf: float | Quantity | None = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """
@@ -3070,18 +3070,18 @@ def nan_to_num(
     x_unit = get_unit(x)
     if isinstance(x, Quantity):
         if nan is not None:
-            nan = Quantity(nan).in_unit(x_unit).mantissa
+            nan = Quantity(nan).in_unit(x_unit).mantissa  # type: ignore[assignment]
         else:
             nan = 0.0
         if posinf is not None:
-            posinf = Quantity(posinf).in_unit(x_unit).mantissa
+            posinf = Quantity(posinf).in_unit(x_unit).mantissa  # type: ignore[assignment]
         if neginf is not None:
-            neginf = Quantity(neginf).in_unit(x_unit).mantissa
-        r = jnp.nan_to_num(x.mantissa, nan=nan, posinf=posinf, neginf=neginf, **kwargs)
+            neginf = Quantity(neginf).in_unit(x_unit).mantissa  # type: ignore[assignment]
+        r = jnp.nan_to_num(x.mantissa, nan=nan, posinf=posinf, neginf=neginf, **kwargs)  # type: ignore[arg-type]
         return r if x_unit.is_unitless else Quantity(r, unit=x_unit)
     else:
         nan = 0.0 if nan is None else nan
-        return jnp.nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf, **kwargs)
+        return jnp.nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
@@ -3144,7 +3144,7 @@ def trace(
 @set_module_as('saiunit.math')
 def percentile(
     a: Union[jax.Array, Quantity],
-    q: jax.typing.ArrayLike,
+    q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
@@ -3216,7 +3216,7 @@ def percentile(
 @set_module_as('saiunit.math')
 def nanpercentile(
     a: Union[jax.Array, Quantity],
-    q: jax.typing.ArrayLike,
+    q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
@@ -3289,7 +3289,7 @@ def nanpercentile(
 @set_module_as('saiunit.math')
 def quantile(
     a: Union[jax.Array, Quantity],
-    q: jax.typing.ArrayLike,
+    q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
@@ -3361,7 +3361,7 @@ def quantile(
 @set_module_as('saiunit.math')
 def nanquantile(
     a: Union[jax.Array, Quantity],
-    q: jax.typing.ArrayLike,
+    q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
@@ -3469,7 +3469,7 @@ def _fun_keep_unit_binary(func, x1, x2, *args, **kwargs):
 
 
 @set_module_as('saiunit.math')
-def fmod(x1: Union[Quantity, jax.typing.ArrayLike],
+def fmod(x1: Union[Quantity, ArrayLike],
          x2: Union[Quantity, jax.Array], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the element-wise remainder of division.
@@ -3499,7 +3499,7 @@ def fmod(x1: Union[Quantity, jax.typing.ArrayLike],
 
 
 @set_module_as('saiunit.math')
-def mod(x1: Union[Quantity, jax.typing.ArrayLike], x2: Union[Quantity, jax.Array], **kwargs) -> Union[Quantity, jax.Array]:
+def mod(x1: Union[Quantity, ArrayLike], x2: Union[Quantity, jax.Array], **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the element-wise modulus of division.
 
@@ -3529,8 +3529,8 @@ def mod(x1: Union[Quantity, jax.typing.ArrayLike], x2: Union[Quantity, jax.Array
 
 @set_module_as('saiunit.math')
 def copysign(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3563,8 +3563,8 @@ def copysign(
 
 @set_module_as('saiunit.math')
 def maximum(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3596,8 +3596,8 @@ def maximum(
 
 @set_module_as('saiunit.math')
 def minimum(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3629,8 +3629,8 @@ def minimum(
 
 @set_module_as('saiunit.math')
 def fmax(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3663,8 +3663,8 @@ def fmax(
 
 @set_module_as('saiunit.math')
 def fmin(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3697,8 +3697,8 @@ def fmin(
 
 @set_module_as('saiunit.math')
 def lcm(
-    x1: Union[Quantity, jax.typing.ArrayLike],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x1: Union[Quantity, ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3730,8 +3730,8 @@ def lcm(
 
 
 @set_module_as('saiunit.math')
-def gcd(x1: Union[Quantity, jax.typing.ArrayLike],
-        x2: Union[Quantity, jax.typing.ArrayLike],  **kwargs) -> Union[Quantity, jax.Array]:
+def gcd(x1: Union[Quantity, ArrayLike],
+        x2: Union[Quantity, ArrayLike],  **kwargs) -> Union[Quantity, jax.Array]:
     """
     Return the greatest common divisor of `x1` and `x2`.
 
@@ -3762,8 +3762,8 @@ def gcd(x1: Union[Quantity, jax.typing.ArrayLike],
 
 @set_module_as('saiunit.math')
 def add(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3796,8 +3796,8 @@ def add(
 
 @set_module_as('saiunit.math')
 def subtract(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3830,8 +3830,8 @@ def subtract(
 
 @set_module_as('saiunit.math')
 def remainder(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3873,8 +3873,8 @@ def remainder(
 
 @set_module_as('saiunit.math')
 def nextafter(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3911,12 +3911,12 @@ def nextafter(
 # ----------------------------
 @set_module_as('saiunit.math')
 def interp(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    xp: Union[Quantity, jax.typing.ArrayLike],
-    fp: Union[Quantity, jax.typing.ArrayLike],
-    left: Union[Quantity, jax.typing.ArrayLike] = None,
-    right: Union[Quantity, jax.typing.ArrayLike] = None,
-    period: Union[Quantity, jax.typing.ArrayLike] = None,
+    x: Union[Quantity, ArrayLike],
+    xp: Union[Quantity, ArrayLike],
+    fp: Union[Quantity, ArrayLike],
+    left: Optional[Union[Quantity, ArrayLike]] = None,
+    right: Optional[Union[Quantity, ArrayLike]] = None,
+    period: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -3962,15 +3962,15 @@ def interp(
         Quantity(right).in_unit(x_unit).mantissa if right is not None else right,
         Quantity(period).in_unit(x_unit).mantissa if period is not None else period
     )
-    r = jnp.interp(x, xp=xp, fp=fp, left=left, right=right, period=period, **kwargs)
+    r = jnp.interp(x, xp=xp, fp=fp, left=left, right=right, period=period, **kwargs)  # type: ignore[arg-type]
     return maybe_decimal(Quantity(r, unit=y_unit))
 
 
 @set_module_as('saiunit.math')
 def clip(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    a_min: Union[Quantity, jax.typing.ArrayLike],
-    a_max: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    a_min: Union[Quantity, ArrayLike],
+    a_max: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -4009,9 +4009,9 @@ def clip(
 @set_module_as('saiunit.math')
 def histogram(
     x: Union[jax.Array, Quantity],
-    bins: jax.typing.ArrayLike = 10,
-    range: Optional[Sequence[jax.typing.ArrayLike | Quantity]] = None,
-    weights: Optional[jax.typing.ArrayLike] = None,
+    bins: ArrayLike = 10,  # type: ignore[assignment]
+    range: Optional[Sequence[ArrayLike | Quantity]] = None,
+    weights: Optional[ArrayLike] = None,
     density: Optional[bool] = None,
     **kwargs,
 ) -> Tuple[jax.Array, jax.Array | Quantity]:
@@ -4071,13 +4071,13 @@ def histogram(
     unit = UNITLESS
     if isinstance(x, Quantity):
         unit = x.unit
-        x = x.mantissa
+        x = x.mantissa  # type: ignore[assignment]
     if range is not None:
         range = (
             Quantity(range[0]).in_unit(unit).mantissa,
             Quantity(range[1]).in_unit(unit).mantissa
         )
-    hist, bin_edges = jnp.histogram(x, bins, range=range, weights=weights, density=density, **kwargs)
+    hist, bin_edges = jnp.histogram(x, bins, range=range, weights=weights, density=density, **kwargs)  # type: ignore[arg-type]
     if unit.is_unitless:
         return hist, bin_edges
     return hist, Quantity(bin_edges, unit=unit)
@@ -4090,7 +4090,7 @@ def compress(
     axis: Optional[int] = None,
     *,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike] = None,
+    fill_value: Optional[ArrayLike] = None,
     **kwargs,
 ) -> Union[jax.Array, Quantity]:
     """
@@ -4138,7 +4138,7 @@ def compress(
     if fill_value is not None:
         fill_value = Quantity(fill_value).in_unit(a_unit).mantissa
     else:
-        fill_value = 0
+        fill_value = 0  # type: ignore[assignment]
     return _fun_keep_unit_unary(functools.partial(jnp.compress, condition),
                                 a, axis=axis, size=size, fill_value=fill_value, **kwargs)
 
@@ -4149,7 +4149,7 @@ def extract(
     arr: Union[jax.Array, Quantity],
     *,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike | Quantity] = None,
+    fill_value: Optional[ArrayLike | Quantity] = None,
     **kwargs,
 ) -> jax.Array | Quantity:
     """
@@ -4193,20 +4193,20 @@ def extract(
     if fill_value is not None:
         fill_value = Quantity(fill_value).in_unit(a_unit).mantissa
     else:
-        fill_value = 0
+        fill_value = 0  # type: ignore[assignment]
     return _fun_keep_unit_unary(functools.partial(jnp.extract, condition),
                                 arr, size=size, fill_value=fill_value, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def take(
-    a: Union[Quantity, jax.typing.ArrayLike],
-    indices: Union[Quantity, jax.typing.ArrayLike],
+    a: Union[Quantity, ArrayLike],
+    indices: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     mode: Optional[str] = None,
     unique_indices: bool = False,
     indices_are_sorted: bool = False,
-    fill_value: Optional[Union[Quantity, jax.typing.ArrayLike]] = None,
+    fill_value: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -4273,14 +4273,14 @@ def take(
         return a.take(indices, axis=axis, mode=mode, unique_indices=unique_indices,
                       indices_are_sorted=indices_are_sorted, fill_value=fill_value)
     else:
-        return jnp.take(a, indices, axis=axis, mode=mode, unique_indices=unique_indices,
-                        indices_are_sorted=indices_are_sorted, fill_value=fill_value, **kwargs)
+        return jnp.take(a, indices, axis=axis, mode=mode, unique_indices=unique_indices,  # type: ignore[arg-type]
+                        indices_are_sorted=indices_are_sorted, fill_value=fill_value, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
 def select(
-    condlist: list[Union[jax.typing.ArrayLike]],
-    choicelist: Union[Quantity, jax.typing.ArrayLike],
+    condlist: list[Union[ArrayLike]],
+    choicelist: Union[Quantity, ArrayLike],
     default: int = 0,
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
@@ -4420,7 +4420,7 @@ def unique(
     *,
     equal_nan: bool = False,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike, Quantity] = None,
+    fill_value: Optional[ArrayLike, Quantity] = None,  # type: ignore[valid-type]
     **kwargs,
 ) -> Sequence[jax.Array | Quantity] | jax.Array | Quantity:
     """
@@ -4492,7 +4492,7 @@ def unique(
 
 @set_module_as('saiunit.math')
 def round(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     decimals: int = 0,
     **kwargs,
 ) -> jax.Array | Quantity:
@@ -4524,7 +4524,7 @@ def round(
 
 @set_module_as('saiunit.math')
 def around(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     decimals: int = 0,
     **kwargs,
 ) -> jax.Array | Quantity:
@@ -4556,7 +4556,7 @@ def around(
 
 @set_module_as('saiunit.math')
 def rint(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -4585,7 +4585,7 @@ def rint(
 
 @set_module_as('saiunit.math')
 def floor(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array | Quantity:
     """
@@ -4614,7 +4614,7 @@ def floor(
 
 @set_module_as('saiunit.math')
 def ceil(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array | Quantity:
     """
@@ -4643,7 +4643,7 @@ def ceil(
 
 @set_module_as('saiunit.math')
 def trunc(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array | Quantity:
     """
@@ -4672,7 +4672,7 @@ def trunc(
 
 @set_module_as('saiunit.math')
 def fix(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> jax.Array | Quantity:
     """
@@ -4701,7 +4701,7 @@ def fix(
 
 @set_module_as('saiunit.math')
 def modf(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Tuple[jax.Array | Quantity, jax.Array | Quantity]:
     """
@@ -4764,7 +4764,7 @@ def gather(input: jax.Array | Quantity, dim: int, index: jax.Array, **kwargs):
     # Normalize dim to be positive
     if isinstance(input, Quantity):
         unit = input.unit
-        input = input.mantissa
+        input = input.mantissa  # type: ignore[assignment]
     else:
         unit = UNITLESS
     ndim = input.ndim

--- a/saiunit/math/_fun_remove_unit.py
+++ b/saiunit/math/_fun_remove_unit.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import (Union, Optional, Sequence)
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 
 from saiunit._backend import get_backend
 from saiunit._base_getters import get_unit
@@ -48,7 +48,7 @@ __all__ = [
 
 @set_module_as('saiunit.math')
 def get_promote_dtypes(
-    *args: Union[Quantity, jax.typing.ArrayLike],
+    *args: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
     """
@@ -74,7 +74,7 @@ def get_promote_dtypes(
         dtype('float32')
     """
     args = maybe_custom_array_tree(args)
-    return jnp.promote_types(*jax.tree.leaves(args), **kwargs)
+    return jnp.promote_types(*jax.tree.leaves(args), **kwargs)  # type: ignore[return-value]
 
 
 def _fun_remove_unit_unary(func, x, *args, **kwargs):
@@ -92,7 +92,7 @@ def _fun_remove_unit_unary(func, x, *args, **kwargs):
 
 @set_module_as('saiunit.math')
 def iscomplexobj(
-    x: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
     **kwargs,
 ) -> bool:
     """
@@ -127,7 +127,7 @@ def iscomplexobj(
 @set_module_as('saiunit.math')
 def heaviside(
     x1: Union[Quantity, jax.Array],
-    x2: Union[Quantity, jax.typing.ArrayLike],
+    x2: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[Quantity, jax.Array]:
     """
@@ -162,7 +162,7 @@ def heaviside(
     """
     x1 = maybe_custom_array(x1)
     x2 = maybe_custom_array(x2)
-    x1 = x1.mantissa if isinstance(x1, Quantity) else x1
+    x1 = x1.mantissa if isinstance(x1, Quantity) else x1  # type: ignore[assignment]
     if isinstance(x2, Quantity):
         if not x2.is_unitless:
             raise TypeError(
@@ -174,7 +174,7 @@ def heaviside(
 
 
 @set_module_as('saiunit.math')
-def signbit(x: Union[jax.typing.ArrayLike, Quantity], **kwargs) -> jax.Array:
+def signbit(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
     """
     Return element-wise True where the sign bit is set (less than zero).
 
@@ -206,7 +206,7 @@ def signbit(x: Union[jax.typing.ArrayLike, Quantity], **kwargs) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def sign(x: Union[jax.typing.ArrayLike, Quantity], **kwargs) -> jax.Array:
+def sign(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
     """
     Return the sign of each element in the input array.
 
@@ -240,8 +240,8 @@ def sign(x: Union[jax.typing.ArrayLike, Quantity], **kwargs) -> jax.Array:
 
 @set_module_as('saiunit.math')
 def bincount(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    weights: Optional[jax.typing.ArrayLike] = None,
+    x: Union[ArrayLike, Quantity],
+    weights: Optional[ArrayLike] = None,
     minlength: int = 0,
     *,
     length: Optional[int] = None,
@@ -288,8 +288,8 @@ def bincount(
 
 @set_module_as('saiunit.math')
 def digitize(
-    x: Union[jax.typing.ArrayLike, Quantity],
-    bins: Union[jax.typing.ArrayLike, Quantity],
+    x: Union[ArrayLike, Quantity],
+    bins: Union[ArrayLike, Quantity],
     right: bool = False,
     **kwargs,
 ) -> jax.Array:
@@ -359,7 +359,7 @@ def digitize(
                 f'Either pass a Quantity for x with matching units, or strip the unit from bins.'
             )
         bins = bins.mantissa
-    return jnp.digitize(x, bins, right=right, **kwargs)
+    return jnp.digitize(x, bins, right=right, **kwargs)  # type: ignore[arg-type]
 
 
 def _name_of(func) -> str:
@@ -385,7 +385,7 @@ def _fun_logic_unary(func, x, *args, **kwargs):
 
 @set_module_as('saiunit.math')
 def all(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     keepdims: bool = False,
     where: Optional[jax.Array] = None,
@@ -432,7 +432,7 @@ def all(
 
 @set_module_as('saiunit.math')
 def any(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     keepdims: bool = False,
     where: Optional[jax.Array] = None,
@@ -477,7 +477,7 @@ def any(
 
 @set_module_as('saiunit.math')
 def logical_not(
-    x: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
     **kwargs,
 ) -> Union[bool, jax.Array]:
     """
@@ -553,8 +553,8 @@ def _fun_logic_binary(func, x, y, *args, **kwargs):
 
 @set_module_as('saiunit.math')
 def equal(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -595,8 +595,8 @@ def equal(
 
 @set_module_as('saiunit.math')
 def not_equal(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -632,8 +632,8 @@ def not_equal(
 
 @set_module_as('saiunit.math')
 def greater(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -673,8 +673,8 @@ def greater(
 
 @set_module_as('saiunit.math')
 def greater_equal(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[
@@ -711,8 +711,8 @@ def greater_equal(
 
 @set_module_as('saiunit.math')
 def less(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -748,8 +748,8 @@ def less(
 
 @set_module_as('saiunit.math')
 def less_equal(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[
@@ -786,8 +786,8 @@ def less_equal(
 
 @set_module_as('saiunit.math')
 def array_equal(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[
@@ -826,10 +826,10 @@ def array_equal(
 
 @set_module_as('saiunit.math')
 def isclose(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
-    rtol: float | Quantity = None,
-    atol: float | Quantity = None,
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
+    rtol: float | Quantity | None = None,
+    atol: float | Quantity | None = None,
     equal_nan: bool = False,
     **kwargs,
 ) -> Union[bool, jax.Array]:
@@ -896,17 +896,17 @@ def isclose(
         rtol = 1e-5 * unit
     if atol is None:
         atol = 1e-8 * unit
-    atol = Quantity(atol).in_unit(unit).mantissa
-    rtol = Quantity(rtol).in_unit(unit).mantissa
+    atol = Quantity(atol).in_unit(unit).mantissa  # type: ignore[assignment]
+    rtol = Quantity(rtol).in_unit(unit).mantissa  # type: ignore[assignment]
     return _fun_logic_binary('isclose', x, y, rtol=rtol, atol=atol, equal_nan=equal_nan, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def allclose(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
-    rtol: float | Quantity = None,
-    atol: float | Quantity = None,
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
+    rtol: float | Quantity | None = None,
+    atol: float | Quantity | None = None,
     equal_nan: bool = False,
     **kwargs,
 ) -> Union[bool, jax.Array]:
@@ -966,7 +966,7 @@ def allclose(
                 f'Either pass a Quantity for y with matching units, or strip the unit from x.'
             )
         x_val = x.mantissa
-        y_val = y
+        y_val = y  # type: ignore[assignment]
     elif isinstance(y, Quantity):
         if not y.is_unitless:
             raise TypeError(
@@ -983,15 +983,15 @@ def allclose(
         rtol = 1e-5 * unit
     if atol is None:
         atol = 1e-8 * unit
-    rtol = Quantity(rtol).in_unit(unit).mantissa
-    atol = Quantity(atol).in_unit(unit).mantissa
-    return jnp.allclose(x_val, y_val, rtol=rtol, atol=atol, equal_nan=equal_nan, **kwargs)
+    rtol = Quantity(rtol).in_unit(unit).mantissa  # type: ignore[assignment]
+    atol = Quantity(atol).in_unit(unit).mantissa  # type: ignore[assignment]
+    return jnp.allclose(x_val, y_val, rtol=rtol, atol=atol, equal_nan=equal_nan, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
 def logical_and(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -1028,8 +1028,8 @@ def logical_and(
 
 @set_module_as('saiunit.math')
 def logical_or(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -1066,8 +1066,8 @@ def logical_or(
 
 @set_module_as('saiunit.math')
 def logical_xor(
-    x: Union[Quantity, jax.typing.ArrayLike],
-    y: Union[Quantity, jax.typing.ArrayLike],
+    x: Union[Quantity, ArrayLike],
+    y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
 ) -> Union[bool, jax.Array]:
@@ -1109,7 +1109,7 @@ def logical_xor(
 
 @set_module_as('saiunit.math')
 def argsort(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     axis: Optional[int] = -1,
     *,
     kind: None = None,
@@ -1167,7 +1167,7 @@ def argsort(
 
 @set_module_as('saiunit.math')
 def argmax(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     axis: Optional[int] = None,
     **kwargs,
 ) -> jax.Array:
@@ -1206,7 +1206,7 @@ def argmax(
 
 @set_module_as('saiunit.math')
 def argmin(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     axis: Optional[int] = None,
     keepdims: Optional[bool] = None,
     **kwargs,
@@ -1245,8 +1245,8 @@ def argmin(
 
 @set_module_as('saiunit.math')
 def nanargmax(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    axis: int = None,
+    a: Union[ArrayLike, Quantity],
+    axis: int | None = None,
     keepdims: bool = False,
     **kwargs,
 ) -> jax.Array:
@@ -1287,8 +1287,8 @@ def nanargmax(
 
 @set_module_as('saiunit.math')
 def nanargmin(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    axis: int = None,
+    a: Union[ArrayLike, Quantity],
+    axis: int | None = None,
     keepdims: bool = False,
     **kwargs,
 ) -> jax.Array:
@@ -1329,10 +1329,10 @@ def nanargmin(
 
 @set_module_as('saiunit.math')
 def argwhere(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     *,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike] = None,
+    fill_value: Optional[ArrayLike] = None,
     **kwargs,
 ) -> jax.Array:
     """
@@ -1370,16 +1370,16 @@ def argwhere(
     if size is not None:
         extra['size'] = size
     if fill_value is not None:
-        extra['fill_value'] = fill_value
+        extra['fill_value'] = fill_value  # type: ignore[assignment]
     return _fun_remove_unit_unary('argwhere', a, **extra, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def nonzero(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     *,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike] = None,
+    fill_value: Optional[ArrayLike] = None,
     **kwargs,
 ) -> Sequence[jax.Array]:
     """
@@ -1416,16 +1416,16 @@ def nonzero(
     if size is not None:
         extra['size'] = size
     if fill_value is not None:
-        extra['fill_value'] = fill_value
+        extra['fill_value'] = fill_value  # type: ignore[assignment]
     return _fun_remove_unit_unary('nonzero', a, **extra, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def flatnonzero(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     *,
     size: Optional[int] = None,
-    fill_value: Optional[jax.typing.ArrayLike] = None,
+    fill_value: Optional[ArrayLike] = None,
     **kwargs,
 ) -> jax.Array:
     """
@@ -1464,13 +1464,13 @@ def flatnonzero(
     if size is not None:
         extra['size'] = size
     if fill_value is not None:
-        extra['fill_value'] = Quantity(fill_value).in_unit(a_unit).mantissa
+        extra['fill_value'] = Quantity(fill_value).in_unit(a_unit).mantissa  # type: ignore[assignment]
     return _fun_remove_unit_unary('flatnonzero', a, **extra, **kwargs)
 
 
 @set_module_as('saiunit.math')
 def count_nonzero(
-    a: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
     axis: Optional[int] = None,
     keepdims: Optional[bool] = None,
     **kwargs,
@@ -1508,8 +1508,8 @@ def count_nonzero(
 
 @set_module_as('saiunit.math')
 def searchsorted(
-    a: Union[jax.typing.ArrayLike, Quantity],
-    v: Union[jax.typing.ArrayLike, Quantity],
+    a: Union[ArrayLike, Quantity],
+    v: Union[ArrayLike, Quantity],
     side: str = 'left',
     sorter: Optional[jax.Array] = None,
     *,
@@ -1555,13 +1555,13 @@ def searchsorted(
     a_unit = get_unit(a)
     v = Quantity(v).in_unit(a_unit).mantissa
     a = Quantity(a).mantissa
-    r = jnp.searchsorted(a, v, side=side, sorter=sorter, method=method, **kwargs)
+    r = jnp.searchsorted(a, v, side=side, sorter=sorter, method=method, **kwargs)  # type: ignore[arg-type]
     return r
 
 
 @set_module_as('saiunit.math')
 def diag_indices_from(
-    arr: Union[jax.typing.ArrayLike, Quantity],
+    arr: Union[ArrayLike, Quantity],
     **kwargs,
 ) -> tuple[jax.Array, ...]:
     """

--- a/saiunit/math/_fun_remove_unit_test.py
+++ b/saiunit/math/_fun_remove_unit_test.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-import brainstate as bst
+import brainstate as bst  # type: ignore[import-untyped]
 import jax.numpy as jnp
 import pytest
 from absl.testing import parameterized

--- a/saiunit/math/_misc.py
+++ b/saiunit/math/_misc.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import (Union, TypeVar, Any)
 
-from saiunit._jax_compat import jax, jnp
+from saiunit._jax_compat import jax, jnp, ArrayLike
 import numpy as np
 
 from saiunit._base_unit import Unit
@@ -188,7 +188,7 @@ def issubdtype(a: T, b: T) -> bool:
         >>> sumath.issubdtype(jnp.int32, jnp.floating)
         False
     """
-    return jnp.issubdtype(a, b)
+    return jnp.issubdtype(a, b)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
@@ -219,7 +219,7 @@ def result_type(*args):
 
 
 @set_module_as('saiunit.math')
-def ndim(a: Union[Quantity, jax.typing.ArrayLike]) -> int:
+def ndim(a: Union[Quantity, ArrayLike]) -> int:
     """Return the number of dimensions of an array or ``Quantity``.
 
     Parameters
@@ -252,7 +252,7 @@ def ndim(a: Union[Quantity, jax.typing.ArrayLike]) -> int:
 
 
 @set_module_as('saiunit.math')
-def isreal(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
+def isreal(a: Union[Quantity, ArrayLike]) -> jax.Array:
     """Test element-wise whether each element is real (has zero imaginary part).
 
     Parameters
@@ -282,7 +282,7 @@ def isreal(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def isscalar(a: Union[Quantity, jax.typing.ArrayLike]) -> bool:
+def isscalar(a: Union[Quantity, ArrayLike]) -> bool:
     """Return ``True`` if the input is a scalar (zero-dimensional).
 
     Parameters
@@ -314,7 +314,7 @@ def isscalar(a: Union[Quantity, jax.typing.ArrayLike]) -> bool:
 
 
 @set_module_as('saiunit.math')
-def isfinite(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
+def isfinite(a: Union[Quantity, ArrayLike]) -> jax.Array:
     """Test element-wise for finiteness (not inf and not NaN).
 
     Parameters
@@ -344,7 +344,7 @@ def isfinite(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def isinf(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
+def isinf(a: Union[Quantity, ArrayLike]) -> jax.Array:
     """Test element-wise for positive or negative infinity.
 
     Parameters
@@ -374,7 +374,7 @@ def isinf(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def isnan(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
+def isnan(a: Union[Quantity, ArrayLike]) -> jax.Array:
     """Test element-wise for NaN.
 
     Parameters
@@ -404,7 +404,7 @@ def isnan(a: Union[Quantity, jax.typing.ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def shape(a: Union[Quantity, jax.typing.ArrayLike]) -> tuple[int, ...]:
+def shape(a: Union[Quantity, ArrayLike]) -> tuple[int, ...]:
     """
     Return the shape of an array.
 
@@ -445,7 +445,7 @@ def shape(a: Union[Quantity, jax.typing.ArrayLike]) -> tuple[int, ...]:
 
 
 @set_module_as('saiunit.math')
-def size(a: Union[Quantity, jax.typing.ArrayLike], axis: int = None) -> int:
+def size(a: Union[Quantity, ArrayLike], axis: int | None = None) -> int:
     """
     Return the number of elements along a given axis.
 
@@ -489,7 +489,7 @@ def size(a: Union[Quantity, jax.typing.ArrayLike], axis: int = None) -> int:
 
 
 @set_module_as('saiunit.math')
-def finfo(a: Union[Quantity, jax.typing.ArrayLike]) -> jnp.finfo:
+def finfo(a: Union[Quantity, ArrayLike]) -> jnp.finfo:
     a = maybe_custom_array(a)
     if isinstance(a, Quantity):
         return jnp.finfo(a.mantissa)
@@ -498,7 +498,7 @@ def finfo(a: Union[Quantity, jax.typing.ArrayLike]) -> jnp.finfo:
 
 
 @set_module_as('saiunit.math')
-def iinfo(a: Union[Quantity, jax.typing.ArrayLike]) -> jnp.iinfo:
+def iinfo(a: Union[Quantity, ArrayLike]) -> jnp.iinfo:
     a = maybe_custom_array(a)
     if isinstance(a, Quantity):
         return jnp.iinfo(a.mantissa)
@@ -566,7 +566,7 @@ def get_dtype(a):
             return bool
         elif isinstance(a, int):
             if environ is None:
-                from brainstate import environ
+                from brainstate import environ  # type: ignore[import-untyped]
             return environ.ditype()
         elif isinstance(a, float):
             if environ is None:
@@ -640,8 +640,8 @@ def is_int(array):
 
 @set_module_as('saiunit.math')
 def gradient(
-    f: Union[jax.typing.ArrayLike, Quantity],
-    *varargs: Union[jax.typing.ArrayLike, Quantity],
+    f: Union[ArrayLike, Quantity],
+    *varargs: Union[ArrayLike, Quantity],
     axis: Union[int, Sequence[int], None] = None,
     edge_order: Union[int, None] = None,
 ) -> Union[jax.Array, list[jax.Array], Quantity, list[Quantity]]:
@@ -707,18 +707,18 @@ def gradient(
         if isinstance(f, Quantity) and not is_unitless(f):
             return Quantity(jnp.gradient(f.mantissa, axis=axis), unit=f.unit)
         else:
-            return jnp.gradient(f)
+            return jnp.gradient(f)  # type: ignore[arg-type]
     elif len(varargs) == 1:
         unit = get_unit(f) / get_unit(varargs[0])
         if isinstance(unit, Unit) and unit.is_unitless:
-            return jnp.gradient(f, varargs[0], axis=axis)
+            return jnp.gradient(f, varargs[0], axis=axis)  # type: ignore[arg-type]
         else:
-            return [Quantity(r, unit=unit) for r in jnp.gradient(f.mantissa, Quantity(varargs[0]).mantissa, axis=axis)]
+            return [Quantity(r, unit=unit) for r in jnp.gradient(f.mantissa, Quantity(varargs[0]).mantissa, axis=axis)]  # type: ignore[union-attr]
     else:
         unit_list = [get_unit(f) / get_unit(v) for v in varargs]
         f = f.mantissa if isinstance(f, Quantity) else f
-        varargs = [v.mantissa if isinstance(v, Quantity) else v for v in varargs]
-        result_list = jnp.gradient(f, *varargs, axis=axis)
+        varargs = [v.mantissa if isinstance(v, Quantity) else v for v in varargs]  # type: ignore[assignment]
+        result_list = jnp.gradient(f, *varargs, axis=axis)  # type: ignore[arg-type]
         return [(Quantity(r, unit=unit) if unit is not None else r) for r, unit in zip(result_list, unit_list)]
 
 

--- a/saiunit/math/_misc.py
+++ b/saiunit/math/_misc.py
@@ -121,7 +121,7 @@ def _removechars(s, chars):
 
 # constants
 # ---------
-e = np.e
+e = np.e  # type: ignore[misc]
 pi = np.pi
 inf = np.inf
 nan = np.nan

--- a/saiunit/math/_misc_test.py
+++ b/saiunit/math/_misc_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import brainstate
+import brainstate  # type: ignore[import-untyped]
 import jax.numpy as jnp
 import numpy as np
 from scipy.special import exprel

--- a/saiunit/math/fft.py
+++ b/saiunit/math/fft.py
@@ -17,5 +17,5 @@ from saiunit.fft import *
 from saiunit.fft import __all__ as __all__
 
 if __name__ == '__main__':
-    fft
+    fft  # type: ignore[name-defined] # noqa: F821
     __all__

--- a/saiunit/math/linalg.py
+++ b/saiunit/math/linalg.py
@@ -18,5 +18,5 @@ from saiunit.linalg import *
 from saiunit.linalg import __all__ as __all__
 
 if __name__ == '__main__':
-    eigh
+    eigh  # type: ignore[name-defined] # noqa: F821
     __all__

--- a/saiunit/sparse/_coo.py
+++ b/saiunit/sparse/_coo.py
@@ -32,6 +32,7 @@ from saiunit._base_getters import (
     maybe_decimal,
     split_mantissa_unit,
 )
+from saiunit._jax_compat import ArrayLike
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
 from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
@@ -149,7 +150,7 @@ class COO(SparseMatrix):
         self.data, self.row, self.col = map(asarray, args)
         self._rows_sorted = rows_sorted
         self._cols_sorted = cols_sorted
-        super().__init__(args, shape=shape)
+        super().__init__(args, shape=shape)  # type: ignore[arg-type]
 
     @classmethod
     def fromdense(
@@ -225,7 +226,7 @@ class COO(SparseMatrix):
         data = jnp.ones(diag_size, dtype=dtype)
         idx = jnp.arange(diag_size, dtype=index_dtype)
         zero = _const_like(idx, 0)
-        k = _const_like(idx, k)
+        k = _const_like(idx, k)  # type: ignore[assignment]
         row = lax.sub(idx, lax.cond(k >= 0, lambda: zero, lambda: k))
         col = lax.add(idx, lax.cond(k <= 0, lambda: zero, lambda: k))
         return cls(
@@ -235,7 +236,7 @@ class COO(SparseMatrix):
             cols_sorted=True
         )
 
-    def with_data(self, data: jax.Array | Quantity) -> COO:
+    def with_data(self, data: jax.Array | Quantity) -> COO:  # type: ignore[override]
         """
         Create a new COO matrix with the same sparsity structure but different data.
 
@@ -300,7 +301,7 @@ class COO(SparseMatrix):
             Array([[0., 3.],
                    [4., 0.]], dtype=float32)
         """
-        return coo_todense(self)
+        return coo_todense(self)  # type: ignore[return-value]
 
     def transpose(self, axes: Tuple[int, ...] | None = None) -> COO:
         if axes is not None:
@@ -480,7 +481,7 @@ class COO(SparseMatrix):
         return self._binary_rop(other, operator.mod)
 
     def __matmul__(
-        self, other: jax.typing.ArrayLike
+        self, other: ArrayLike
     ) -> jax.Array | Quantity:
         if isinstance(other, (JAXSparse, SparseMatrix)):
             raise NotImplementedError("matmul between two sparse objects.")
@@ -495,15 +496,15 @@ class COO(SparseMatrix):
             **self._info._asdict()
         )
         if other.ndim == 1:
-            return coo_matvec(self_promoted, other)
+            return coo_matvec(self_promoted, other)  # type: ignore[arg-type]
         elif other.ndim == 2:
-            return coo_matmat(self_promoted, other)
+            return coo_matmat(self_promoted, other)  # type: ignore[arg-type]
         else:
             raise NotImplementedError(f"matmul with object of shape {other.shape}")
 
     def __rmatmul__(
         self,
-        other: jax.typing.ArrayLike
+        other: ArrayLike
     ) -> jax.Array | Quantity:
         if isinstance(other, (JAXSparse, SparseMatrix)):
             raise NotImplementedError("matmul between two sparse objects.")
@@ -518,10 +519,10 @@ class COO(SparseMatrix):
             **self._info._asdict()
         )
         if other.ndim == 1:
-            return coo_matvec(self_promoted, other, transpose=True)
+            return coo_matvec(self_promoted, other, transpose=True)  # type: ignore[arg-type]
         elif other.ndim == 2:
             other = other.T
-            return coo_matmat(self_promoted, other, transpose=True).T
+            return coo_matmat(self_promoted, other, transpose=True).T  # type: ignore[arg-type]
         else:
             raise NotImplementedError(f"matmul with object of shape {other.shape}")
 

--- a/saiunit/sparse/_coo_test.py
+++ b/saiunit/sparse/_coo_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import unittest
 
-import brainstate as bst
+import brainstate as bst  # type: ignore[import-untyped]
 import jax
 
 import saiunit as u

--- a/saiunit/sparse/_csr.py
+++ b/saiunit/sparse/_csr.py
@@ -101,7 +101,7 @@ class CSR(SparseMatrix):
         Array([[1., 0., 2.],
                [0., 0., 3.]], dtype=float32)
     """
-    data: jax.Array | Quantity
+    data: jax.Array | Quantity  # type: ignore[assignment]
     indices: jax.Array
     indptr: jax.Array
     shape: tuple[int, int]
@@ -155,7 +155,7 @@ class CSR(SparseMatrix):
             jnp.cumsum(jnp.bincount(row, length=N).astype(index_dtype)))
         return cls((data, indices, indptr), shape=(N, M))
 
-    def with_data(self, data: jax.Array | Quantity) -> CSR:
+    def with_data(self, data: jax.Array | Quantity) -> CSR:  # type: ignore[override]
         """
         Create a new CSR matrix with the same sparsity structure but different data.
 
@@ -481,7 +481,7 @@ class CSC(SparseMatrix):
     def _eye(cls, N, M, k, *, dtype=None, index_dtype='int32'):
         return CSR._eye(M, N, -k, dtype=dtype, index_dtype=index_dtype).T
 
-    def with_data(self, data: jax.Array | Quantity) -> CSC:
+    def with_data(self, data: jax.Array | Quantity) -> CSC:  # type: ignore[override]
         """
         Create a new CSC matrix with the same sparsity structure but different data.
 

--- a/saiunit/sparse/_csr_test.py
+++ b/saiunit/sparse/_csr_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import unittest
 
-import brainstate as bst
+import brainstate as bst  # type: ignore[import-untyped]
 import jax
 
 import saiunit as u
@@ -769,7 +769,7 @@ def test_csr_fromdense_raises_on_numpy_quantity():
         u.sparse.CSR.fromdense(q)
 
 
-def test_csr_fromdense_raises_on_numpy_quantity():
+def test_csr_fromdense_raises_on_numpy_quantity():  # type: ignore[no-redef]
     import numpy as np
     import pytest
     import saiunit as u

--- a/saiunit/typing.py
+++ b/saiunit/typing.py
@@ -90,13 +90,14 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Annotated, Any, Union, get_type_hints, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, Union, get_type_hints, get_origin
 
 import numpy as np
 
 from ._jax_compat import Array as _JaxArray
+from ._jax_compat import ArrayLike, ScalarOrArrayLike
 
-from ._base_dimension import UnitMismatchError, DimensionMismatchError
+from ._base_dimension import Dimension, UnitMismatchError, DimensionMismatchError
 from ._base_dimension import get_or_create_dimension
 from ._base_quantity import Quantity
 from ._base_unit import Unit
@@ -107,6 +108,8 @@ __all__ = [
     'is_physical_type',
 
     # Core type aliases
+    'ArrayLike',
+    'ScalarOrArrayLike',
     'QuantityLike',
     'UnitLike',
     'DimensionLike',
@@ -410,35 +413,72 @@ DimensionLike = Union["Dimension", str]
 # ---------------------------------------------------------------------------
 # Pre-built physical-type aliases
 # ---------------------------------------------------------------------------
+#
+# At runtime, ``Quantity['length']`` returns a metaclass-backed class that
+# supports ``isinstance`` checks. Static type checkers (mypy/pyright) don't
+# know about ``Quantity.__class_getitem__`` and would otherwise emit
+# ``Quantity expects no type arguments`` and ``Name "length" is not defined``
+# for every alias below. To keep both worlds happy, ``TYPE_CHECKING`` exposes
+# plain ``Quantity`` aliases (acceptable in any annotation context), while
+# the runtime branch keeps the metaclass-backed types needed by ``isinstance``
+# and ``validate_units``.
 
-# Eager module-level aliases for common physical types.
 HAS_UNIT = Quantity
-DIMENSIONLESS_TYPE = Quantity['dimensionless']
-LENGTH = Quantity['length']
-MASS = Quantity['mass']
-TIME = Quantity['time']
-CURRENT = Quantity['current']
-TEMPERATURE = Quantity['temperature']
-SUBSTANCE = Quantity['substance']
-LUMINOSITY = Quantity['luminosity']
-FREQUENCY = Quantity['frequency']
-FORCE = Quantity['force']
-ENERGY = Quantity['energy']
-POWER = Quantity['power']
-PRESSURE = Quantity['pressure']
-CHARGE = Quantity['charge']
-VOLTAGE = Quantity['voltage']
-RESISTANCE = Quantity['resistance']
-CAPACITANCE = Quantity['capacitance']
-CONDUCTANCE = Quantity['conductance']
-MAGNETIC_FLUX = Quantity['magnetic flux']
-MAGNETIC_FIELD = Quantity['magnetic field']
-INDUCTANCE = Quantity['inductance']
-SPEED = Quantity['speed']
-ACCELERATION = Quantity['acceleration']
-AREA = Quantity['area']
-VOLUME = Quantity['volume']
-DENSITY = Quantity['density']
+
+if TYPE_CHECKING:
+    DIMENSIONLESS_TYPE = Quantity
+    LENGTH = Quantity
+    MASS = Quantity
+    TIME = Quantity
+    CURRENT = Quantity
+    TEMPERATURE = Quantity
+    SUBSTANCE = Quantity
+    LUMINOSITY = Quantity
+    FREQUENCY = Quantity
+    FORCE = Quantity
+    ENERGY = Quantity
+    POWER = Quantity
+    PRESSURE = Quantity
+    CHARGE = Quantity
+    VOLTAGE = Quantity
+    RESISTANCE = Quantity
+    CAPACITANCE = Quantity
+    CONDUCTANCE = Quantity
+    MAGNETIC_FLUX = Quantity
+    MAGNETIC_FIELD = Quantity
+    INDUCTANCE = Quantity
+    SPEED = Quantity
+    ACCELERATION = Quantity
+    AREA = Quantity
+    VOLUME = Quantity
+    DENSITY = Quantity
+else:
+    DIMENSIONLESS_TYPE = Quantity['dimensionless']
+    LENGTH = Quantity['length']
+    MASS = Quantity['mass']
+    TIME = Quantity['time']
+    CURRENT = Quantity['current']
+    TEMPERATURE = Quantity['temperature']
+    SUBSTANCE = Quantity['substance']
+    LUMINOSITY = Quantity['luminosity']
+    FREQUENCY = Quantity['frequency']
+    FORCE = Quantity['force']
+    ENERGY = Quantity['energy']
+    POWER = Quantity['power']
+    PRESSURE = Quantity['pressure']
+    CHARGE = Quantity['charge']
+    VOLTAGE = Quantity['voltage']
+    RESISTANCE = Quantity['resistance']
+    CAPACITANCE = Quantity['capacitance']
+    CONDUCTANCE = Quantity['conductance']
+    MAGNETIC_FLUX = Quantity['magnetic flux']
+    MAGNETIC_FIELD = Quantity['magnetic field']
+    INDUCTANCE = Quantity['inductance']
+    SPEED = Quantity['speed']
+    ACCELERATION = Quantity['acceleration']
+    AREA = Quantity['area']
+    VOLUME = Quantity['volume']
+    DENSITY = Quantity['density']
 
 
 # ---------------------------------------------------------------------------
@@ -577,7 +617,7 @@ def _extract_unit_metadata(hint) -> tuple[str, Any] | None:
 
     # Check for _AnnotatedQuantityMeta (new-style Quantity[...])
     if isinstance(hint, _AnnotatedQuantityMeta):
-        meta = hint._metadata
+        meta = hint._metadata  # type: ignore[attr-defined]
         if isinstance(meta, Unit):
             return ("unit", meta)
         if is_physical_type(meta):

--- a/saiunit/typing_test.py
+++ b/saiunit/typing_test.py
@@ -313,7 +313,7 @@ class TestValidateUnits:
 
     def test_physical_type_annotation(self):
         @validate_units
-        def f(x: u.Quantity["length"]):
+        def f(x: u.Quantity["length"]):  # type: ignore[name-defined]
             return x
 
         result = f(1.0 * u.meter)
@@ -332,7 +332,7 @@ class TestValidateUnits:
 
     def test_none_value_skipped(self):
         @validate_units
-        def f(x: u.Quantity[u.meter] = None):
+        def f(x: u.Quantity[u.meter] = None):  # type: ignore[assignment]
             return x
 
         result = f(None)
@@ -381,8 +381,8 @@ class TestIntegration:
         @validate_units
         def kinetic_energy(
             m: u.Quantity[u.kilogram],
-            v: u.Quantity["speed"],
-        ) -> u.Quantity["energy"]:
+            v: u.Quantity["speed"],  # type: ignore[name-defined]
+        ) -> u.Quantity["energy"]:  # type: ignore[name-defined]
             return 0.5 * m * v ** 2
 
         mass = 10.0 * u.kilogram
@@ -394,7 +394,7 @@ class TestIntegration:
     def test_isinstance_and_validate_together(self):
         """isinstance check + validate_units on same function."""
         @validate_units
-        def f(x: u.Quantity["length"]):
+        def f(x: u.Quantity["length"]):  # type: ignore[name-defined]
             return x
 
         q_length = 5.0 * u.meter


### PR DESCRIPTION
## Summary
- Reduce mypy errors from 2,019 → 0 across `saiunit/` (111 source files)
- Add a dedicated `type_check` CI job that runs `mypy saiunit/` on Ubuntu/Python 3.13
- Migrate ~658 `jax.typing.ArrayLike` references to a narrow alias that excludes bare Python scalars, eliminating the dominant `union-attr` false-positives

## Key changes
- **Narrow `ArrayLike`** in `saiunit/_jax_compat.py`: `jax.Array | np.ndarray | np.number | np.bool_` (and a `ScalarOrArrayLike` superset). Re-exported from `saiunit.typing`.
- **`TYPE_CHECKING` Quantity** imports added to `_base_getters.py` and `_base_unit.py` to remove circular-import name-defined errors.
- **`Unit` class** gains slot-typed attributes (`_dim`, `_base`, `_scale`, `_factor`, `_dispname`, `_name`, `_display_parts`, ...) so mypy can resolve `unit._base` etc.
- **`Quantity.__init__`** unit param narrowed to `Unit | str | None` with a runtime `assert isinstance(unit, Unit)` after string-parsing; `_mantissa` typed as `ArrayLike`.
- **16 implicit-Optional parameters** in `lax/math/fft` modules fixed (e.g. `fill_value: Union[Quantity, ArrayLike] = None` → `Optional[Union[...]]`).
- Targeted `# type: ignore[...]` only where (a) JAX stubs require strict `Array` but accept `ArrayLike` at runtime, (b) `absl-py` `parameterized.product` confuses mypy in test fixtures, (c) third-party stubs are missing (`brainstate`, `cupy`, `opt_einsum`, `jax.util`).
- New CI job `type_check` (~1 min) installs `requirements-dev.txt` + `mypy>=1.11,<3` and runs `mypy saiunit/`.

## Test plan
- [x] `mypy saiunit/` → 0 errors locally (mypy 2.1.0)
- [x] `pytest saiunit/_base*_test.py saiunit/typing_test.py` → 638 passed, 4 skipped
- [x] `pytest saiunit/math/` → 727 passed
- [x] `pytest saiunit/lax/ saiunit/fft/ saiunit/sparse/ saiunit/linalg/` → 764 passed
- [x] `pytest saiunit/autograd/` → 62 passed
- [x] `pytest saiunit/_scatter_test.py saiunit/_backend_parametrize_test.py saiunit/custom_array_test.py saiunit/_celsius_test.py` → 206 passed, 69 skipped
- [x] Runtime smoke test (`Quantity`, `display_in_unit`, `in_unit`, `==`, `math.flatten`) ✓
- [ ] CI: new `type_check` job runs `mypy saiunit/` and passes
- [ ] CI: existing test matrix (Linux/macOS/Windows + `test_no_jax`) still passes