### PR TITLE
refactor(typing): consolidate type aliases under saiunit/_typing.py

### DIFF
--- a/docs/superpowers/specs/2026-05-24-saiunit-typing-consolidation-design.md
+++ b/docs/superpowers/specs/2026-05-24-saiunit-typing-consolidation-design.md
@@ -1,0 +1,192 @@
+# Spec: Consolidate type aliases under `saiunit/_typing.py`
+
+**Date:** 2026-05-24
+**Branch:** multi-backend
+**Scope:** Internal refactor; no public API breakage.
+
+## Goal
+
+Make `saiunit/_typing.py` the single internal source of truth for low-level
+type aliases (`Array`, `ArrayLike`, `ScalarOrArrayLike`, `DTypeLike`, `Shape`,
+`Axis`, `Axes`, `PyTree`). Replace every direct reference to `jax.Array`,
+`jax.typing.DTypeLike`, etc. across saiunit's production code with imports
+from `saiunit._typing` (or the re-exporting public `saiunit.typing`).
+
+## Motivation
+
+Today these aliases live in `saiunit/_jax_compat.py` (a runtime-compat
+module). Direct references to `jax.Array` / `jax.typing.DTypeLike` are
+scattered across ~30 files. This makes the no-JAX code path fragile —
+`jax.typing.DTypeLike` blows up the moment JAX is absent — and ties typing
+to the runtime-shim module. Pulling type aliases into a dedicated module
+gives saiunit one place to evolve them and lets the runtime shim shrink to
+its actual job (JAX vs. NumPy backend).
+
+## Architecture
+
+```
+saiunit/_typing.py        ← NEW: internal source for basic type aliases
+saiunit/_jax_compat.py    ← drops type aliases (Array/ArrayLike/etc.) from __all__
+saiunit/typing.py         ← re-exports aliases from _typing + keeps Quantity-aware types
+```
+
+**Import rules:**
+- `_typing.py` depends only on `numpy` and the JAX-presence probe; no Quantity dependency.
+- `_jax_compat.py` no longer publishes type aliases. It may import from `_typing` for its own internal use.
+- `typing.py` re-exports every alias from `_typing` so `from saiunit.typing import ArrayLike` continues to work for external users.
+- All saiunit production code imports basic aliases from `saiunit._typing` (private path is appropriate for internal callers).
+
+## `saiunit/_typing.py` contents
+
+```python
+"""Internal type aliases used across saiunit.
+
+Centralized here so the no-JAX path stays import-safe and so saiunit core
+modules don't depend on the runtime shim (`_jax_compat`) just to grab a
+type alias. External users should import these from `saiunit.typing`, which
+re-exports them.
+"""
+from __future__ import annotations
+
+from typing import Any, Sequence, Union
+
+import numpy as np
+
+try:
+    import jax as _jax            # noqa: F401  (presence probe only)
+    _HAS_JAX = True
+except ImportError:
+    _HAS_JAX = False
+
+
+if _HAS_JAX:
+    import jax as _jax
+    Array = _jax.Array
+    ArrayLike = _jax.Array | np.ndarray | np.number | np.bool_
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex
+    DTypeLike = _jax.typing.DTypeLike
+else:
+    class _JaxSentinel:
+        __slots__ = ()
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("JAX is not installed")
+    Array = type("Array", (_JaxSentinel,), {})
+    ArrayLike = np.ndarray | np.number | np.bool_                       # type: ignore[misc]
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex        # type: ignore[misc]
+    DTypeLike = Any                                                     # type: ignore[misc]
+
+
+Shape = Sequence[int]
+Axis = int
+Axes = Union[int, Sequence[int]]
+PyTree = Any  # See https://docs.jax.dev/en/latest/pytrees.html — an opaque tree of leaves.
+
+
+__all__ = [
+    "Array",
+    "ArrayLike",
+    "ScalarOrArrayLike",
+    "DTypeLike",
+    "Shape",
+    "Axis",
+    "Axes",
+    "PyTree",
+]
+```
+
+The sentinel class for `Array` mirrors the existing pattern in
+`_jax_compat.py` so `isinstance(x, Array)` keeps returning `False` (the
+right answer) when JAX is absent.
+
+## `saiunit/_jax_compat.py` changes
+
+- Remove `Array`, `ArrayLike`, `ScalarOrArrayLike`, `DTypeLike` definitions.
+- Drop them from `__all__`.
+- Keep `Tracer`, `ShapedArray`, `ShapeDtypeStruct`, `DynamicJaxprTracer`, `TracerArrayConversionError`, `register_pytree_node_class`, `ensure_compile_time_eval`, `result_type`, `canonicalize_dtype`, `tree_map`, `tree_structure`, `tree_flatten`, `tree`, `device_put`, `devices`, `require_jax`, `HAS_JAX`, `jax`, `jnp`.
+- If anything inside `_jax_compat.py` itself needs `Array`/`ArrayLike`/etc., import them from `saiunit._typing` at the top.
+
+## `saiunit/typing.py` changes
+
+- Drop the line `from ._jax_compat import Array as _JaxArray` and `from ._jax_compat import ArrayLike, ScalarOrArrayLike`.
+- Replace with `from ._typing import Array, ArrayLike, ScalarOrArrayLike, DTypeLike, Shape, Axis, Axes, PyTree`.
+- Add the new aliases to `__all__` so they're exported from `saiunit.typing`.
+- `QuantityLike` continues to use the now-local `Array` alias.
+
+## Production-code migration
+
+Replace every direct reference across the following files:
+
+**`ArrayLike` / `ScalarOrArrayLike` imports (from `_jax_compat` → from `_typing`):**
+- `saiunit/custom_array.py`
+- `saiunit/fft/_fft_change_unit.py`
+- `saiunit/fft/_fft_keep_unit.py`
+- `saiunit/lax/_lax_accept_unitless.py`
+- `saiunit/lax/_lax_array_creation.py`
+- `saiunit/lax/_lax_change_unit.py`
+- `saiunit/lax/_lax_keep_unit.py`
+- `saiunit/lax/_lax_linalg.py`
+- `saiunit/lax/_lax_remove_unit.py`
+- `saiunit/lax/_misc.py`
+- `saiunit/linalg/_linalg_change_unit.py`
+- `saiunit/linalg/_linalg_keep_unit.py`
+- `saiunit/linalg/_linalg_remove_unit.py`
+- `saiunit/math/_activation.py`
+- `saiunit/math/_einops.py`
+- `saiunit/math/_exprel.py`
+- `saiunit/math/_fun_accept_unitless.py`
+- `saiunit/math/_fun_array_creation.py`
+- `saiunit/math/_fun_change_unit.py`
+- `saiunit/math/_fun_keep_unit.py`
+- `saiunit/math/_fun_remove_unit.py`
+- `saiunit/math/_misc.py`
+- `saiunit/sparse/_coo.py`
+- `saiunit/sparse/_csr.py`
+- `saiunit/_base_getters.py`
+- `saiunit/_base_quantity.py`
+- `saiunit/_sparse_base.py`
+
+**`jax.typing.DTypeLike` → `DTypeLike` (imported from `saiunit._typing`):**
+- `saiunit/fft/_fft_change_unit.py`
+- `saiunit/lax/_lax_array_creation.py`
+- `saiunit/lax/_lax_change_unit.py`
+- `saiunit/lax/_lax_keep_unit.py`
+- `saiunit/math/_einops.py`
+- `saiunit/math/_fun_accept_unitless.py`
+- `saiunit/math/_fun_array_creation.py`
+
+**`jax.Array` → `Array` (imported from `saiunit._typing`):**
+- `saiunit/lax/_lax_accept_unitless.py`
+- `saiunit/lax/_lax_array_creation.py`
+- `saiunit/lax/_lax_change_unit.py`
+- `saiunit/lax/_lax_keep_unit.py`
+- `saiunit/lax/_lax_remove_unit.py`
+- `saiunit/math/_einops.py`
+- (plus any other file that uses `jax.Array` in annotations or docstrings)
+
+**Local `Shape = Sequence[int]` definitions:**
+- `saiunit/fft/_fft_change_unit.py` (line 61) — remove the local definition; import `Shape` from `saiunit._typing` instead.
+
+**Docstring replacements:**
+Replace docstring references that currently say `jax.Array` or `jax.typing.DTypeLike` with `Array` / `DTypeLike` to keep the docs consistent with the new aliases. Docstring text in `Returns` / `Parameters` sections counts.
+
+## Test scope
+
+- Test files (`_test.py`) are **not** migrated. They may continue to reference `jax.Array` / `jax.typing.DTypeLike` directly.
+- Existing tests must continue to pass: `saiunit/typing_test.py`, `saiunit/_no_jax_test.py`, `saiunit/_jax_guard_test.py`, `saiunit/_backend_parametrize_test.py`, plus the broader suite.
+- Add a small block of new tests in `saiunit/typing_test.py` covering the newly-public aliases (`Array`, `DTypeLike`, `Shape`, `Axis`, `Axes`, `PyTree`) — at minimum: importable from `saiunit.typing`, are the expected types, and `isinstance` for `Array` still behaves correctly with/without JAX.
+
+## Acceptance criteria
+
+1. `from saiunit.typing import Array, ArrayLike, ScalarOrArrayLike, DTypeLike, Shape, Axis, Axes, PyTree` works.
+2. `grep -rn "jax\.typing\|jax\.Array" saiunit/ --include="*.py"` returns no matches in production code (test files are out of scope).
+3. `grep -rn "from saiunit\._jax_compat import .*ArrayLike\|from saiunit\._jax_compat import .*DTypeLike\|from saiunit\._jax_compat import .*ScalarOrArrayLike\|from \._jax_compat import .*ArrayLike\|from \._jax_compat import .*DTypeLike\|from \._jax_compat import .*ScalarOrArrayLike" saiunit/ --include="*.py" | grep -v "_test.py"` returns no matches.
+4. `saiunit/_jax_compat.py`'s `__all__` no longer contains `Array`, `ArrayLike`, `ScalarOrArrayLike`, `DTypeLike`.
+5. Full test suite passes (under both JAX-installed and no-JAX conditions, if separate jobs exist).
+6. `mypy` type-check job (the `type_check` CI job from commit `b32ee04`) remains clean.
+
+## Non-goals
+
+- Top-level re-exports (`saiunit.ArrayLike`) are **not** added — aliases stay under `saiunit.typing`.
+- No changes to `QuantityLike`, `UnitLike`, `DimensionLike`, `PhysicalType`, `validate_units`, or the pre-built physical-type aliases (`LENGTH`, `MASS`, …).
+- No changes to test files.
+- No version bump.

--- a/saiunit/_backend.py
+++ b/saiunit/_backend.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from saiunit._exceptions import BackendError
 from saiunit._jax_compat import HAS_JAX, jax, jnp
+from saiunit._typing import Array
 
 # Local alias kept for backwards compatibility with callers that reference
 # ``_jax_xp`` directly. ``None`` when JAX is not installed.
@@ -88,16 +89,16 @@ def is_numpy_array(x) -> bool:
     """
     if not isinstance(x, (np.ndarray, np.generic)):
         return False
-    if HAS_JAX and isinstance(x, jax.Array):
+    if HAS_JAX and isinstance(x, Array):
         return False
     return True
 
 
 def is_jax_array(x) -> bool:
-    """Return True if ``x`` is a ``jax.Array``. False if JAX is not installed."""
+    """Return True if ``x`` is an ``Array``. False if JAX is not installed."""
     if not HAS_JAX:
         return False
-    return isinstance(x, jax.Array)
+    return isinstance(x, Array)
 
 
 def is_cupy_array(x) -> bool:

--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -24,11 +24,11 @@ from ._jax_compat import (
     HAS_JAX,
     jax,
     jnp,
-    ArrayLike,
     ShapeDtypeStruct as _ShapeDtypeStruct,
     ShapedArray as _ShapedArray,
     Tracer as _Tracer,
 )
+from ._typing import Array, ArrayLike, DTypeLike
 
 if TYPE_CHECKING:
     from ._base_quantity import Quantity
@@ -651,7 +651,7 @@ def display_in_unit(
 def maybe_decimal(
     val: 'Quantity | ArrayLike',
     unit: 'Unit | None' = None
-) -> 'jax.Array | Quantity | ArrayLike':
+) -> 'Array | Quantity | ArrayLike':
     """
     Convert a quantity to a plain number if it is dimensionless.
 
@@ -743,7 +743,7 @@ def unit_scale_align_to_first(*args) -> 'list[Quantity]':
 def array_with_unit(
     mantissa,
     unit: 'Unit',
-    dtype: jax.typing.DTypeLike | None = None
+    dtype: DTypeLike | None = None
 ) -> 'Quantity':
     """
     Create a new `Quantity` with the given unit.

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -30,14 +30,17 @@ from ._jax_compat import (
     HAS_JAX,
     jax,
     jnp,
-    ArrayLike,
-    Array as _JaxArray,
-    DTypeLike as _JaxDTypeLike,
     canonicalize_dtype as _canonicalize_dtype,
     ensure_compile_time_eval as _ensure_compile_time_eval,
     register_pytree_node_class,
     result_type as _result_type,
     tree as _jtree,
+)
+from ._typing import (
+    Array,
+    ArrayLike,
+    Array as _JaxArray,
+    DTypeLike,
 )
 from ._base_dimension import Dimension, UnitMismatchError, _is_tracer
 from ._base_getters import (
@@ -554,7 +557,7 @@ class Quantity:
         self,
         mantissa: PyTree | Unit,
         unit: 'Unit | str | None' = UNITLESS,
-        dtype: jax.typing.DTypeLike | None = None,
+        dtype: DTypeLike | None = None,
     ):
 
         # ``ensure_compile_time_eval`` is a no-op outside tracing; inside a
@@ -1339,7 +1342,7 @@ class Quantity:
         return Quantity(to_backend(self._mantissa, "numpy"), unit=self.unit)
 
     def to_jax(self) -> 'Quantity':
-        """Return a new Quantity with mantissa converted to ``jax.Array``.
+        """Return a new Quantity with mantissa converted to ``Array``.
 
         No-op (returns ``self``) if the mantissa is already a JAX array.
         """
@@ -1522,7 +1525,7 @@ class Quantity:
         return Quantity(mt, unit=self.unit)
 
     @property
-    def isreal(self) -> jax.Array:
+    def isreal(self) -> Array:
         xp = get_backend(self)
         # array_api_compat.numpy lacks isreal; fall back to imag == 0.
         if hasattr(xp, "isreal"):
@@ -1534,19 +1537,19 @@ class Quantity:
         return self.ndim == 0
 
     @property
-    def isfinite(self) -> jax.Array:
+    def isfinite(self) -> Array:
         return get_backend(self).isfinite(self.mantissa)
 
     @property
-    def isinfinite(self) -> jax.Array:
+    def isinfinite(self) -> Array:
         return get_backend(self).isinf(self.mantissa)
 
     @property
-    def isinf(self) -> jax.Array:
+    def isinf(self) -> Array:
         return get_backend(self).isinf(self.mantissa)
 
     @property
-    def isnan(self) -> jax.Array:
+    def isnan(self) -> Array:
         return get_backend(self).isnan(self.mantissa)
 
     # ----------------------- #
@@ -2402,7 +2405,7 @@ class Quantity:
 
     def astype(
         self,
-        dtype: jax.typing.DTypeLike
+        dtype: DTypeLike
     ) -> 'Quantity':
         """
         Return a copy of this quantity with the mantissa cast to *dtype*.
@@ -2692,7 +2695,7 @@ class Quantity:
         r = Quantity(result_mantissa, unit=result_unit)  # type: ignore[arg-type]
         return maybe_decimal(r)
 
-    def searchsorted(self, v, side: str = 'left', sorter=None) -> jax.Array:
+    def searchsorted(self, v, side: str = 'left', sorter=None) -> Array:
         """Find indices where elements should be inserted to maintain order."""
         if isinstance(v, Quantity):
             v = v.in_unit(self.unit).mantissa
@@ -3459,7 +3462,7 @@ class Quantity:
 
         return saiunit_fn(*inputs, **kwargs)
 
-    def __array__(self, dtype: jax.typing.DTypeLike | None = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Support ``numpy.array()`` and ``numpy.asarray()`` functions.
 
         Only dimensionless quantities are coercible — converting a unit-bearing

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -24,7 +24,7 @@ from ._base_dimension import (
     DIMENSIONLESS,
     _is_tracer,
 )
-from ._jax_compat import ArrayLike
+from ._typing import ArrayLike
 
 if TYPE_CHECKING:
     from ._base_quantity import Quantity

--- a/saiunit/_celsius.py
+++ b/saiunit/_celsius.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from ._base_quantity import Quantity
 from ._misc import maybe_custom_array
 from ._unit_common import kelvin
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import ArrayLike
 
 __all__ = [
     "celsius2kelvin",

--- a/saiunit/_jax_compat.py
+++ b/saiunit/_jax_compat.py
@@ -30,13 +30,15 @@ not installed, fallbacks are provided so that:
   :class:`BackendError` with an install hint when called.
 
 External callers should not import this module directly. Inside saiunit, prefer
-``from saiunit._jax_compat import jax, jnp, Array, ...``.
+``from saiunit._jax_compat import jax, jnp, tree, ...``. Type aliases (``Array``,
+``ArrayLike``, ``DTypeLike``, ...) live in :mod:`saiunit._typing` and should be
+imported from there.
 """
 
 from __future__ import annotations
 
 import contextlib
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
 
@@ -46,10 +48,6 @@ __all__ = [
     "HAS_JAX",
     "jax",
     "jnp",
-    "Array",
-    "ArrayLike",
-    "ScalarOrArrayLike",
-    "DTypeLike",
     "Tracer",
     "ShapedArray",
     "ShapeDtypeStruct",
@@ -91,17 +89,6 @@ except ImportError:  # pragma: no cover - exercised only in no-jax CI job
 if HAS_JAX:
     jax = _jax
     jnp = _jnp
-    Array = _jax.Array
-    # Narrow array-like alias: types that genuinely support ``.shape`` /
-    # ``.ndim`` / ``.dtype``. Excludes bare Python scalars (``bool``, ``int``,
-    # ``float``, ``complex``) so that mypy/pyright don't emit ``union-attr``
-    # false positives when downstream code reads those attributes. Callers
-    # that want to accept Python scalars too should use :data:`ScalarOrArrayLike`.
-    ArrayLike = _jax.Array | np.ndarray | np.number | np.bool_
-    # Wide alias: everything :data:`jax.typing.ArrayLike` accepts, including
-    # bare Python scalars. Use sparingly — prefer :data:`ArrayLike`.
-    ScalarOrArrayLike = ArrayLike | bool | int | float | complex
-    DTypeLike = _jax.typing.DTypeLike
     Tracer = _jax.core.Tracer
     ShapedArray = _jax.core.ShapedArray
     ShapeDtypeStruct = _jax.ShapeDtypeStruct
@@ -124,7 +111,7 @@ else:
     class _JaxSentinel:
         """Class that no real object can ever be an instance of.
 
-        Used as a placeholder for ``jax.Array``, ``jax.core.Tracer``, etc.
+        Used as a placeholder for ``jax.core.Tracer``, etc.
         ``isinstance(x, _JaxSentinel)`` is always ``False``, which is the
         correct answer when JAX is not installed.
         """
@@ -137,14 +124,10 @@ else:
                 "Install with: pip install saiunit[jax]"
             )
 
-    Array = type("Array", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     Tracer = type("Tracer", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     ShapedArray = type("ShapedArray", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     ShapeDtypeStruct = type("ShapeDtypeStruct", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
     DynamicJaxprTracer = type("DynamicJaxprTracer", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
-    ArrayLike = np.ndarray | np.number | np.bool_  # type: ignore[misc, assignment]
-    ScalarOrArrayLike = ArrayLike | bool | int | float | complex  # type: ignore[misc]
-    DTypeLike = Any  # type: ignore[assignment, misc]
 
     class TracerArrayConversionError(Exception):  # type: ignore[no-redef]
         """Placeholder for ``jax.errors.TracerArrayConversionError``.

--- a/saiunit/_sparse_base.py
+++ b/saiunit/_sparse_base.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Union
 import numpy as np
 
 from ._jax_compat import Tracer as _Tracer
+from ._typing import Array
 
 if TYPE_CHECKING:
     import jax
@@ -61,7 +62,7 @@ class SparseMatrix:
 
     Attributes
     ----------
-    data : jax.Array
+    data : Array
         The non-zero values in the sparse matrix.
 
     Notes
@@ -86,7 +87,7 @@ class SparseMatrix:
         True
     """
 
-    data: jax.Array
+    data: Array
     shape: tuple[int, ...]
     nse: property
     dtype: property
@@ -95,7 +96,7 @@ class SparseMatrix:
 
     def __init__(
         self,
-        args: tuple[jax.Array, ...],
+        args: tuple[Array, ...],
         *,
         shape: Sequence[int]
     ):
@@ -148,14 +149,14 @@ class SparseMatrix:
 
     def with_data(
         self,
-        data: Union[jax.Array, np.ndarray, numbers.Number, 'Quantity']
+        data: Union[Array, np.ndarray, numbers.Number, 'Quantity']
     ):
         """
         Create a new sparse matrix with the same sparsity structure but different data.
 
         Parameters
         ----------
-        data : jax.Array, numpy.ndarray, numbers.Number, or Quantity
+        data : Array, numpy.ndarray, numbers.Number, or Quantity
             The new non-zero values. Must have the same shape, dtype, and unit
             as the current ``self.data``.
 
@@ -198,7 +199,7 @@ class SparseMatrix:
 
         Returns
         -------
-        jax.Array or Quantity
+        Array or Quantity
             The sum of all elements in the sparse matrix.
 
         Raises
@@ -212,9 +213,9 @@ class SparseMatrix:
 
     def yw_to_w(
         self,
-        y_dim_arr: Union[jax.Array, np.ndarray, 'Quantity'],
-        w_dim_arr: Union[jax.Array, np.ndarray, 'Quantity']
-    ) -> Union[jax.Array, 'Quantity']:
+        y_dim_arr: Union[Array, np.ndarray, 'Quantity'],
+        w_dim_arr: Union[Array, np.ndarray, 'Quantity']
+    ) -> Union[Array, 'Quantity']:
         """
         The protocol method to convert the product of the sparse matrix and a vector to the sparse matrix data.
 

--- a/saiunit/_typing.py
+++ b/saiunit/_typing.py
@@ -1,0 +1,108 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Internal type aliases used across saiunit.
+
+Centralized here so the no-JAX path stays import-safe and so saiunit core
+modules don't depend on the runtime shim (``_jax_compat``) just to grab a
+type alias. External users should import these from :mod:`saiunit.typing`,
+which re-exports every name in :data:`__all__`.
+
+Aliases
+-------
+Array
+    Either ``jax.Array`` (when JAX is installed) or a sentinel class whose
+    ``isinstance`` check is always False (when JAX is absent). Safe to use in
+    annotations and ``isinstance`` checks regardless of backend.
+ArrayLike
+    Narrow array-like alias: types that genuinely support ``.shape`` /
+    ``.ndim`` / ``.dtype``. Excludes bare Python scalars so that static
+    checkers don't emit ``union-attr`` false positives when callers read
+    those attributes.
+ScalarOrArrayLike
+    Wide alias: everything :data:`jax.typing.ArrayLike` accepts, including
+    bare Python scalars. Use sparingly — prefer :data:`ArrayLike`.
+DTypeLike
+    Anything acceptable as a NumPy/JAX dtype specifier.
+Shape
+    Sequence of integer dimensions, e.g. ``(3, 4)`` or ``[3, 4]``.
+Axis
+    Single axis index.
+Axes
+    A single axis index or a sequence of axis indices.
+PyTree
+    Opaque pytree alias (an arbitrarily-nested structure of registered
+    container nodes whose leaves are arrays/scalars/etc.). See
+    https://docs.jax.dev/en/latest/pytrees.html.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, Union
+
+import numpy as np
+
+try:
+    import jax as _jax
+    _HAS_JAX = True
+except ImportError:  # pragma: no cover - exercised only in no-jax CI job
+    _jax = None  # type: ignore[assignment]
+    _HAS_JAX = False
+
+
+if _HAS_JAX:
+    Array = _jax.Array
+    ArrayLike = _jax.Array | np.ndarray | np.number | np.bool_
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex
+    DTypeLike = _jax.typing.DTypeLike
+else:
+    class _JaxSentinel:
+        """Class that no real object can ever be an instance of.
+
+        Used as a placeholder for ``jax.Array`` when JAX is not installed.
+        ``isinstance(x, _JaxSentinel)`` is always ``False``, which is the
+        correct answer when JAX is not installed.
+        """
+
+        __slots__ = ()
+
+        def __init__(self, *args, **kwargs):  # pragma: no cover
+            raise RuntimeError(
+                "Cannot instantiate JAX sentinel type without JAX. "
+                "Install with: pip install saiunit[jax]"
+            )
+
+    Array = type("Array", (_JaxSentinel,), {})  # type: ignore[misc, assignment]
+    ArrayLike = np.ndarray | np.number | np.bool_  # type: ignore[misc, assignment]
+    ScalarOrArrayLike = ArrayLike | bool | int | float | complex  # type: ignore[misc]
+    DTypeLike = Any  # type: ignore[assignment, misc]
+
+
+Shape = Sequence[int]
+Axis = int
+Axes = Union[int, Sequence[int]]
+PyTree = Any
+
+
+__all__ = [
+    "Array",
+    "ArrayLike",
+    "ScalarOrArrayLike",
+    "DTypeLike",
+    "Shape",
+    "Axis",
+    "Axes",
+    "PyTree",
+]

--- a/saiunit/custom_array.py
+++ b/saiunit/custom_array.py
@@ -22,7 +22,8 @@ from typing import Any, Optional, Union, Sequence
 import numpy as np
 
 from saiunit import math
-from saiunit._jax_compat import HAS_JAX, jnp, ArrayLike  # type: ignore[attr-defined]
+from saiunit._jax_compat import HAS_JAX, jnp
+from saiunit._typing import ArrayLike
 
 __all__ = [
     'CustomArray',

--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 from typing import Callable, Union, Sequence
 
-from saiunit._jax_compat import HAS_JAX, jax, jnp, ArrayLike
+from saiunit._jax_compat import HAS_JAX, jax, jnp
+from saiunit._typing import ArrayLike, DTypeLike, Shape
 import numpy as np
 
 if HAS_JAX:
@@ -56,9 +57,6 @@ def unit_change(
         return set_module_as('saiunit.fft')(func)
 
     return actual_decorator
-
-
-Shape = Sequence[int]
 
 
 # return original unit * time unit
@@ -786,7 +784,7 @@ def fftfreq(
     n: int,
     d: Union[Quantity, ArrayLike] = 1.0,  # type: ignore[assignment]
     *,
-    dtype: jax.typing.DTypeLike | None = None,
+    dtype: DTypeLike | None = None,
     device: xla_client.Device | jax.sharding.Sharding | None = None,
     **kwargs,
 ) -> Union[Quantity, ArrayLike]:
@@ -847,7 +845,7 @@ def rfftfreq(
     n: int,
     d: Union[Quantity, ArrayLike] = 1.0,  # type: ignore[assignment]
     *,
-    dtype: jax.typing.DTypeLike | None = None,
+    dtype: DTypeLike | None = None,
     device: xla_client.Device | jax.sharding.Sharding | None = None,
     **kwargs,
 ) -> Union[Quantity, ArrayLike]:

--- a/saiunit/fft/_fft_keep_unit.py
+++ b/saiunit/fft/_fft_keep_unit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Union, Sequence
 
-from saiunit._jax_compat import HAS_JAX, jax, ArrayLike
+from saiunit._jax_compat import HAS_JAX, jax
+from saiunit._typing import ArrayLike
 
 if HAS_JAX:
     from jax.numpy import fft as jnpfft

--- a/saiunit/lax/_lax_accept_unitless.py
+++ b/saiunit/lax/_lax_accept_unitless.py
@@ -24,7 +24,7 @@ from saiunit._base_unit import Unit
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as
 from saiunit.math._fun_accept_unitless import _fun_accept_unitless_unary, _fun_accept_unitless_binary, _fun_unitless_binary
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike
 
 __all__ = [
     # math funcs only accept unitless (unary)
@@ -61,7 +61,7 @@ def acos(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise arc cosine: :math:`\mathrm{acos}(x)`.
 
     Parameters
@@ -74,7 +74,7 @@ def acos(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         The arc cosine of ``x``. Always unitless.
 
     Examples
@@ -95,7 +95,7 @@ def acosh(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise inverse hyperbolic cosine: :math:`\mathrm{acosh}(x)`.
 
     Parameters
@@ -107,7 +107,7 @@ def acosh(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.acosh, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -118,7 +118,7 @@ def asin(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise arc sine: :math:`\mathrm{asin}(x)`.
 
     Parameters
@@ -130,7 +130,7 @@ def asin(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.asin, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -141,7 +141,7 @@ def asinh(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise inverse hyperbolic sine: :math:`\mathrm{asinh}(x)`.
 
     Parameters
@@ -153,7 +153,7 @@ def asinh(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.asinh, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -164,7 +164,7 @@ def atan(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise arc tangent: :math:`\mathrm{atan}(x)`.
 
     Parameters
@@ -176,7 +176,7 @@ def atan(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.atan, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -187,7 +187,7 @@ def atanh(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise inverse hyperbolic tangent: :math:`\mathrm{atanh}(x)`.
 
     Parameters
@@ -199,7 +199,7 @@ def atanh(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.atanh, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -212,7 +212,7 @@ def collapse(
     stop_dimension: Optional[int] = None,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """Collapses dimensions of an array into a single dimension.
 
     For example, if ``operand`` is an array with shape ``[2, 3, 4]``,
@@ -246,7 +246,7 @@ def cumlogsumexp(
     reverse: Optional[bool] = False,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """Compute a cumulative logsumexp along ``axis``.
 
     Parameters
@@ -262,7 +262,7 @@ def cumlogsumexp(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.cumlogsumexp,
@@ -277,7 +277,7 @@ def bessel_i0e(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Exponentially scaled modified Bessel function of order 0:
     :math:`\mathrm{i0e}(x) = e^{-|x|} \mathrm{i0}(x)`.
 
@@ -290,7 +290,7 @@ def bessel_i0e(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
 
     Examples
@@ -310,7 +310,7 @@ def bessel_i1e(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Exponentially scaled modified Bessel function of order 1:
     :math:`\mathrm{i1e}(x) = e^{-|x|} \mathrm{i1}(x)`.
 
@@ -323,7 +323,7 @@ def bessel_i1e(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.bessel_i1e, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -334,7 +334,7 @@ def digamma(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise digamma: :math:`\psi(x)`.
 
     Parameters
@@ -346,7 +346,7 @@ def digamma(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.digamma, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -357,7 +357,7 @@ def lgamma(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise log gamma: :math:`\mathrm{log}(\Gamma(x))`.
 
     Parameters
@@ -369,7 +369,7 @@ def lgamma(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.lgamma, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -380,7 +380,7 @@ def erf(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise error function: :math:`\mathrm{erf}(x)`.
 
     Parameters
@@ -392,7 +392,7 @@ def erf(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
 
     Examples
@@ -413,7 +413,7 @@ def erfc(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise complementary error function: :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`.
 
     Parameters
@@ -425,7 +425,7 @@ def erfc(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.erfc, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -436,7 +436,7 @@ def erf_inv(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise inverse error function: :math:`\mathrm{erf}^{-1}(x)`.
 
     Parameters
@@ -448,7 +448,7 @@ def erf_inv(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_unary(lax.erf_inv, x, unit_to_scale=unit_to_scale, **kwargs)
@@ -459,7 +459,7 @@ def logistic(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise logistic (sigmoid) function: :math:`\frac{1}{1 + e^{-x}}`.
 
     Parameters
@@ -471,7 +471,7 @@ def logistic(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
 
     Examples
@@ -495,7 +495,7 @@ def atan2(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise arc tangent of two variables: :math:`\mathrm{atan}({x \over y})`.
 
     Parameters
@@ -509,7 +509,7 @@ def atan2(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
 
     Examples
@@ -530,7 +530,7 @@ def polygamma(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise polygamma: :math:`\psi^{(m)}(x)`.
 
     Parameters
@@ -544,7 +544,7 @@ def polygamma(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.polygamma, x, y, unit_to_scale=unit_to_scale, **kwargs)
@@ -556,7 +556,7 @@ def igamma(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise regularized incomplete gamma function.
 
     Parameters
@@ -570,7 +570,7 @@ def igamma(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.igamma, x, y, unit_to_scale=unit_to_scale, **kwargs)
@@ -582,7 +582,7 @@ def igammac(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise complementary regularized incomplete gamma function.
 
     Parameters
@@ -596,7 +596,7 @@ def igammac(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.igammac, x, y, unit_to_scale=unit_to_scale, **kwargs)
@@ -608,7 +608,7 @@ def igamma_grad_a(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise derivative of the regularized incomplete gamma function.
 
     Parameters
@@ -622,7 +622,7 @@ def igamma_grad_a(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.igamma_grad_a, x, y, unit_to_scale=unit_to_scale, **kwargs)
@@ -634,7 +634,7 @@ def random_gamma_grad(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise derivative of samples from ``Gamma(a, 1)``.
 
     Parameters
@@ -648,7 +648,7 @@ def random_gamma_grad(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.random_gamma_grad, x, y, unit_to_scale=unit_to_scale, **kwargs)
@@ -660,7 +660,7 @@ def zeta(
     q: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise Hurwitz zeta function: :math:`\zeta(x, q)`.
 
     Parameters
@@ -674,7 +674,7 @@ def zeta(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_accept_unitless_binary(lax.zeta, x, q, unit_to_scale=unit_to_scale, **kwargs)
@@ -719,7 +719,7 @@ def betainc(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise regularized incomplete beta integral.
 
     Parameters
@@ -735,7 +735,7 @@ def betainc(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
 
     Examples
@@ -758,7 +758,7 @@ def shift_left(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise left shift: :math:`x \ll y`.
 
     Parameters
@@ -770,7 +770,7 @@ def shift_left(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_unitless_binary(lax.shift_left, x, y, **kwargs)
@@ -781,7 +781,7 @@ def shift_right_arithmetic(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise arithmetic right shift: :math:`x \gg y`.
 
     Parameters
@@ -793,7 +793,7 @@ def shift_right_arithmetic(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_unitless_binary(lax.shift_right_arithmetic, x, y, **kwargs)
@@ -804,7 +804,7 @@ def shift_right_logical(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""Elementwise logical right shift: :math:`x \gg y`.
 
     Parameters
@@ -816,7 +816,7 @@ def shift_right_logical(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Always unitless.
     """
     return _fun_unitless_binary(lax.shift_right_logical, x, y, **kwargs)
@@ -846,7 +846,7 @@ def fft(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         The FFT result. Always unitless.
     """
     return _fun_accept_unitless_unary(lax.fft,

--- a/saiunit/lax/_lax_array_creation.py
+++ b/saiunit/lax/_lax_array_creation.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 from saiunit._base_unit import Unit
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 Shape = Union[int, Sequence[int]]
 
@@ -42,7 +42,7 @@ def zeros_like_array(
     x: Union[Quantity, ArrayLike],
     unit: Optional[Unit] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Create a zero-filled array with the same shape and dtype as ``x``.
 
     Parameters
@@ -56,7 +56,7 @@ def zeros_like_array(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         A zero-filled array. If ``x`` is a ``Quantity`` (or ``unit`` is
         provided), the result is a ``Quantity`` with the corresponding unit.
 
@@ -93,11 +93,11 @@ def zeros_like_array(
 # array creation (misc)
 @set_module_as('saiunit.lax')
 def iota(
-    dtype: jax.typing.DTypeLike,
+    dtype: DTypeLike,
     size: int,
     unit: Optional[Unit] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Create an iota array (integer sequence) with an optional unit.
 
     Wraps XLA's ``Iota`` operator.
@@ -113,7 +113,7 @@ def iota(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         An array ``[0, 1, 2, ..., size - 1]`` of the given dtype.
 
     Examples
@@ -138,13 +138,13 @@ def iota(
 
 @set_module_as('saiunit.lax')
 def broadcasted_iota(
-    dtype: jax.typing.DTypeLike,
+    dtype: DTypeLike,
     shape: Shape,
     dimension: int,
     _sharding=None,
     unit: Optional[Unit] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Broadcast an iota array into the given shape along one dimension.
 
     Convenience wrapper around ``iota``.
@@ -164,7 +164,7 @@ def broadcasted_iota(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         An array of the given shape with iota values along ``dimension``.
 
     Examples

--- a/saiunit/lax/_lax_change_unit.py
+++ b/saiunit/lax/_lax_change_unit.py
@@ -24,7 +24,7 @@ from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
 from saiunit.math._fun_change_unit import _fun_change_unit_unary, _fun_change_unit_binary
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 __all__ = [
     # math funcs change unit (unary)
@@ -56,7 +56,7 @@ def unit_change(
 def rsqrt(
     x: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise reciprocal square root: :math:`1 \over \sqrt{x}`.
 
     Parameters
@@ -66,7 +66,7 @@ def rsqrt(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The reciprocal square root. If ``x`` has unit ``u``, the result has
         unit ``u ** -0.5``.
 
@@ -95,9 +95,9 @@ def conv(
     window_strides: Sequence[int],
     padding: str,
     precision: lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None,
+    preferred_element_type: DTypeLike | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around ``conv_general_dilated``.
 
     Parameters
@@ -118,7 +118,7 @@ def conv(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         An array containing the convolution result.
     """
     return _fun_change_unit_binary(lax.conv,
@@ -137,9 +137,9 @@ def conv_transpose(
     dimension_numbers: jax.lax.ConvGeneralDilatedDimensionNumbers = None,
     transpose_kernel: bool = False,
     precision: lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None,
+    preferred_element_type: DTypeLike | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper for calculating the N-d convolution "transpose".
 
     This function directly calculates a fractionally strided conv rather than
@@ -186,7 +186,7 @@ def div(
     x: Union[ArrayLike, Quantity],
     y: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise division: :math:`x \over y`.
 
     Integer division overflow (division by zero or signed division of
@@ -201,7 +201,7 @@ def div(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The quotient. The resulting unit is ``unit(x) / unit(y)``.
 
     Examples
@@ -228,10 +228,10 @@ def dot_general(
     y: Union[ArrayLike, Quantity],
     dimension_numbers: jax.lax.DotDimensionNumbers,
     precision: jax.lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None,
+    preferred_element_type: DTypeLike | None = None,
     out_type=None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """General dot product/contraction operator.
 
     Wraps XLA's `DotGeneral
@@ -294,7 +294,7 @@ def pow(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise power: :math:`x^y`.
 
     Parameters
@@ -306,7 +306,7 @@ def pow(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The result of ``x ** y``. If ``x`` has unit ``u``, the result
         has unit ``u ** y``.
 
@@ -349,7 +349,7 @@ def integer_pow(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise integer power: :math:`x^y`, where :math:`y` is a fixed integer.
 
     Parameters
@@ -361,7 +361,7 @@ def integer_pow(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The result of ``x ** y``. If ``x`` has unit ``u``, the result
         has unit ``u ** y``.
 
@@ -416,7 +416,7 @@ def mul(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The product. The resulting unit is ``unit(x) * unit(y)``.
 
     Examples
@@ -485,7 +485,7 @@ def batch_matmul(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The batch matrix product of shape ``[..., m, n]``.
         The resulting unit is ``unit(x) * unit(y)``.
 

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -20,7 +20,7 @@ from typing import Any, Union, Sequence, Callable, Optional
 import jax
 import numpy as np
 from jax import lax
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 # Mirror of ``jax._src.typing.Shape`` (which has no public alias).
 # Used purely for type-hint clarity in this module.
@@ -73,7 +73,7 @@ def slice(
     limit_indices: Sequence[int],
     strides: Sequence[int] | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Wraps XLA's `Slice
     <https://www.tensorflow.org/xla/operation_semantics#slice>`_
     operator.
@@ -126,7 +126,7 @@ def dynamic_slice(
     start_indices: ArrayLike | Sequence[ArrayLike],
     slice_sizes: Shape,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Wraps XLA's `DynamicSlice
     <https://www.tensorflow.org/xla/operation_semantics#dynamicslice>`_
     operator.
@@ -174,7 +174,7 @@ def dynamic_update_slice(
     update: Union[Quantity, ArrayLike],
     start_indices: ArrayLike | Sequence[ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Wraps XLA's `DynamicUpdateSlice
     <https://www.tensorflow.org/xla/operation_semantics#dynamicupdateslice>`_
     operator.
@@ -229,7 +229,7 @@ def gather(
     mode: str | jax.lax.GatherScatterMode | None = None,
     fill_value: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Gather operator.
 
     Wraps `XLA's Gather operator
@@ -331,7 +331,7 @@ def index_take(
     idxs: ArrayLike,
     axes: Sequence[int],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Take elements from an array at the given indices along the given axes.
 
     Parameters
@@ -345,7 +345,7 @@ def index_take(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The gathered elements. If ``src`` is a ``Quantity``, the result
         preserves the same unit.
 
@@ -375,7 +375,7 @@ def slice_in_dim(
     stride: int = 1,
     axis: int = 0,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around :func:`lax.slice` applying to only one dimension.
 
     This is effectively equivalent to ``operand[..., start_index:limit_index:stride]``
@@ -428,7 +428,7 @@ def index_in_dim(
     axis: int = 0,
     keepdims: bool = True,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around :func:`lax.slice` to perform int indexing.
 
     This is effectively equivalent to ``operand[..., start_index:limit_index:stride]``
@@ -479,7 +479,7 @@ def dynamic_slice_ind_dim(
     slice_size: int,
     axis: int = 0,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around :func:`lax.dynamic_slice` applied to one dimension.
 
     This is roughly equivalent to the following Python indexing syntax applied
@@ -530,7 +530,7 @@ def dynamic_index_in_dim(
     index: int | ArrayLike,
     axis: int = 0, keepdims: bool = True,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around dynamic_slice to perform int indexing.
 
     This is roughly equivalent to the following Python indexing syntax applied
@@ -577,7 +577,7 @@ def dynamic_update_slice_in_dim(
     update: Union[Quantity, ArrayLike],
     start_index: ArrayLike, axis: int,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around :func:`dynamic_update_slice` to update
     a slice in a single ``axis``.
 
@@ -636,7 +636,7 @@ def dynamic_update_index_in_dim(
     index: ArrayLike,
     axis: int,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Convenience wrapper around :func:`dynamic_update_slice` to update a slice
     of size 1 in a single ``axis``.
 
@@ -696,7 +696,7 @@ def sort(
     dimension: int = -1,
     is_stable: bool = True, num_keys: int = 1,
     **kwargs,
-) -> Union[Quantity, jax.Array] | Sequence[Union[Quantity, jax.Array]]:
+) -> Union[Quantity, Array] | Sequence[Union[Quantity, Array]]:
     """Wraps XLA's `Sort
     <https://www.tensorflow.org/xla/operation_semantics#sort>`_ operator.
 
@@ -757,7 +757,7 @@ def sort_key_val(
     dimension: int = -1,
     is_stable: bool = True,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], Union[Quantity, jax.Array]]:
+) -> tuple[Union[Quantity, Array], Union[Quantity, Array]]:
     """Sort ``keys`` along ``dimension`` and apply the same permutation to ``values``.
 
     Parameters
@@ -773,9 +773,9 @@ def sort_key_val(
 
     Returns
     -------
-    sorted_keys : jax.Array or Quantity
+    sorted_keys : Array or Quantity
         The sorted keys. Preserves the unit of ``keys``.
-    sorted_values : jax.Array or Quantity
+    sorted_values : Array or Quantity
         The values permuted to match the sorted order of ``keys``.
         Preserves the unit of ``values``.
 
@@ -814,7 +814,7 @@ def sort_key_val(
 def neg(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise negation: :math:`-x`.
 
     Parameters
@@ -824,7 +824,7 @@ def neg(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The negated array. If ``x`` is a ``Quantity``, the result
         preserves the same unit.
 
@@ -852,7 +852,7 @@ def cummax(
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Compute a cumulative maximum along ``axis``.
 
     Parameters
@@ -868,7 +868,7 @@ def cummax(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The cumulative maximum array. Preserves the unit of ``operand``.
 
     Examples
@@ -893,7 +893,7 @@ def cummin(
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Compute a cumulative minimum along ``axis``.
 
     Parameters
@@ -909,7 +909,7 @@ def cummin(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The cumulative minimum array. Preserves the unit of ``operand``.
 
     Examples
@@ -934,7 +934,7 @@ def cumsum(
     axis: int = 0,
     reverse: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Compute a cumulative sum along ``axis``.
 
     Parameters
@@ -950,7 +950,7 @@ def cumsum(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The cumulative sum array. Preserves the unit of ``operand``.
 
     Examples
@@ -978,7 +978,7 @@ def _fun_lax_scatter(
     indices_are_sorted,
     unique_indices,
     mode
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     fun_name = getattr(fun, "__name__", "scatter")
     require_jax_backend(f"saiunit.lax.{fun_name}", operand, updates)
     operand = maybe_custom_array(operand)
@@ -1013,7 +1013,7 @@ def scatter(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-update operator.
 
     Wraps `XLA's Scatter operator
@@ -1098,7 +1098,7 @@ def scatter_add(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-add operator.
 
     Wraps `XLA's Scatter operator
@@ -1148,7 +1148,7 @@ def scatter_sub(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-sub operator.
 
     Wraps `XLA's Scatter operator
@@ -1198,7 +1198,7 @@ def scatter_mul(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-multiply operator.
 
     Wraps `XLA's Scatter operator
@@ -1248,7 +1248,7 @@ def scatter_min(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-min operator.
 
     Wraps `XLA's Scatter operator
@@ -1298,7 +1298,7 @@ def scatter_max(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-max operator.
 
     Wraps `XLA's Scatter operator
@@ -1349,7 +1349,7 @@ def scatter_apply(
     unique_indices: bool = False,
     mode: str | jax.lax.GatherScatterMode | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Scatter-apply operator.
 
     Wraps `XLA's Scatter operator
@@ -1411,7 +1411,7 @@ def complex(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise make complex number: :math:`x + jy`.
 
     Build a complex number from real and imaginary parts.
@@ -1425,7 +1425,7 @@ def complex(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The complex array. If inputs are ``Quantity``, the result
         preserves the same unit.
 
@@ -1452,7 +1452,7 @@ def pad(
     padding_value: Union[Quantity, ArrayLike],
     padding_config: Sequence[tuple[int, int, int]],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Applies low, high, and/or interior padding to an array.
 
     Wraps XLA's `Pad
@@ -1480,7 +1480,7 @@ def sub(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise subtraction: :math:`x - y`.
 
     Parameters
@@ -1492,7 +1492,7 @@ def sub(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The difference. Preserves the unit of the inputs.
 
     Examples
@@ -1516,9 +1516,9 @@ def sub(
 @set_module_as('saiunit.math')
 def convert_element_type(
     operand: Union[Quantity, ArrayLike],
-    new_dtype: jax.typing.DTypeLike,
+    new_dtype: DTypeLike,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Elementwise cast.
 
     Wraps XLA's `ConvertElementType
@@ -1539,9 +1539,9 @@ def convert_element_type(
 @set_module_as('saiunit.math')
 def bitcast_convert_type(
     operand: Union[Quantity, ArrayLike],
-    new_dtype: jax.typing.DTypeLike,
+    new_dtype: DTypeLike,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Elementwise bitcast.
 
     Wraps XLA's `BitcastConvertType
@@ -1567,7 +1567,7 @@ def bitcast_convert_type(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         An array of shape ``output_shape`` (see above) and type ``new_dtype``,
         constructed from the same bits as ``operand``.
     """
@@ -1581,7 +1581,7 @@ def clamp(
     x: Union[Quantity, ArrayLike],
     max: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Elementwise clamp.
 
     Returns :math:`\mathrm{clamp}(x) = \begin{cases}
@@ -1597,7 +1597,7 @@ def clamp(
     if all(isinstance(i, Quantity) for i in (min, x, max)):
         unit = min.unit  # type: ignore[union-attr]
         return maybe_decimal(Quantity(lax.clamp(min.mantissa, x.to_decimal(unit), max.to_decimal(unit), **kwargs), unit=unit))  # type: ignore[union-attr]
-    elif all(isinstance(i, (jax.Array, np.ndarray, np.bool_, np.number, bool, int, float, builtins.complex)) for i in
+    elif all(isinstance(i, (Array, np.ndarray, np.bool_, np.number, bool, int, float, builtins.complex)) for i in
              (min, x, max)):
         return lax.clamp(min, x, max, **kwargs)  # type: ignore[arg-type]
     else:
@@ -1614,7 +1614,7 @@ def approx_max_k(
     reduction_input_size_override: int = -1,
     aggregate_to_topk: bool = True,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
+) -> tuple[Union[Quantity, Array], ArrayLike]:
     """Returns max ``k`` values and their indices of the ``operand`` in an approximate manner.
 
     See https://arxiv.org/abs/2206.14286 for the algorithm details.
@@ -1677,7 +1677,7 @@ def approx_min_k(
     reduction_input_size_override: int = -1,
     aggregate_to_topk: bool = True,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
+) -> tuple[Union[Quantity, Array], ArrayLike]:
     """Returns min ``k`` values and their indices of the ``operand`` in an approximate manner.
 
     See https://arxiv.org/abs/2206.14286 for the algorithm details.
@@ -1740,7 +1740,7 @@ def top_k(
     operand: Union[Quantity, ArrayLike],
     k: int,
     **kwargs,
-) -> tuple[Union[Quantity, jax.Array], ArrayLike]:
+) -> tuple[Union[Quantity, Array], ArrayLike]:
     """Returns top ``k`` values and their indices along the last axis of ``operand``.
 
     Args:
@@ -1775,7 +1775,7 @@ def top_k(
 def broadcast(
     operand: Union[Quantity, ArrayLike],
     sizes: Sequence[int]
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Broadcast an array by adding new leading dimensions.
 
     Parameters
@@ -1787,7 +1787,7 @@ def broadcast(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The broadcasted array. Preserves the unit of ``operand``.
 
     Examples
@@ -1812,7 +1812,7 @@ def broadcast_in_dim(
     operand: Union[Quantity, ArrayLike],
     shape: Shape,
     broadcast_dimensions: Sequence[int]
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Broadcast an array into a target shape (XLA BroadcastInDim).
 
     Parameters
@@ -1828,7 +1828,7 @@ def broadcast_in_dim(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The broadcasted array. Preserves the unit of ``operand``.
 
     Examples
@@ -1850,7 +1850,7 @@ def broadcast_in_dim(
 def broadcast_to_rank(
     x: Union[Quantity, ArrayLike],
     rank: int
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """Add leading dimensions of size 1 to give ``x`` rank ``rank``.
 
     Parameters
@@ -1862,7 +1862,7 @@ def broadcast_to_rank(
 
     Returns
     -------
-    result : jax.Array or Quantity
+    result : Array or Quantity
         The array with added leading dimensions. Preserves the unit of ``x``.
 
     Examples

--- a/saiunit/lax/_lax_linalg.py
+++ b/saiunit/lax/_lax_linalg.py
@@ -25,7 +25,7 @@ from saiunit._base_getters import fail_for_unit_mismatch, maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
 from saiunit.math._fun_change_unit import _fun_change_unit_unary
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike
 
 __all__ = [
     # linear algebra unary
@@ -65,7 +65,7 @@ def cholesky(
 
     Returns
     -------
-    L : jax.Array or Quantity
+    L : Array or Quantity
         The lower-triangular Cholesky factor with shape ``[..., n, n]``.
         If ``x`` carries a unit ``u``, the result has unit ``u ** 0.5``.
         If decomposition fails, the result is filled with NaNs.
@@ -115,12 +115,12 @@ def eig(
 
     Returns
     -------
-    w : jax.Array or Quantity
+    w : Array or Quantity
         The eigenvalues.  If ``x`` has a unit, ``w`` preserves that unit.
-    vl : jax.Array, optional
+    vl : Array, optional
         The left eigenvectors (unitless).  Only returned when
         ``compute_left_eigenvectors`` is ``True``.
-    vr : jax.Array, optional
+    vr : Array, optional
         The right eigenvectors (unitless).  Only returned when
         ``compute_right_eigenvectors`` is ``True``.
 
@@ -184,7 +184,7 @@ def eigh(
     symmetrize_input: bool = True,
     sort_eigenvalues: bool = True,
     subset_by_index: tuple[int, int] | None = None,
-) -> tuple[Quantity | jax.Array, jax.Array]:
+) -> tuple[Quantity | Array, Array]:
     r"""Eigendecomposition of a Hermitian matrix.
 
     Compute the eigenvectors and eigenvalues of a complex Hermitian or
@@ -210,10 +210,10 @@ def eigh(
 
     Returns
     -------
-    v : jax.Array
+    v : Array
         Eigenvectors (unitless).  ``v[..., :, i]`` is the normalised
         eigenvector for eigenvalue ``w[..., i]``.
-    w : jax.Array or Quantity
+    w : Array or Quantity
         Eigenvalues in ascending order.  If ``x`` has a unit, ``w``
         preserves that unit.
 
@@ -242,7 +242,7 @@ def eigh(
 @set_module_as('saiunit.lax')
 def hessenberg(
     x: Union[Quantity, ArrayLike],
-) -> tuple[Quantity | jax.Array, jax.Array]:
+) -> tuple[Quantity | Array, Array]:
     """Reduce a square matrix to upper Hessenberg form.
 
     Currently implemented on CPU only.
@@ -255,12 +255,12 @@ def hessenberg(
 
     Returns
     -------
-    h : jax.Array or Quantity
+    h : Array or Quantity
         The upper Hessenberg form.  The upper triangle and first
         sub-diagonal contain the Hessenberg matrix; elements below the
         first sub-diagonal hold the Householder reflectors.  If ``x``
         has a unit, ``h`` preserves that unit.
-    taus : jax.Array
+    taus : Array
         Scalar factors of the elementary Householder reflectors (unitless).
 
     See Also
@@ -290,7 +290,7 @@ def hessenberg(
 @set_module_as('saiunit.lax')
 def lu(
     x: Union[Quantity, ArrayLike],
-) -> tuple[Quantity | jax.Array, jax.Array, jax.Array]:
+) -> tuple[Quantity | Array, Array, Array]:
     r"""LU decomposition with partial pivoting.
 
     Compute the matrix decomposition :math:`P \cdot A = L \cdot U` where
@@ -304,14 +304,14 @@ def lu(
 
     Returns
     -------
-    lu : jax.Array or Quantity
+    lu : Array or Quantity
         A matrix containing :math:`L` in its lower triangle and :math:`U`
         in its upper triangle (the unit diagonal of :math:`L` is implicit).
         If ``x`` has a unit, ``lu`` preserves that unit.
-    pivots : jax.Array
+    pivots : Array
         An ``int32`` array with shape ``[..., min(m, n)]`` encoding row
         swaps.
-    permutation : jax.Array
+    permutation : Array
         An ``int32`` array with shape ``[..., m]`` representing the row
         permutation.
 
@@ -339,7 +339,7 @@ def lu(
 def householder_product(
     a: Union[Quantity, ArrayLike],
     taus: Union[Quantity, ArrayLike],
-) -> jax.Array:
+) -> Array:
     """Product of elementary Householder reflectors.
 
     Reconstruct the orthogonal (unitary) matrix :math:`Q` from a set of
@@ -357,7 +357,7 @@ def householder_product(
 
     Returns
     -------
-    Q : jax.Array
+    Q : Array
         The orthogonal (unitary) matrix with the same shape as ``a``
         (always unitless).
 
@@ -394,7 +394,7 @@ def householder_product(
 @set_module_as('saiunit.lax')
 def qdwh(
     x: Union[Quantity, ArrayLike],
-) -> tuple[jax.Array, Quantity | jax.Array, int, bool]:
+) -> tuple[Array, Quantity | Array, int, bool]:
     r"""Polar decomposition via QR-based dynamically weighted Halley iteration.
 
     Compute the polar decomposition :math:`x = U \cdot H` where :math:`U`
@@ -407,9 +407,9 @@ def qdwh(
 
     Returns
     -------
-    u : jax.Array
+    u : Array
         The unitary factor (unitless).
-    h : jax.Array or Quantity
+    h : Array or Quantity
         The Hermitian positive semi-definite factor.  If ``x`` has a unit,
         ``h`` preserves that unit.
     num_iters : int
@@ -441,7 +441,7 @@ def qdwh(
 @set_module_as('saiunit.lax')
 def qr(
     x: Union[Quantity, ArrayLike],
-) -> tuple[jax.Array, Quantity | jax.Array]:
+) -> tuple[Array, Quantity | Array]:
     r"""QR decomposition.
 
     Compute the QR decomposition :math:`A = Q \cdot R` where :math:`Q` is
@@ -454,9 +454,9 @@ def qr(
 
     Returns
     -------
-    q : jax.Array
+    q : Array
         The unitary factor (unitless) with shape ``[..., m, min(m, n)]``.
-    r : jax.Array or Quantity
+    r : Array or Quantity
         The upper-triangular factor with shape ``[..., min(m, n), n]``.
         If ``x`` has a unit, ``r`` preserves that unit.
 
@@ -486,7 +486,7 @@ def schur(
     compute_schur_vectors: bool = True,
     sort_eig_vals: bool = False,
     select_callable: Callable[..., Any] | None = None
-) -> tuple[jax.Array, Quantity | jax.Array]:
+) -> tuple[Array, Quantity | Array]:
     r"""Schur decomposition.
 
     Compute the Schur decomposition :math:`A = Q \cdot T \cdot Q^H` where
@@ -507,9 +507,9 @@ def schur(
 
     Returns
     -------
-    t : jax.Array
+    t : Array
         The Schur form (unitless).
-    q : jax.Array or Quantity
+    q : Array or Quantity
         The Schur vectors.  If ``x`` has a unit, ``q`` preserves that unit.
 
     Examples
@@ -542,7 +542,7 @@ def svd(
     compute_uv: bool = True,
     subset_by_index: tuple[int, int] | None = None,
     algorithm: jax.lax.linalg.SvdAlgorithm | None = None,
-) -> Union[Quantity, ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
+) -> Union[Quantity, ArrayLike] | tuple[Array, Quantity | Array, Array]:
     """Singular value decomposition.
 
     Compute the SVD of a matrix.  When ``compute_uv`` is ``True``, return
@@ -566,12 +566,12 @@ def svd(
 
     Returns
     -------
-    u : jax.Array
+    u : Array
         Left singular vectors (unitless).  Only returned when
         ``compute_uv=True``.
-    s : jax.Array or Quantity
+    s : Array or Quantity
         Singular values.  If ``x`` has a unit, ``s`` preserves that unit.
-    vh : jax.Array
+    vh : Array
         Right singular vectors (unitless).  Only returned when
         ``compute_uv=True``.
 
@@ -609,7 +609,7 @@ def triangular_solve(
     left_side: bool = False, lower: bool = False,
     transpose_a: bool = False, conjugate_a: bool = False,
     unit_diagonal: bool = False,
-) -> Quantity | jax.Array:
+) -> Quantity | Array:
     r"""Triangular solve.
 
     Solve the matrix equation :math:`\mathit{op}(A) \cdot X = B` (when
@@ -638,7 +638,7 @@ def triangular_solve(
 
     Returns
     -------
-    X : jax.Array or Quantity
+    X : Array or Quantity
         The solution with the same shape and dtype as ``b``.  If ``b``
         carries a unit, ``X`` preserves that unit.
 
@@ -681,7 +681,7 @@ def triangular_solve(
 def tridiagonal(
     a: Union[Quantity, ArrayLike],
     lower: bool = True,
-) -> tuple[Quantity | jax.Array, Quantity | jax.Array, Quantity | jax.Array, jax.Array]:
+) -> tuple[Quantity | Array, Quantity | Array, Quantity | Array, Array]:
     """Reduce a symmetric/Hermitian matrix to tridiagonal form.
 
     Currently implemented on CPU and GPU only.
@@ -696,18 +696,18 @@ def tridiagonal(
 
     Returns
     -------
-    a_out : jax.Array or Quantity
+    a_out : Array or Quantity
         The matrix with the tridiagonal representation stored in its
         diagonal and first sub/super-diagonal; remaining elements hold the
         Householder reflectors.  If ``a`` has a unit, ``a_out`` preserves
         that unit.
-    d : jax.Array or Quantity
+    d : Array or Quantity
         The diagonal of the tridiagonal matrix.  Preserves the unit of ``a``
         if present.
-    e : jax.Array or Quantity
+    e : Array or Quantity
         The first sub-diagonal (``lower=True``) or super-diagonal
         (``lower=False``).  Preserves the unit of ``a`` if present.
-    taus : jax.Array
+    taus : Array
         Scalar factors of the elementary Householder reflectors (unitless).
 
     Examples
@@ -737,7 +737,7 @@ def tridiagonal_solve(
     d: Union[Quantity, ArrayLike],
     du: Union[Quantity, ArrayLike],
     b: Union[Quantity, ArrayLike],
-) -> Quantity | jax.Array:
+) -> Quantity | Array:
     r"""Solve a tridiagonal linear system.
 
     Compute the solution :math:`X` of the tridiagonal system
@@ -762,7 +762,7 @@ def tridiagonal_solve(
 
     Returns
     -------
-    X : jax.Array or Quantity
+    X : Array or Quantity
         The solution of the tridiagonal system.  If ``b`` has a unit, ``X``
         preserves that unit.
 

--- a/saiunit/lax/_lax_remove_unit.py
+++ b/saiunit/lax/_lax_remove_unit.py
@@ -23,7 +23,7 @@ from jax import lax
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as
 from saiunit.math._fun_remove_unit import _fun_remove_unit_unary, _fun_logic_binary
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike
 
 __all__ = [
     # math funcs remove unit (unary)
@@ -41,7 +41,7 @@ __all__ = [
 @set_module_as('saiunit.lax')
 def population_count(
     x: Union[ArrayLike, Quantity],
-) -> jax.Array:
+) -> Array:
     r"""Elementwise popcount: count the number of set bits in each element.
 
     Parameters
@@ -52,7 +52,7 @@ def population_count(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         The number of set bits in each element. Always unitless.
 
     Examples
@@ -72,7 +72,7 @@ def population_count(
 @set_module_as('saiunit.lax')
 def clz(
     x: Union[ArrayLike, Quantity],
-) -> jax.Array:
+) -> Array:
     r"""Elementwise count of leading zeros.
 
     Parameters
@@ -83,7 +83,7 @@ def clz(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         The count of leading zeros in each element. Always unitless.
 
     Examples
@@ -105,7 +105,7 @@ def clz(
 def eq(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise equals: :math:`x = y`.
 
     Parameters
@@ -117,7 +117,7 @@ def eq(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples
@@ -139,7 +139,7 @@ def eq(
 def ne(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise not-equals: :math:`x \neq y`.
 
     Parameters
@@ -151,7 +151,7 @@ def ne(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples
@@ -173,7 +173,7 @@ def ne(
 def ge(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise greater-than-or-equals: :math:`x \geq y`.
 
     Parameters
@@ -185,7 +185,7 @@ def ge(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples
@@ -207,7 +207,7 @@ def ge(
 def gt(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise greater-than: :math:`x > y`.
 
     Parameters
@@ -219,7 +219,7 @@ def gt(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples
@@ -241,7 +241,7 @@ def gt(
 def le(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise less-than-or-equals: :math:`x \leq y`.
 
     Parameters
@@ -253,7 +253,7 @@ def le(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples
@@ -275,7 +275,7 @@ def le(
 def lt(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     r"""Elementwise less-than: :math:`x < y`.
 
     Parameters
@@ -287,7 +287,7 @@ def lt(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Boolean array. Always unitless.
 
     Examples

--- a/saiunit/lax/_misc.py
+++ b/saiunit/lax/_misc.py
@@ -22,7 +22,7 @@ from jax import lax
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike
 
 __all__ = [
     'reduce', 'reduce_precision',
@@ -81,7 +81,7 @@ def reduce(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         The reduced result.  Note that unit information is not preserved
         through the raw XLA reduce; see Notes.
 
@@ -148,7 +148,7 @@ def reduce_precision(
 
     When the input is a :class:`~saiunit.Quantity`, the precision reduction
     is applied to the mantissa and the result is returned as a plain
-    :class:`jax.Array` (the unit is stripped).
+    :class:`Array` (the unit is stripped).
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def reduce_precision(
 
     Returns
     -------
-    result : jax.Array
+    result : Array
         Array with reduced-precision values.  Unit information from a
         :class:`~saiunit.Quantity` input is not preserved.
 

--- a/saiunit/linalg/_linalg_change_unit.py
+++ b/saiunit/linalg/_linalg_change_unit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Union
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike
 
 from saiunit._base_unit import UNITLESS
 from saiunit._base_getters import maybe_decimal
@@ -56,7 +57,7 @@ def cholesky(
     upper: bool = False,
     symmetrize_input: bool = True,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the Cholesky decomposition of a matrix.
 
@@ -253,7 +254,7 @@ def lstsq(
     *,
     numpy_resid: bool = False,
     **kwargs,
-) -> tuple[Union[ArrayLike, Quantity], jax.Array, jax.Array, jax.Array]:
+) -> tuple[Union[ArrayLike, Quantity], Array, Array, Array]:
     """
     Return the least-squares solution to a linear equation.
 

--- a/saiunit/linalg/_linalg_keep_unit.py
+++ b/saiunit/linalg/_linalg_keep_unit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Union
 
-from saiunit._jax_compat import HAS_JAX, jax, jnp, Array, require_jax, ArrayLike
+from saiunit._jax_compat import HAS_JAX, jax, jnp, require_jax
+from saiunit._typing import Array, ArrayLike
 
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
@@ -52,7 +53,7 @@ def norm(
     axis: None | tuple[int, ...] | int = None,
     keepdims: bool = False,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the norm of a matrix or vector.
 
     Computes a variety of vector and matrix norms, preserving the physical
@@ -133,7 +134,7 @@ def matrix_norm(
     keepdims: bool = False,
     ord: int | str = 'fro',
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the norm of a matrix or stack of matrices.
 
     SaiUnit implementation of :func:`numpy.linalg.matrix_norm`.
@@ -180,7 +181,7 @@ def vector_norm(
     keepdims: bool = False,
     ord: int | str = 2,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the vector norm of a vector or batch of vectors.
 
     SaiUnit implementation of :func:`numpy.linalg.vector_norm`.
@@ -312,7 +313,7 @@ def svd(
     subset_by_index: tuple[int, int] | None = None,
     algorithm: jax.lax.linalg.SvdAlgorithm | None = None,
     **kwargs,
-) -> Union[Quantity, ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
+) -> Union[Quantity, ArrayLike] | tuple[Array, Quantity | Array, Array]:
     """Singular value decomposition.
 
     SaiUnit implementation of :func:`numpy.linalg.svd`.
@@ -410,7 +411,7 @@ def svd(
 def svdvals(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the singular values of a matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.svdvals`.
@@ -444,7 +445,7 @@ def svdvals(
 def eig(
     a: Union[Quantity, ArrayLike],
     **kwargs,
-) -> tuple[Union[jax.Array, Quantity], Union[jax.Array, Quantity]]:
+) -> tuple[Union[Array, Quantity], Union[Array, Quantity]]:
     """Compute the eigenvalues and eigenvectors of a square matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.eig`.
@@ -487,7 +488,7 @@ def eigh(
     UPLO: str | None = None,
     symmetrize_input: bool = True,
     **kwargs,
-) -> tuple[Union[jax.Array, Quantity], Union[jax.Array, Quantity]]:
+) -> tuple[Union[Array, Quantity], Union[Array, Quantity]]:
     """Compute eigenvalues and eigenvectors of a Hermitian matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.eigh`.
@@ -541,7 +542,7 @@ def eigh(
 def eigvals(
     a: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the eigenvalues of a general matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.eigvals`.
@@ -578,7 +579,7 @@ def eigvalsh(
     *,
     symmetrize_input: bool = True,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """Compute the eigenvalues of a Hermitian matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.eigvalsh`.

--- a/saiunit/linalg/_linalg_remove_unit.py
+++ b/saiunit/linalg/_linalg_remove_unit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import (Union, Optional)
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike
 
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
@@ -34,7 +35,7 @@ def cond(
     x: Union[ArrayLike, Quantity],
     p=None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """Compute the condition number of a matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.cond`.
@@ -58,7 +59,7 @@ def cond(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Condition number(s) of shape ``x.shape[:-2]``.  Always
         dimensionless.
 
@@ -105,7 +106,7 @@ def matrix_rank(
     *,
     tol: ArrayLike | None = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """Compute the rank of a matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.matrix_rank`.
@@ -131,7 +132,7 @@ def matrix_rank(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Matrix rank of shape ``M.shape[:-2]``, as a dimensionless
         integer array.
 
@@ -180,7 +181,7 @@ def slogdet(
     *,
     method: str | None = None,
     **kwargs,
-) -> tuple[jax.Array, jax.Array]:
+) -> tuple[Array, Array]:
     """Compute the sign and (natural) logarithm of the absolute determinant.
 
     SaiUnit implementation of :func:`numpy.linalg.slogdet`.
@@ -205,10 +206,10 @@ def slogdet(
 
     Returns
     -------
-    sign : jax.Array
+    sign : Array
         Sign of the determinant (``+1.``, ``-1.``, or ``0.``), of shape
         ``a.shape[:-2]``.
-    logabsdet : jax.Array
+    logabsdet : Array
         Natural logarithm of the absolute value of the determinant, of
         shape ``a.shape[:-2]``.
 

--- a/saiunit/math/_activation.py
+++ b/saiunit/math/_activation.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from saiunit._jax_compat import HAS_JAX, jax, require_jax, ArrayLike
+from saiunit._jax_compat import HAS_JAX, jax, require_jax
+from saiunit._typing import Array, ArrayLike
 from saiunit._jax_guard import require_jax_backend
 
 if HAS_JAX:
@@ -43,7 +44,7 @@ __all__ = [
 @set_module_as('saiunit.math')
 def relu(
     x: Union[Quantity, ArrayLike],
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Rectified linear unit activation function.
 
     Computes the element-wise function:
@@ -68,7 +69,7 @@ def relu(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         An array with the same shape as *x* where negative values are
         replaced by zero. Units are preserved when present.
 
@@ -93,7 +94,7 @@ def relu(
 def relu6(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Rectified Linear Unit 6 activation function.
 
     Computes the element-wise function
@@ -121,7 +122,7 @@ def relu6(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*, clipped to the range [0, 6].
 
     Examples
@@ -141,7 +142,7 @@ def relu6(
 def sigmoid(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Sigmoid activation function.
 
     Computes the element-wise function:
@@ -159,7 +160,7 @@ def sigmoid(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with values in the range (0, 1).
 
     Examples
@@ -179,7 +180,7 @@ def sigmoid(
 def softplus(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Softplus activation function.
 
     Computes the element-wise function
@@ -197,7 +198,7 @@ def softplus(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with non-negative values.
 
     Examples
@@ -217,7 +218,7 @@ def softplus(
 def sparse_plus(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Sparse plus function.
 
     Computes the function:
@@ -245,7 +246,7 @@ def sparse_plus(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -265,7 +266,7 @@ def sparse_plus(
 def sparse_sigmoid(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Sparse sigmoid activation function.
 
     Computes the function:
@@ -295,7 +296,7 @@ def sparse_sigmoid(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with values in the range [0, 1].
 
     Examples
@@ -315,7 +316,7 @@ def sparse_sigmoid(
 def soft_sign(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Soft-sign activation function.
 
     Computes the element-wise function
@@ -333,7 +334,7 @@ def soft_sign(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with values in the range (-1, 1).
 
     Examples
@@ -353,7 +354,7 @@ def soft_sign(
 def silu(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""SiLU (aka swish) activation function.
 
     Computes the element-wise function:
@@ -373,7 +374,7 @@ def silu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -393,7 +394,7 @@ def silu(
 def swish(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Swish (aka SiLU) activation function.
 
     Computes the element-wise function:
@@ -413,7 +414,7 @@ def swish(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -433,7 +434,7 @@ def swish(
 def log_sigmoid(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Log-sigmoid activation function.
 
     Computes the element-wise function:
@@ -451,7 +452,7 @@ def log_sigmoid(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with non-positive values.
 
     Examples
@@ -471,7 +472,7 @@ def log_sigmoid(
 def leaky_relu(
     x: Union[Quantity, ArrayLike],
     negative_slope: ArrayLike = 1e-2  # type: ignore[assignment]
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     r"""Leaky rectified linear unit activation function.
 
     Computes the element-wise function:
@@ -494,7 +495,7 @@ def leaky_relu(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         An array with the same shape as *x*.
 
     Examples
@@ -517,7 +518,7 @@ def leaky_relu(
 def hard_sigmoid(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Hard Sigmoid activation function.
 
     Computes the element-wise function
@@ -535,7 +536,7 @@ def hard_sigmoid(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with values in the range [0, 1].
 
     Examples
@@ -555,7 +556,7 @@ def hard_sigmoid(
 def hard_silu(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Hard SiLU (swish) activation function.
 
     Computes the element-wise function
@@ -576,7 +577,7 @@ def hard_silu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -599,7 +600,7 @@ hard_swish = hard_silu
 def hard_tanh(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Hard :math:`\mathrm{tanh}` activation function.
 
     Computes the element-wise function:
@@ -621,7 +622,7 @@ def hard_tanh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with values clipped to the range [-1, 1].
 
     Examples
@@ -642,7 +643,7 @@ def elu(
     x: Union[Quantity, ArrayLike],
     alpha: ArrayLike = 1.0,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Exponential linear unit activation function.
 
     Computes the element-wise function:
@@ -665,7 +666,7 @@ def elu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -688,7 +689,7 @@ def celu(
     x: Union[Quantity, ArrayLike],
     alpha: ArrayLike = 1.0,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Continuously-differentiable exponential linear unit activation.
 
     Computes the element-wise function:
@@ -715,7 +716,7 @@ def celu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -735,7 +736,7 @@ def celu(
 def selu(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Scaled exponential linear unit activation.
 
     Computes the element-wise function:
@@ -763,7 +764,7 @@ def selu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -784,7 +785,7 @@ def gelu(
     x: Union[Quantity, ArrayLike],
     approximate: bool = True,
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Gaussian error linear unit activation function.
 
     If ``approximate=False``, computes the element-wise function:
@@ -814,7 +815,7 @@ def gelu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples
@@ -835,7 +836,7 @@ def glu(
     x: Union[Quantity, ArrayLike],
     axis: int = -1,
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Gated linear unit activation function.
 
     Computes the function:
@@ -861,7 +862,7 @@ def glu(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array whose size along *axis* is half that of the input.
 
     Examples
@@ -883,7 +884,7 @@ def squareplus(
     x: Union[Quantity, ArrayLike],
     b: ArrayLike = 4,  # type: ignore[assignment]
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Squareplus activation function.
 
     Computes the element-wise function
@@ -905,7 +906,7 @@ def squareplus(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with non-negative values.
 
     Examples
@@ -925,7 +926,7 @@ def squareplus(
 def mish(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
-) -> jax.Array:
+) -> Array:
     r"""Mish activation function.
 
     Computes the element-wise function:
@@ -947,7 +948,7 @@ def mish(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         An array with the same shape as *x*.
 
     Examples

--- a/saiunit/math/_einops.py
+++ b/saiunit/math/_einops.py
@@ -22,7 +22,8 @@ import operator
 from collections import OrderedDict
 from typing import Set, Tuple, List, Dict, Union, Callable, Optional, Sequence, TypeVar
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike, DTypeLike
 import numpy as np
 import opt_einsum  # type: ignore[import-untyped]
 
@@ -545,7 +546,7 @@ def einreduce(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         The reduced tensor with the same type as the input.
 
     Examples
@@ -601,7 +602,7 @@ def einrearrange(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         Tensor of the same type as input. If possible, a view to the
         original tensor is returned.
 
@@ -645,7 +646,7 @@ def einrepeat(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         Tensor of the same type as input.
 
     Examples
@@ -783,8 +784,8 @@ def _dot_general(
     rhs: ArrayLike | Quantity,
     dimension_numbers: jax.lax.DotDimensionNumbers,
     precision: jax.lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None
-) -> jax.Array | Quantity:
+    preferred_element_type: DTypeLike | None = None
+) -> Array | Quantity:
     unit = UNITLESS
     if isinstance(lhs, Quantity):
         unit = unit * lhs.unit  # type: ignore[assignment]
@@ -805,7 +806,7 @@ def _dot_general(
         return Quantity(r, unit=unit)
 
 
-def _delta(dtype: jax.typing.DTypeLike, shape_, axes: Sequence[int]) -> jax.Array:
+def _delta(dtype: DTypeLike, shape_, axes: Sequence[int]) -> Array:
     """This utility function exists for creating Kronecker delta arrays."""
     axes = safe_map(int, axes)
     dtype = jax.dtypes.canonicalize_dtype(dtype)
@@ -977,8 +978,8 @@ def einsum(
     *operands,
     optimize: str | bool | list[tuple[int, ...]] = "optimal",
     precision: jax.lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None,
-) -> jax.Array:
+    preferred_element_type: DTypeLike | None = None,
+) -> Array:
     """Einstein summation for arrays and quantities.
 
     ``einsum`` is a powerful and generic API for computing various reductions,
@@ -1005,7 +1006,7 @@ def einsum(
 
     Returns
     -------
-    out : jax.Array or Quantity
+    out : Array or Quantity
         Result of the Einstein summation. When operands carry physical
         units, the output unit is derived from the contraction.
 

--- a/saiunit/math/_einops_test.py
+++ b/saiunit/math/_einops_test.py
@@ -22,7 +22,7 @@ import saiunit as u
 from saiunit._base_getters import assert_quantity
 from saiunit.math._einops import einrearrange, einreduce, einrepeat, _enumerate_directions
 from saiunit.math._einops_parsing import EinopsError
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import ArrayLike
 
 
 class Array(u.CustomArray):

--- a/saiunit/math/_exprel.py
+++ b/saiunit/math/_exprel.py
@@ -29,6 +29,7 @@ from math import factorial
 from typing import Optional
 
 from saiunit._jax_compat import HAS_JAX, jnp, require_jax
+from saiunit._typing import Array
 
 if HAS_JAX:
     from jax import core
@@ -337,7 +338,7 @@ def exprel(x, /, order: int = 2):
 
     Returns
     -------
-    y : jax.Array
+    y : Array
         ``(exp(x) - 1) / x``, with the singularity at ``x = 0``
         handled correctly (returns 1).
 

--- a/saiunit/math/_fun_accept_unitless.py
+++ b/saiunit/math/_fun_accept_unitless.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 from typing import Union, Optional, Tuple, Any, Callable
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 from saiunit._backend import get_backend
 from saiunit._base_unit import Unit
@@ -121,7 +122,7 @@ def _fun_accept_unitless_unary(
 def exprel(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Relative error exponential, ``(exp(x) - 1)/x``.
 
@@ -151,7 +152,7 @@ def exp(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Calculate the exponential of all elements in the input.
 
@@ -168,7 +169,7 @@ def exp(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise exponential.
 
     Examples
@@ -188,7 +189,7 @@ def exp2(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Calculate ``2**x`` element-wise.
 
@@ -201,7 +202,7 @@ def exp2(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise ``2**x``.
 
     Examples
@@ -221,7 +222,7 @@ def expm1(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Calculate ``exp(x) - 1`` element-wise with improved precision near zero.
 
@@ -234,7 +235,7 @@ def expm1(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise ``exp(x) - 1``.
 
     Examples
@@ -254,7 +255,7 @@ def log(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Natural logarithm, element-wise.
 
@@ -267,7 +268,7 @@ def log(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise natural logarithm.
 
     Examples
@@ -287,7 +288,7 @@ def log10(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Base-10 logarithm, element-wise.
 
@@ -300,7 +301,7 @@ def log10(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise base-10 logarithm.
 
     Examples
@@ -320,7 +321,7 @@ def log1p(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Natural logarithm of ``1 + x``, element-wise.
 
@@ -335,7 +336,7 @@ def log1p(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise ``log(1 + x)``.
 
     Examples
@@ -355,7 +356,7 @@ def log2(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Base-2 logarithm, element-wise.
 
@@ -368,7 +369,7 @@ def log2(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise base-2 logarithm.
 
     Examples
@@ -388,7 +389,7 @@ def arccos(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse cosine, element-wise.
 
@@ -401,7 +402,7 @@ def arccos(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians, in ``[0, pi]``.
 
     Examples
@@ -421,7 +422,7 @@ def arccosh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse hyperbolic cosine, element-wise.
 
@@ -434,7 +435,7 @@ def arccosh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise inverse hyperbolic cosine.
 
     Examples
@@ -454,7 +455,7 @@ def arcsin(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse sine, element-wise.
 
@@ -467,7 +468,7 @@ def arcsin(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians, in ``[-pi/2, pi/2]``.
 
     Examples
@@ -487,7 +488,7 @@ def arcsinh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse hyperbolic sine, element-wise.
 
@@ -500,7 +501,7 @@ def arcsinh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise inverse hyperbolic sine.
 
     Examples
@@ -520,7 +521,7 @@ def arctan(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse tangent, element-wise.
 
@@ -533,7 +534,7 @@ def arctan(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians, in ``[-pi/2, pi/2]``.
 
     Examples
@@ -553,7 +554,7 @@ def arctanh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Inverse hyperbolic tangent, element-wise.
 
@@ -566,7 +567,7 @@ def arctanh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise inverse hyperbolic tangent.
 
     Examples
@@ -586,7 +587,7 @@ def cos(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Cosine, element-wise.
 
@@ -599,7 +600,7 @@ def cos(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise cosine.
 
     Examples
@@ -619,7 +620,7 @@ def cosh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Hyperbolic cosine, element-wise.
 
@@ -632,7 +633,7 @@ def cosh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise hyperbolic cosine.
 
     Examples
@@ -652,7 +653,7 @@ def sin(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Sine, element-wise.
 
@@ -665,7 +666,7 @@ def sin(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise sine.
 
     Examples
@@ -685,7 +686,7 @@ def sinc(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Normalized sinc function, ``sin(pi*x) / (pi*x)``, element-wise.
 
@@ -698,7 +699,7 @@ def sinc(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise sinc.
 
     Examples
@@ -718,7 +719,7 @@ def sinh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Hyperbolic sine, element-wise.
 
@@ -731,7 +732,7 @@ def sinh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise hyperbolic sine.
 
     Examples
@@ -751,7 +752,7 @@ def tan(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Tangent, element-wise.
 
@@ -764,7 +765,7 @@ def tan(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise tangent.
 
     Examples
@@ -784,7 +785,7 @@ def tanh(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Hyperbolic tangent, element-wise.
 
@@ -797,7 +798,7 @@ def tanh(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise hyperbolic tangent, in ``(-1, 1)``.
 
     Examples
@@ -817,7 +818,7 @@ def deg2rad(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Convert angles from degrees to radians.
 
@@ -830,7 +831,7 @@ def deg2rad(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians.
 
     Examples
@@ -850,7 +851,7 @@ def rad2deg(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Convert angles from radians to degrees.
 
@@ -863,7 +864,7 @@ def rad2deg(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in degrees.
 
     Examples
@@ -883,7 +884,7 @@ def degrees(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Convert angles from radians to degrees (alias for :func:`rad2deg`).
 
@@ -896,7 +897,7 @@ def degrees(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in degrees.
 
     Examples
@@ -916,7 +917,7 @@ def radians(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Convert angles from degrees to radians (alias for :func:`deg2rad`).
 
@@ -929,7 +930,7 @@ def radians(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians.
 
     Examples
@@ -949,7 +950,7 @@ def angle(
     x: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the angle of the complex argument, element-wise.
 
@@ -962,7 +963,7 @@ def angle(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians, in ``(-pi, pi]``.
 
     Examples
@@ -982,7 +983,7 @@ def frexp(
     x: Union[Quantity, ArrayLike],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> Tuple[jax.Array, jax.Array]:
+) -> Tuple[Array, Array]:
     """
     Decompose elements into mantissa and base-2 exponent.
 
@@ -998,9 +999,9 @@ def frexp(
 
     Returns
     -------
-    mantissa : jax.Array
+    mantissa : Array
         Floating values in ``(-1, 1)``.
-    exponent : jax.Array
+    exponent : Array
         Integer exponents of 2.
 
     Examples
@@ -1064,7 +1065,7 @@ def hypot(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Given the legs of a right triangle, return its hypotenuse.
 
@@ -1081,7 +1082,7 @@ def hypot(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Hypotenuse values.
 
     Examples
@@ -1102,7 +1103,7 @@ def arctan2(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Element-wise arc tangent of ``x / y`` choosing the quadrant correctly.
 
@@ -1117,7 +1118,7 @@ def arctan2(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Angle in radians, in ``(-pi, pi]``.
 
     Examples
@@ -1139,7 +1140,7 @@ def logaddexp(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Logarithm of the sum of exponentiations of the inputs.
 
@@ -1156,7 +1157,7 @@ def logaddexp(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise ``log(exp(x) + exp(y))``.
 
     Examples
@@ -1177,7 +1178,7 @@ def logaddexp2(
     y: Union[ArrayLike, Quantity],
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Logarithm of the sum of exponentiations of the inputs in base 2.
 
@@ -1194,7 +1195,7 @@ def logaddexp2(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise ``log2(2**x + 2**y)``.
 
     Examples
@@ -1216,7 +1217,7 @@ def corrcoef(
     rowvar: bool = True,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""
     Return Pearson product-moment correlation coefficients.
 
@@ -1260,10 +1261,10 @@ def correlate(
     mode: str = 'valid',
     *,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     r"""
     Cross-correlation of two 1-dimensional sequences.
 
@@ -1320,7 +1321,7 @@ def cov(
     aweights: Optional[ArrayLike] = None,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Estimate a covariance matrix, given data and weights.
 
@@ -1426,7 +1427,7 @@ def ldexp(
 def bitwise_not(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute bit-wise NOT, element-wise.
 
@@ -1439,7 +1440,7 @@ def bitwise_not(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise bit-wise NOT.
 
     Examples
@@ -1458,7 +1459,7 @@ def bitwise_not(
 def invert(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute bit-wise inversion (NOT), element-wise.
 
@@ -1471,7 +1472,7 @@ def invert(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise bit-wise inversion.
 
     Examples
@@ -1514,7 +1515,7 @@ def bitwise_and(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute bit-wise AND of two arrays, element-wise.
 
@@ -1529,7 +1530,7 @@ def bitwise_and(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise bit-wise AND.
 
     Examples
@@ -1550,7 +1551,7 @@ def bitwise_or(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute bit-wise OR of two arrays, element-wise.
 
@@ -1565,7 +1566,7 @@ def bitwise_or(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise bit-wise OR.
 
     Examples
@@ -1586,7 +1587,7 @@ def bitwise_xor(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute bit-wise XOR of two arrays, element-wise.
 
@@ -1601,7 +1602,7 @@ def bitwise_xor(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise bit-wise XOR.
 
     Examples
@@ -1622,7 +1623,7 @@ def left_shift(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Shift the bits of an integer to the left, element-wise.
 
@@ -1637,7 +1638,7 @@ def left_shift(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise left shift.
 
     Examples
@@ -1657,7 +1658,7 @@ def right_shift(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Shift the bits of an integer to the right, element-wise.
 
@@ -1672,7 +1673,7 @@ def right_shift(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Element-wise right shift.
 
     Examples

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import (Union, Optional, List, Any, Tuple)
 
-from saiunit._jax_compat import jax, jnp, Array, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike, DTypeLike
 import numpy as np
 
 from saiunit._backend import get_backend, get_default_backend
@@ -65,7 +66,7 @@ __all__ = [
 def full(
     shape: Shape,
     fill_value: Union[Quantity, int, float],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
 ) -> Union[Array, Quantity]:
     """
     Return a new quantity or array of given shape, filled with ``fill_value``.
@@ -86,7 +87,7 @@ def full(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array (or ``Quantity``) of ``fill_value`` with the given shape and
         dtype.
 
@@ -114,7 +115,7 @@ def eye(
     N: int,
     M: Optional[int] = None,
     k: int = 0,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS,
 ) -> Union[Array, Quantity]:
     """
@@ -138,7 +139,7 @@ def eye(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         An array of shape ``(N, M)`` where all elements are zero except for
         the ``k``-th diagonal, whose values are one (optionally carrying
         ``unit``).
@@ -166,7 +167,7 @@ def eye(
 @set_module_as('saiunit.math')
 def identity(
     n: int,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS
 ) -> Union[Array, Quantity]:
     """
@@ -186,7 +187,7 @@ def identity(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         ``n x n`` array with its main diagonal set to one and all other
         elements zero.
 
@@ -216,7 +217,7 @@ def tri(
     N: int,
     M: Optional[int] = None,
     k: int = 0,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS
 ) -> Union[Array, Quantity]:
     """
@@ -240,7 +241,7 @@ def tri(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of shape ``(N, M)`` with its lower triangle filled with ones
         and zero elsewhere; i.e. ``T[i, j] == 1`` for ``j <= i + k``,
         0 otherwise.
@@ -269,7 +270,7 @@ def tri(
 @set_module_as('saiunit.math')
 def empty(
     shape: Shape,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS
 ) -> Union[Array, Quantity]:
     """
@@ -287,7 +288,7 @@ def empty(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of uninitialized (arbitrary) data of the given shape and dtype.
 
     Examples
@@ -313,7 +314,7 @@ def empty(
 @set_module_as('saiunit.math')
 def ones(
     shape: Shape,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS
 ) -> Union[Array, Quantity]:
     """
@@ -331,7 +332,7 @@ def ones(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of ones with the given shape and dtype.
 
     Examples
@@ -356,7 +357,7 @@ def ones(
 @set_module_as('saiunit.math')
 def zeros(
     shape: Shape,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     unit: Unit = UNITLESS
 ) -> Union[Array, Quantity]:
     """
@@ -374,7 +375,7 @@ def zeros(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of zeros with the given shape and dtype.
 
     Examples
@@ -399,9 +400,9 @@ def zeros(
 def full_like(
     a: Union[Quantity, ArrayLike],
     fill_value: Union[Quantity, ArrayLike],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     shape: Shape | None = None
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return a new quantity or array with the same shape and type as a given array, filled with ``fill_value``.
 
@@ -421,7 +422,7 @@ def full_like(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         New array with the same shape and type as ``a``, filled with
         ``fill_value``.
 
@@ -481,7 +482,7 @@ def diag(
     v: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Extract a diagonal or construct a diagonal array.
 
@@ -503,7 +504,7 @@ def diag(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         The extracted diagonal or constructed diagonal array.
 
     Examples
@@ -540,7 +541,7 @@ def tril(
     m: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the lower triangle of an array.
 
@@ -560,7 +561,7 @@ def tril(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Lower triangle of ``m``, of the same shape and data-type as ``m``.
 
     Examples
@@ -594,7 +595,7 @@ def triu(
     m: Union[Quantity, ArrayLike],
     k: int = 0,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the upper triangle of an array.
 
@@ -614,7 +615,7 @@ def triu(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Upper triangle of ``m``, of the same shape and data-type as ``m``.
 
     See Also
@@ -650,10 +651,10 @@ def triu(
 @set_module_as('saiunit.math')
 def empty_like(
     prototype: Union[Quantity, ArrayLike],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     shape: Shape | None = None,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return a new uninitialized quantity or array with the same shape and type as a given array.
 
@@ -672,7 +673,7 @@ def empty_like(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of uninitialized (arbitrary) data with the same shape and type
         as ``prototype``.
 
@@ -704,10 +705,10 @@ def empty_like(
 @set_module_as('saiunit.math')
 def ones_like(
     a: Union[Quantity, ArrayLike],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     shape: Shape | None = None,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return a quantity or array of ones with the same shape and type as a given array.
 
@@ -726,7 +727,7 @@ def ones_like(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of ones with the same shape and type as ``a``.
 
     Examples
@@ -758,10 +759,10 @@ def ones_like(
 @set_module_as('saiunit.math')
 def zeros_like(
     a: Union[Quantity, ArrayLike],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     shape: Shape | None = None,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return a quantity or array of zeros with the same shape and type as a given array.
 
@@ -780,7 +781,7 @@ def zeros_like(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of zeros with the same shape and type as ``a``.
 
     Examples
@@ -812,10 +813,10 @@ def zeros_like(
 @set_module_as('saiunit.math')
 def asarray(
     a: Any,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     order: Optional[str] = None,
     unit: Optional[Unit] = None,
-) -> Quantity | jax.Array | None:
+) -> Quantity | Array | None:
     """
     Convert the input to a quantity or array.
 
@@ -841,7 +842,7 @@ def asarray(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array interpretation of ``a``.
 
     Raises
@@ -901,8 +902,8 @@ def arange(
     start: Optional[Union[Quantity, ArrayLike]] = None,
     stop: Optional[Union[Quantity, ArrayLike]] = None,
     step: Optional[Union[Quantity, ArrayLike]] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None
-) -> Union[Quantity, jax.Array]:
+    dtype: Optional[DTypeLike] = None
+) -> Union[Quantity, Array]:
     """
     Return evenly spaced values within a given interval.
 
@@ -925,7 +926,7 @@ def arange(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Array of evenly spaced values.
 
     Raises
@@ -980,8 +981,8 @@ def linspace(
     num: int = 50,
     endpoint: Optional[bool] = True,
     retstep: Optional[bool] = False,
-    dtype: Optional[jax.typing.DTypeLike] = None
-) -> Union[Quantity, jax.Array]:
+    dtype: Optional[DTypeLike] = None
+) -> Union[Quantity, Array]:
     """
     Return evenly spaced numbers over a specified interval.
 
@@ -1009,7 +1010,7 @@ def linspace(
 
     Returns
     -------
-    samples : Quantity or jax.Array
+    samples : Quantity or Array
         ``num`` equally spaced samples in the closed interval
         ``[start, stop]`` or the half-open interval ``[start, stop)``.
 
@@ -1052,7 +1053,7 @@ def logspace(
     num: Optional[int] = 50,
     endpoint: Optional[bool] = True,
     base: Optional[float] = 10.0,
-    dtype: Optional[jax.typing.DTypeLike] = None
+    dtype: Optional[DTypeLike] = None
 ):
     """
     Return numbers spaced evenly on a log scale.
@@ -1082,7 +1083,7 @@ def logspace(
 
     Returns
     -------
-    samples : jax.Array
+    samples : Array
         ``num`` samples, equally spaced on a log scale.
 
     Raises
@@ -1121,7 +1122,7 @@ def fill_diagonal(
     val: Union[Quantity, ArrayLike],
     wrap: Optional[bool] = False,
     inplace: Optional[bool] = False
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Fill the main diagonal of the given array of any dimensionality.
 
@@ -1144,7 +1145,7 @@ def fill_diagonal(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         The input array with the diagonal filled.
 
     Examples
@@ -1180,7 +1181,7 @@ def meshgrid(
     copy: Optional[bool] = True,
     sparse: Optional[bool] = False,
     indexing: Optional[str] = 'xy'
-) -> List[Union[Quantity, jax.Array]]:
+) -> List[Union[Quantity, Array]]:
     """
     Return coordinate matrices from coordinate vectors.
 
@@ -1203,7 +1204,7 @@ def meshgrid(
 
     Returns
     -------
-    X1, X2, ..., XN : list of Quantity or jax.Array
+    X1, X2, ..., XN : list of Quantity or Array
         Coordinate matrices.
 
     Examples
@@ -1248,7 +1249,7 @@ def vander(
     N: Optional[bool] = None,
     increasing: Optional[bool] = False,
     unit: Unit = UNITLESS
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Generate a Vandermonde matrix.
 
@@ -1270,7 +1271,7 @@ def vander(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         Vandermonde matrix.
 
     Raises
@@ -1318,7 +1319,7 @@ def tril_indices(n, k=0, m=None):
 def tril_indices_from(
     arr: Union[Quantity, ArrayLike],
     k: Optional[int] = 0
-) -> Tuple[jax.Array, jax.Array]:
+) -> Tuple[Array, Array]:
     """
     Return the indices for the lower-triangle of an ``(n, m)`` array.
 
@@ -1332,7 +1333,7 @@ def tril_indices_from(
 
     Returns
     -------
-    out : tuple of jax.Array
+    out : tuple of Array
         Row and column indices for the lower triangle.
 
     Examples
@@ -1358,7 +1359,7 @@ def triu_indices(n, k=0, m=None):
 def triu_indices_from(
     arr: Union[Quantity, ArrayLike],
     k: Optional[int] = 0
-) -> Tuple[jax.Array, jax.Array]:
+) -> Tuple[Array, Array]:
     """
     Return the indices for the upper-triangle of an ``(n, m)`` array.
 
@@ -1372,7 +1373,7 @@ def triu_indices_from(
 
     Returns
     -------
-    out : tuple of jax.Array
+    out : tuple of Array
         Row and column indices for the upper triangle.
 
     Examples
@@ -1397,7 +1398,7 @@ def triu_indices_from(
 def from_numpy(
     x: np.ndarray,
     unit: Unit = UNITLESS
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Convert a NumPy array to a JAX array, optionally attaching a unit.
 
@@ -1411,7 +1412,7 @@ def from_numpy(
 
     Returns
     -------
-    out : Quantity or jax.Array
+    out : Quantity or Array
         JAX array (or ``Quantity``) created from ``x``.
 
     Examples

--- a/saiunit/math/_fun_change_unit.py
+++ b/saiunit/math/_fun_change_unit.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Union, Optional, Tuple, Any, Callable
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 from saiunit._backend import get_backend
 from saiunit._base_unit import UNITLESS
@@ -74,7 +75,7 @@ def unit_change(
 def reciprocal(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the reciprocal of the argument, element-wise.
 
@@ -115,7 +116,7 @@ def var(
     *,
     where: Optional[ArrayLike] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the variance along the specified axis.
 
@@ -180,7 +181,7 @@ def nanvar(
     keepdims: bool = False,
     where: Optional[ArrayLike] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the variance along the specified axis, while ignoring NaNs.
 
@@ -239,7 +240,7 @@ def nanvar(
 def sqrt(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the positive square root of each element.
 
@@ -273,7 +274,7 @@ def sqrt(
 def cbrt(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the cube root of each element.
 
@@ -307,7 +308,7 @@ def cbrt(
 def square(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the square of each element.
 
@@ -341,11 +342,11 @@ def square(
 def prod(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     keepdims: Optional[bool] = False,
     initial: Optional[Union[Quantity, ArrayLike]] = None,
     where: Optional[Union[Quantity, ArrayLike]] = None,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the product of array elements over a given axis.
 
@@ -405,7 +406,7 @@ def prod(
 def nanprod(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     keepdims: bool = False,
     initial: Optional[Union[Quantity, ArrayLike]] = None,
     where: Optional[Union[Quantity, ArrayLike]] = None,
@@ -474,7 +475,7 @@ product = prod
 def cumprod(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
 ) -> Union[Quantity, ArrayLike]:
     """
@@ -520,7 +521,7 @@ def cumprod(
 def nancumprod(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
 ) -> Union[Quantity, ArrayLike]:
     """
@@ -828,7 +829,7 @@ def convolve(
     mode: str = 'full',
     *,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
 ) -> Union[Quantity, ArrayLike]:
     """
@@ -888,7 +889,7 @@ def power(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     First array elements raised to powers from second array, element-wise.
 
@@ -954,7 +955,7 @@ def floor_divide(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the largest integer smaller or equal to the division of the inputs.
 
@@ -992,7 +993,7 @@ def float_power(
     x: Union[Quantity, ArrayLike],
     y: ArrayLike,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     First array elements raised to powers from second array, element-wise.
 
@@ -1063,9 +1064,9 @@ def dot(
     b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute the dot product of two arrays or quantities.
 
@@ -1117,7 +1118,7 @@ def multi_dot(
     *,
     precision: jax.lax.PrecisionLike = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Efficiently compute matrix products between a sequence of arrays.
 
@@ -1178,9 +1179,9 @@ def vdot(
     b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Perform a conjugate multiplication of two 1D vectors.
 
@@ -1234,7 +1235,7 @@ def vecdot(
     /, *,
     axis: int = -1,
     precision: jax.lax.PrecisionLike = None,
-    preferred_element_type: jax.typing.DTypeLike | None = None,
+    preferred_element_type: DTypeLike | None = None,
     **kwargs,
 ):
     """
@@ -1293,9 +1294,9 @@ def inner(
     b: Union[ArrayLike, Quantity],
     *,
     precision: jax.lax.PrecisionLike = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute the inner product of two arrays or quantities.
 
@@ -1349,7 +1350,7 @@ def outer(
     b: Union[ArrayLike, Quantity],
     out: Optional[Any] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute the outer product of two vectors or quantities.
 
@@ -1393,7 +1394,7 @@ def kron(
     a: Union[ArrayLike, Quantity],
     b: Union[ArrayLike, Quantity],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute the Kronecker product of two arrays or quantities.
 
@@ -1432,9 +1433,9 @@ def matmul(
     b: Union[ArrayLike, Quantity],
     *,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute the matrix product of two arrays or quantities.
 
@@ -1486,9 +1487,9 @@ def tensordot(
     b: Union[ArrayLike, Quantity],
     axes: int | Sequence[int] | Sequence[Sequence[int]] = 2,
     precision: Any = None,
-    preferred_element_type: Optional[jax.typing.DTypeLike] = None,
+    preferred_element_type: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Compute tensor dot product along specified axes.
 

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import functools
 from typing import (Union, Sequence, Tuple, Optional)
 
-from saiunit._jax_compat import jax, jnp, tree, ArrayLike
+from saiunit._jax_compat import jax, jnp, tree
+from saiunit._typing import Array, ArrayLike, DTypeLike
 import numpy as np
 
 from saiunit._backend import get_backend
@@ -194,9 +195,9 @@ def _fun_keep_unit_sequence(
 def concatenate(
     arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     axis: Optional[int] = None,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Join a sequence of quantities or arrays along an existing axis.
 
@@ -237,9 +238,9 @@ def concatenate(
 def stack(
     arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
     axis: int = 0,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Join a sequence of quantities or arrays along a new axis.
 
@@ -273,9 +274,9 @@ def stack(
 @set_module_as('saiunit.math')
 def vstack(
     tup: Union[Sequence[ArrayLike], Sequence[Quantity]],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Stack quantities or arrays in sequence vertically (row wise).
 
@@ -310,9 +311,9 @@ row_stack = vstack
 @set_module_as('saiunit.math')
 def hstack(
     arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Stack quantities arrays in sequence horizontally (column wise).
 
@@ -344,9 +345,9 @@ def hstack(
 @set_module_as('saiunit.math')
 def dstack(
     arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Stack quantities or arrays in sequence depth wise (along third axis).
 
@@ -379,7 +380,7 @@ def dstack(
 def column_stack(
     tup: Union[Sequence[ArrayLike], Sequence[Quantity]],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Stack 1-D arrays as columns into a 2-D array.
 
@@ -410,9 +411,9 @@ def column_stack(
 
 @set_module_as('saiunit.math')
 def block(
-    arrays: Sequence[Union[jax.Array, Quantity]],
+    arrays: Sequence[Union[Array, Quantity]],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Assemble a quantity or an array from nested lists of blocks.
 
@@ -440,11 +441,11 @@ def block(
 
 @set_module_as('saiunit.math')
 def append(
-    arr: Union[jax.Array, Quantity],
-    values: Union[jax.Array, Quantity],
+    arr: Union[Array, Quantity],
+    values: Union[Array, Quantity],
     axis: Optional[int] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Append values to the end of a quantity or an array.
 
@@ -495,11 +496,11 @@ def _fun_keep_unit_return_sequence(
 
 @set_module_as('saiunit.math')
 def split(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     indices_or_sections: Union[int, Sequence[int]],
     axis: int = 0,
     **kwargs,
-) -> Union[Sequence[jax.Array | Quantity]]:
+) -> Union[Sequence[Array | Quantity]]:
     """
     Split quantity or array into a list of multiple sub-arrays.
 
@@ -542,7 +543,7 @@ def array_split(
     indices_or_sections: Union[int, ArrayLike],
     axis: Optional[int] = 0,
     **kwargs,
-) -> Union[Sequence[Quantity | jax.Array]]:
+) -> Union[Sequence[Quantity | Array]]:
     """
     Split an array into multiple sub-arrays.
 
@@ -576,10 +577,10 @@ def array_split(
 
 @set_module_as('saiunit.math')
 def dsplit(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     indices_or_sections: Union[int, Sequence[int]],
     **kwargs,
-) -> Union[Sequence[jax.Array | Quantity]]:
+) -> Union[Sequence[Array | Quantity]]:
     """
     Split a quantity or an array into multiple sub-arrays along the 3rd axis (depth).
 
@@ -612,10 +613,10 @@ def dsplit(
 
 @set_module_as('saiunit.math')
 def hsplit(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     indices_or_sections: Union[int, Sequence[int]],
     **kwargs,
-) -> Union[Sequence[jax.Array | Quantity]]:
+) -> Union[Sequence[Array | Quantity]]:
     """
     Split a quantity or an array into multiple sub-arrays horizontally (column-wise).
 
@@ -648,10 +649,10 @@ def hsplit(
 
 @set_module_as('saiunit.math')
 def vsplit(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     indices_or_sections: Union[int, Sequence[int]],
     **kwargs,
-) -> Union[Sequence[jax.Array | Quantity]]:
+) -> Union[Sequence[Array | Quantity]]:
     """
     Split a quantity or an array into multiple sub-arrays vertically (row-wise).
 
@@ -704,7 +705,7 @@ def _broadcast_fun(func, *args, **kwargs):
 def broadcast_arrays(
     *args: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     Broadcast any number of arrays against each other.
 
@@ -739,7 +740,7 @@ def broadcast_arrays(
 def promote_dtypes(
     *args: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     Promote the data types of the inputs to a common type.
 
@@ -771,7 +772,7 @@ def broadcast_to(
     array: Union[Quantity, ArrayLike],
     shape: Tuple[int, ...],
     **kwargs,
-) -> Quantity | jax.Array:
+) -> Quantity | Array:
     """
     Broadcast an array to a new shape.
 
@@ -809,9 +810,9 @@ def broadcast_to(
 
 @set_module_as('saiunit.math')
 def atleast_1d(
-    *arys: Union[jax.Array, Quantity],
+    *arys: Union[Array, Quantity],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     View inputs as quantities or arrays with at least one dimension.
 
@@ -837,9 +838,9 @@ def atleast_1d(
 
 @set_module_as('saiunit.math')
 def atleast_2d(
-    *arys: Union[jax.Array, Quantity],
+    *arys: Union[Array, Quantity],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     View inputs as quantities or arrays with at least two dimensions.
 
@@ -866,9 +867,9 @@ def atleast_2d(
 
 @set_module_as('saiunit.math')
 def atleast_3d(
-    *arys: Union[jax.Array, Quantity],
+    *arys: Union[Array, Quantity],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     View inputs as quantities or arrays with at least three dimensions.
 
@@ -899,11 +900,11 @@ def atleast_3d(
 
 @set_module_as('saiunit.math')
 def reshape(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     shape: Union[int, Tuple[int, ...]],
     order: str = 'C',
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Gives a new shape to a quantity or an array without changing its data.
 
@@ -950,11 +951,11 @@ def reshape(
 
 @set_module_as('saiunit.math')
 def moveaxis(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     source: Union[int, Tuple[int, ...]],
     destination: Union[int, Tuple[int, ...]],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Moves axes of a quantity or an array to new positions.
     Other axes remain in their original order.
@@ -989,10 +990,10 @@ def moveaxis(
 
 @set_module_as('saiunit.math')
 def transpose(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axes: Optional[Union[int, Tuple[int, ...]]] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Permute the dimensions of a quantity or an array.
 
@@ -1025,11 +1026,11 @@ def transpose(
 
 @set_module_as('saiunit.math')
 def swapaxes(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis1: int,
     axis2: int,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Interchange two axes of a quantity or an array.
 
@@ -1062,10 +1063,10 @@ def swapaxes(
 
 @set_module_as('saiunit.math')
 def tile(
-    A: Union[jax.Array, Quantity],
+    A: Union[Array, Quantity],
     reps: Union[int, Tuple[int, ...]],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Construct a quantity or an array by repeating A the number of times given by reps.
 
@@ -1094,12 +1095,12 @@ def tile(
 
 @set_module_as('saiunit.math')
 def repeat(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     repeats: Union[int, Tuple[int, ...]],
     axis: Optional[int] = None,
     total_repeat_length: Optional[int] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Repeat elements of a quantity or an array.
 
@@ -1133,10 +1134,10 @@ def repeat(
 
 @set_module_as('saiunit.math')
 def flip(
-    m: Union[jax.Array, Quantity],
+    m: Union[Array, Quantity],
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Reverse the order of elements in a quantity or an array along the given axis.
 
@@ -1165,9 +1166,9 @@ def flip(
 
 @set_module_as('saiunit.math')
 def fliplr(
-    m: Union[jax.Array, Quantity],
+    m: Union[Array, Quantity],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Flip quantity or array in the left/right direction.
 
@@ -1194,9 +1195,9 @@ def fliplr(
 
 @set_module_as('saiunit.math')
 def flipud(
-    m: Union[jax.Array, Quantity],
+    m: Union[Array, Quantity],
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Flip quantity or array in the up/down direction.
 
@@ -1223,11 +1224,11 @@ def flipud(
 
 @set_module_as('saiunit.math')
 def roll(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     shift: Union[int, Tuple[int, ...]],
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Roll quantity or array elements along a given axis.
 
@@ -1261,10 +1262,10 @@ def roll(
 
 @set_module_as('saiunit.math')
 def expand_dims(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis: int,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Expand the shape of a quantity or an array.
 
@@ -1294,10 +1295,10 @@ def expand_dims(
 
 @set_module_as('saiunit.math')
 def squeeze(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Remove single-dimensional entries from the shape of a quantity or an array.
 
@@ -1328,7 +1329,7 @@ def squeeze(
 
 @set_module_as('saiunit.math')
 def sort(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis: Optional[int] = -1,
     *,
     kind: None = None,
@@ -1336,7 +1337,7 @@ def sort(
     stable: bool = True,
     descending: bool = False,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return a sorted copy of a quantity or an array.
 
@@ -1375,13 +1376,13 @@ def sort(
 
 @set_module_as('saiunit.math')
 def max(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis: Optional[int] = None,
     keepdims: bool = False,
     initial: Optional[Union[int, float, Quantity]] = None,
-    where: Optional[jax.Array] = None,
+    where: Optional[Array] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return the maximum of a quantity or an array or maximum along an axis.
 
@@ -1420,13 +1421,13 @@ def max(
 
 @set_module_as('saiunit.math')
 def min(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     axis: Optional[int] = None,
     keepdims: bool = False,
     initial: Optional[Union[int, float, Quantity]] = None,
-    where: Optional[jax.Array] = None,
+    where: Optional[Array] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return the minimum of a quantity or an array or minimum along an axis.
 
@@ -1469,12 +1470,12 @@ amin = min
 
 @set_module_as('saiunit.math')
 def diagonal(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     offset: int = 0,
     axis1: int = 0,
     axis2: int = 1,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return specified diagonals.
 
@@ -1510,10 +1511,10 @@ def diagonal(
 
 @set_module_as('saiunit.math')
 def ravel(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     order: str = 'C',
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return a contiguous flattened quantity or array.
 
@@ -1551,7 +1552,7 @@ def flatten(
     start_axis: Optional[int] = None,
     end_axis: Optional[int] = None,
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Flattens input by reshaping it into a one-dimensional tensor.
     If ``start_dim`` or ``end_dim`` are passed, only dimensions starting
     with ``start_dim`` and ending with ``end_dim`` are flattened.
@@ -1608,7 +1609,7 @@ def unflatten(
     axis: int,
     sizes: Sequence[int],
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Expands a dimension of the input tensor over multiple dimensions.
 
@@ -1643,7 +1644,7 @@ def unflatten(
 
 
 @set_module_as('saiunit.math')
-def remove_diag(x: ArrayLike | Quantity, **kwargs) -> jax.Array | Quantity:
+def remove_diag(x: ArrayLike | Quantity, **kwargs) -> Array | Quantity:
     """Remove the diagonal of the matrix.
 
     Parameters
@@ -1684,11 +1685,11 @@ def remove_diag(x: ArrayLike | Quantity, **kwargs) -> jax.Array | Quantity:
 
 @set_module_as('saiunit.math')
 def choose(
-    a: Union[jax.Array, Quantity],
-    choices: Sequence[Union[jax.Array, Quantity]],
+    a: Union[Array, Quantity],
+    choices: Sequence[Union[Array, Quantity]],
     mode: str = 'raise',
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Construct a quantity or an array from an index array and a set of arrays to choose from.
 
@@ -1724,10 +1725,10 @@ def choose(
 
 @set_module_as('saiunit.math')
 def diagflat(
-    v: Union[jax.Array, Quantity],
+    v: Union[Array, Quantity],
     k: int = 0,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Create a two-dimensional a quantity or array with the flattened input as a diagonal.
 
@@ -1773,8 +1774,8 @@ def _fun_keep_unit_unary(func, x, *args, **kwargs):
 
 def astype(
     x: Union[ArrayLike, Quantity],
-    dtype: jax.typing.DTypeLike
-) -> Union[jax.Array, Quantity]:
+    dtype: DTypeLike
+) -> Union[Array, Quantity]:
     """
     Copy of the array, cast to a specified type.
 
@@ -1803,7 +1804,7 @@ def astype(
 
 
 @set_module_as('saiunit.math')
-def real(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def real(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the real part of the complex argument.
 
@@ -1814,7 +1815,7 @@ def real(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1829,7 +1830,7 @@ def real(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
 
 @set_module_as('saiunit.math')
-def imag(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def imag(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the imaginary part of the complex argument.
 
@@ -1840,7 +1841,7 @@ def imag(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1855,7 +1856,7 @@ def imag(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
 
 @set_module_as('saiunit.math')
-def conj(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def conj(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the complex conjugate of the argument.
 
@@ -1866,7 +1867,7 @@ def conj(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1881,7 +1882,7 @@ def conj(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
 
 @set_module_as('saiunit.math')
-def conjugate(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def conjugate(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the complex conjugate of the argument.
 
@@ -1892,7 +1893,7 @@ def conjugate(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Ar
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1907,7 +1908,7 @@ def conjugate(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Ar
 
 
 @set_module_as('saiunit.math')
-def negative(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def negative(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the negative of the argument.
 
@@ -1918,7 +1919,7 @@ def negative(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1933,7 +1934,7 @@ def negative(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
 
 @set_module_as('saiunit.math')
-def positive(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def positive(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the positive of the argument.
 
@@ -1944,7 +1945,7 @@ def positive(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1959,7 +1960,7 @@ def positive(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
 
 @set_module_as('saiunit.math')
-def abs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def abs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the absolute value of the argument.
 
@@ -1970,7 +1971,7 @@ def abs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -1988,11 +1989,11 @@ def abs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 def sum(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     keepdims: bool = False,
     initial: Union[ArrayLike, Quantity, None] = None,
     where: Union[ArrayLike, None] = None,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the sum of the array elements.
 
@@ -2032,7 +2033,7 @@ def sum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2059,9 +2060,9 @@ def sum(
 def nancumsum(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the cumulative sum of the array elements, ignoring NaNs.
 
@@ -2081,7 +2082,7 @@ def nancumsum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2100,12 +2101,12 @@ def nancumsum(
 def nansum(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     keepdims: bool = False,
     initial: Union[ArrayLike, Quantity, None] = None,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the sum of the array elements, ignoring NaNs.
 
@@ -2139,7 +2140,7 @@ def nansum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2166,9 +2167,9 @@ def nansum(
 def cumsum(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the cumulative sum of the array elements.
 
@@ -2188,7 +2189,7 @@ def cumsum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2208,7 +2209,7 @@ def ediff1d(
     to_end: ArrayLike | Quantity | None = None,
     to_begin: ArrayLike | Quantity | None = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the differences between consecutive elements of the array.
 
@@ -2223,7 +2224,7 @@ def ediff1d(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2243,7 +2244,7 @@ def ediff1d(
 
 
 @set_module_as('saiunit.math')
-def absolute(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def absolute(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the absolute value of the argument.
 
@@ -2254,7 +2255,7 @@ def absolute(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2269,7 +2270,7 @@ def absolute(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Arr
 
 
 @set_module_as('saiunit.math')
-def fabs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
+def fabs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, Array]:
     """
     Return the absolute value of the argument.
 
@@ -2280,7 +2281,7 @@ def fabs(x: Union[Quantity, ArrayLike], **kwargs) -> Union[Quantity, jax.Array]:
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2301,7 +2302,7 @@ def median(
     overwrite_input: bool = False,
     keepdims: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the median of the array elements.
 
@@ -2328,7 +2329,7 @@ def median(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2350,7 +2351,7 @@ def nanmin(
     initial: Union[ArrayLike, Quantity, None] = None,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the minimum of the array elements, ignoring NaNs.
 
@@ -2379,7 +2380,7 @@ def nanmin(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2404,7 +2405,7 @@ def nanmax(
     initial: Union[ArrayLike, None] = None,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the maximum of the array elements, ignoring NaNs.
 
@@ -2433,7 +2434,7 @@ def nanmax(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2456,7 +2457,7 @@ def ptp(
     axis: Union[int, Sequence[int], None] = None,
     keepdims: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the range of the array elements (maximum - minimum).
 
@@ -2484,7 +2485,7 @@ def ptp(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2506,7 +2507,7 @@ def average(
     returned: bool = False,
     keepdims: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the weighted average of the array elements.
 
@@ -2547,7 +2548,7 @@ def average(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2565,11 +2566,11 @@ def average(
 def mean(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     keepdims: bool = False, *,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the mean of the array elements.
 
@@ -2602,7 +2603,7 @@ def mean(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2620,12 +2621,12 @@ def mean(
 def std(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     ddof: int = 0,
     keepdims: bool = False, *,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the standard deviation of the array elements.
 
@@ -2663,7 +2664,7 @@ def std(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2684,7 +2685,7 @@ def nanmedian(
     overwrite_input: bool = False,
     keepdims: bool = False,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the median of the array elements, ignoring NaNs.
 
@@ -2717,7 +2718,7 @@ def nanmedian(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2736,11 +2737,11 @@ def nanmedian(
 def nanmean(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     keepdims: bool = False, *,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the mean of the array elements, ignoring NaNs.
 
@@ -2773,7 +2774,7 @@ def nanmean(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2792,12 +2793,12 @@ def nanmean(
 def nanstd(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    dtype: Union[jax.typing.DTypeLike, None] = None,
+    dtype: Union[DTypeLike, None] = None,
     ddof: int = 0,
     keepdims: bool = False, *,
     where: Union[ArrayLike, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the standard deviation of the array elements, ignoring NaNs.
 
@@ -2835,7 +2836,7 @@ def nanstd(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2859,7 +2860,7 @@ def diff(
     prepend: Union[ArrayLike, Quantity, None] = None,
     append: Union[ArrayLike, Quantity, None] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the differences between consecutive elements of the array.
 
@@ -2882,7 +2883,7 @@ def diff(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x` is a Quantity, else an array.
 
     Examples
@@ -2908,7 +2909,7 @@ def rot90(
     axes: Tuple[int, int] = (0, 1),
     **kwargs,
 ) -> Union[
-    jax.Array, Quantity]:
+    Array, Quantity]:
     """
     Rotate an array by 90 degrees in the plane specified by axes.
 
@@ -2949,7 +2950,7 @@ def intersect1d(
     assume_unique: bool = False,
     return_indices: bool = False,
     **kwargs,
-) -> Union[jax.Array, Quantity, tuple[Union[jax.Array, Quantity], jax.Array, jax.Array]]:
+) -> Union[Array, Quantity, tuple[Union[Array, Quantity], Array, Array]]:
     """
     Find the intersection of two arrays.
 
@@ -3017,7 +3018,7 @@ def nan_to_num(
     posinf: float | Quantity | None = None,
     neginf: float | Quantity | None = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Replace NaN with zero and infinity with large finite numbers (default
     behaviour) or with the numbers defined by the user using the `nan`,
@@ -3085,13 +3086,13 @@ def nan_to_num(
 
 @set_module_as('saiunit.math')
 def trace(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     offset: int = 0,
     axis1: int = 0,
     axis2: int = 1,
-    dtype: Optional[jax.typing.DTypeLike] = None,
+    dtype: Optional[DTypeLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return the sum along diagonals of the array.
 
@@ -3142,13 +3143,13 @@ def trace(
 
 @set_module_as('saiunit.math')
 def percentile(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute the q-th percentile of the data along the specified axis.
 
@@ -3188,7 +3189,7 @@ def percentile(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
       Output array.
 
     Examples
@@ -3214,13 +3215,13 @@ def percentile(
 
 @set_module_as('saiunit.math')
 def nanpercentile(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute the q-th percentile of the data along the specified axis, while ignoring nan values.
 
@@ -3260,7 +3261,7 @@ def nanpercentile(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
       Output array.
 
     Examples
@@ -3287,13 +3288,13 @@ def nanpercentile(
 
 @set_module_as('saiunit.math')
 def quantile(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute the q-th percentile of the data along the specified axis.
 
@@ -3333,7 +3334,7 @@ def quantile(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
       Output array.
 
     Examples
@@ -3359,13 +3360,13 @@ def quantile(
 
 @set_module_as('saiunit.math')
 def nanquantile(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     q: ArrayLike,
     axis: Optional[Union[int, Tuple[int]]] = None,
     method: str = 'linear',
     keepdims: Optional[bool] = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Compute the q-th percentile of the data along the specified axis, while ignoring nan values.
 
@@ -3405,7 +3406,7 @@ def nanquantile(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
       Output array.
 
     Examples
@@ -3469,7 +3470,7 @@ def _fun_keep_unit_binary(func, x1, x2, *args, **kwargs):
 
 @set_module_as('saiunit.math')
 def fmod(x1: Union[Quantity, ArrayLike],
-         x2: Union[Quantity, jax.Array], **kwargs) -> Union[Quantity, jax.Array]:
+         x2: Union[Quantity, Array], **kwargs) -> Union[Quantity, Array]:
     """
     Return the element-wise remainder of division.
 
@@ -3482,7 +3483,7 @@ def fmod(x1: Union[Quantity, ArrayLike],
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3498,7 +3499,7 @@ def fmod(x1: Union[Quantity, ArrayLike],
 
 
 @set_module_as('saiunit.math')
-def mod(x1: Union[Quantity, ArrayLike], x2: Union[Quantity, jax.Array], **kwargs) -> Union[Quantity, jax.Array]:
+def mod(x1: Union[Quantity, ArrayLike], x2: Union[Quantity, Array], **kwargs) -> Union[Quantity, Array]:
     """
     Return the element-wise modulus of division.
 
@@ -3511,7 +3512,7 @@ def mod(x1: Union[Quantity, ArrayLike], x2: Union[Quantity, jax.Array], **kwargs
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3531,7 +3532,7 @@ def copysign(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return a copy of the first array elements with the sign of the second array.
 
@@ -3544,7 +3545,7 @@ def copysign(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3565,7 +3566,7 @@ def maximum(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Element-wise maximum of array elements.
 
@@ -3578,7 +3579,7 @@ def maximum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3598,7 +3599,7 @@ def minimum(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Element-wise minimum of array elements.
 
@@ -3611,7 +3612,7 @@ def minimum(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3631,7 +3632,7 @@ def fmax(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Element-wise maximum of array elements ignoring NaNs.
 
@@ -3644,7 +3645,7 @@ def fmax(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3665,7 +3666,7 @@ def fmin(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Element-wise minimum of array elements ignoring NaNs.
 
@@ -3678,7 +3679,7 @@ def fmin(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3699,7 +3700,7 @@ def lcm(
     x1: Union[Quantity, ArrayLike],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the least common multiple of `x1` and `x2`.
 
@@ -3712,7 +3713,7 @@ def lcm(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3730,7 +3731,7 @@ def lcm(
 
 @set_module_as('saiunit.math')
 def gcd(x1: Union[Quantity, ArrayLike],
-        x2: Union[Quantity, ArrayLike],  **kwargs) -> Union[Quantity, jax.Array]:
+        x2: Union[Quantity, ArrayLike],  **kwargs) -> Union[Quantity, Array]:
     """
     Return the greatest common divisor of `x1` and `x2`.
 
@@ -3743,7 +3744,7 @@ def gcd(x1: Union[Quantity, ArrayLike],
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `x1` and `x2` are Quantities that have the same unit, else an array.
 
     Examples
@@ -3764,7 +3765,7 @@ def add(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Add arguments element-wise.
 
@@ -3798,7 +3799,7 @@ def subtract(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Subtract arguments, element-wise.
 
@@ -3832,7 +3833,7 @@ def remainder(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Returns the element-wise remainder of division.
 
@@ -3875,7 +3876,7 @@ def nextafter(
     x: Union[Quantity, ArrayLike],
     y: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return the next floating-point value after x towards y, element-wise.
 
@@ -3917,7 +3918,7 @@ def interp(
     right: Optional[Union[Quantity, ArrayLike]] = None,
     period: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     One-dimensional linear interpolation.
 
@@ -3938,7 +3939,7 @@ def interp(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `fp` is a Quantity, else an array.
 
     Examples
@@ -3971,7 +3972,7 @@ def clip(
     a_min: Union[Quantity, ArrayLike],
     a_max: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Clip (limit) the values in an array.
 
@@ -3986,7 +3987,7 @@ def clip(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Quantity if `a` is a Quantity, else an array.
 
     Examples
@@ -4007,13 +4008,13 @@ def clip(
 
 @set_module_as('saiunit.math')
 def histogram(
-    x: Union[jax.Array, Quantity],
+    x: Union[Array, Quantity],
     bins: ArrayLike = 10,  # type: ignore[assignment]
     range: Optional[Sequence[ArrayLike | Quantity]] = None,
     weights: Optional[ArrayLike] = None,
     density: Optional[bool] = None,
     **kwargs,
-) -> Tuple[jax.Array, jax.Array | Quantity]:
+) -> Tuple[Array, Array | Quantity]:
     """
     Compute the histogram of a set of data.
 
@@ -4084,14 +4085,14 @@ def histogram(
 
 @set_module_as('saiunit.math')
 def compress(
-    condition: jax.Array,
-    a: Union[jax.Array, Quantity],
+    condition: Array,
+    a: Union[Array, Quantity],
     axis: Optional[int] = None,
     *,
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike] = None,
     **kwargs,
-) -> Union[jax.Array, Quantity]:
+) -> Union[Array, Quantity]:
     """
     Return selected slices of a quantity or an array along given axis.
 
@@ -4144,13 +4145,13 @@ def compress(
 
 @set_module_as('saiunit.math')
 def extract(
-    condition: jax.Array,
-    arr: Union[jax.Array, Quantity],
+    condition: Array,
+    arr: Union[Array, Quantity],
     *,
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike | Quantity] = None,
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Return the elements of an array that satisfy some condition.
 
@@ -4207,7 +4208,7 @@ def take(
     indices_are_sorted: bool = False,
     fill_value: Optional[Union[Quantity, ArrayLike]] = None,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Take elements from an array along an axis.
 
@@ -4282,7 +4283,7 @@ def select(
     choicelist: Union[Quantity, ArrayLike],
     default: int = 0,
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Return an array drawn from elements in choicelist, depending on conditions.
 
@@ -4411,7 +4412,7 @@ def where(condition, x=None, y=None, /, *, size=None, fill_value=None, **kwargs)
 
 @set_module_as('saiunit.math')
 def unique(
-    a: Union[jax.Array, Quantity],
+    a: Union[Array, Quantity],
     return_index: bool = False,
     return_inverse: bool = False,
     return_counts: bool = False,
@@ -4421,7 +4422,7 @@ def unique(
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike, Quantity] = None,  # type: ignore[valid-type]
     **kwargs,
-) -> Sequence[jax.Array | Quantity] | jax.Array | Quantity:
+) -> Sequence[Array | Quantity] | Array | Quantity:
     """
     Find the unique elements of a quantity or an array.
 
@@ -4494,7 +4495,7 @@ def round(
     x: Union[Quantity, ArrayLike],
     decimals: int = 0,
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Round an array to the nearest integer.
 
@@ -4507,7 +4508,7 @@ def round(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Rounded values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4526,7 +4527,7 @@ def around(
     x: Union[Quantity, ArrayLike],
     decimals: int = 0,
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Round an array to the nearest integer.
 
@@ -4539,7 +4540,7 @@ def around(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Rounded values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4557,7 +4558,7 @@ def around(
 def rint(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Round an array to the nearest integer.
 
@@ -4568,7 +4569,7 @@ def rint(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Rounded values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4586,7 +4587,7 @@ def rint(
 def floor(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Return the floor of the argument.
 
@@ -4597,7 +4598,7 @@ def floor(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Floor values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4615,7 +4616,7 @@ def floor(
 def ceil(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Return the ceiling of the argument.
 
@@ -4626,7 +4627,7 @@ def ceil(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Ceiling values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4644,7 +4645,7 @@ def ceil(
 def trunc(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Return the truncated value of the argument.
 
@@ -4655,7 +4656,7 @@ def trunc(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Truncated values. Quantity if `x` is a Quantity.
 
     Examples
@@ -4673,7 +4674,7 @@ def trunc(
 def fix(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Return the nearest integer towards zero.
 
@@ -4684,7 +4685,7 @@ def fix(
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Values rounded towards zero. Quantity if `x` is a Quantity.
 
     Examples
@@ -4702,7 +4703,7 @@ def fix(
 def modf(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Tuple[jax.Array | Quantity, jax.Array | Quantity]:
+) -> Tuple[Array | Quantity, Array | Quantity]:
     """
     Return the fractional and integer parts of the array elements.
 
@@ -4729,7 +4730,7 @@ def modf(
 
 
 @set_module_as('saiunit.math')
-def gather(input: jax.Array | Quantity, dim: int, index: jax.Array, **kwargs):
+def gather(input: Array | Quantity, dim: int, index: Array, **kwargs):
     """
     Gather values along an axis specified by dim, according to index.
 
@@ -4737,16 +4738,16 @@ def gather(input: jax.Array | Quantity, dim: int, index: jax.Array, **kwargs):
 
     Parameters
     ----------
-    input : jax.Array, Quantity
+    input : Array, Quantity
       The source array or Quantity.
     dim : int
       The axis along which to index.
-    index : jax.Array
+    index : Array
       The indices of elements to gather.
 
     Returns
     -------
-    out : jax.Array, Quantity
+    out : Array, Quantity
       Array with the gathered elements. Quantity if `input` is a Quantity.
 
     Examples

--- a/saiunit/math/_fun_remove_unit.py
+++ b/saiunit/math/_fun_remove_unit.py
@@ -18,7 +18,8 @@ from typing import (Union, Optional, Sequence)
 
 import numpy as np
 
-from saiunit._jax_compat import HAS_JAX, jax, jnp, tree, ArrayLike
+from saiunit._jax_compat import HAS_JAX, jax, jnp, tree
+from saiunit._typing import Array, ArrayLike
 
 from saiunit._backend import get_backend
 from saiunit._base_getters import get_unit
@@ -52,7 +53,7 @@ __all__ = [
 def get_promote_dtypes(
     *args: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity | jax.Array | Sequence[jax.Array | Quantity]]:
+) -> Union[Quantity | Array | Sequence[Array | Quantity]]:
     """
     Promote the data types of the inputs to a common type.
 
@@ -135,10 +136,10 @@ def iscomplexobj(
 
 @set_module_as('saiunit.math')
 def heaviside(
-    x1: Union[Quantity, jax.Array],
+    x1: Union[Quantity, Array],
     x2: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[Quantity, jax.Array]:
+) -> Union[Quantity, Array]:
     """
     Compute the Heaviside step function.
 
@@ -155,7 +156,7 @@ def heaviside(
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         The Heaviside step function applied to ``x1`` with half-value
         ``x2``.
 
@@ -183,7 +184,7 @@ def heaviside(
 
 
 @set_module_as('saiunit.math')
-def signbit(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
+def signbit(x: Union[ArrayLike, Quantity], **kwargs) -> Array:
     """
     Return element-wise True where the sign bit is set (less than zero).
 
@@ -196,7 +197,7 @@ def signbit(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
 
     Returns
     -------
-    result : jax.Array of bool
+    result : Array of bool
         Boolean array indicating where the sign bit is set.
 
     Examples
@@ -215,7 +216,7 @@ def signbit(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def sign(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
+def sign(x: Union[ArrayLike, Quantity], **kwargs) -> Array:
     """
     Return the sign of each element in the input array.
 
@@ -228,7 +229,7 @@ def sign(x: Union[ArrayLike, Quantity], **kwargs) -> jax.Array:
 
     Returns
     -------
-    y : jax.Array
+    y : Array
         The sign of ``x``. Contains -1 for negative, 0 for zero, and
         +1 for positive elements.
 
@@ -255,7 +256,7 @@ def bincount(
     *,
     length: Optional[int] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Count number of occurrences of each value in array of non-negative ints.
 
@@ -279,7 +280,7 @@ def bincount(
 
     Returns
     -------
-    out : jax.Array of int
+    out : Array of int
         The result of binning the input array.
         The length of ``out`` is equal to ``max(x) + 1``.
 
@@ -308,7 +309,7 @@ def digitize(
     bins: Union[ArrayLike, Quantity],
     right: bool = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the indices of the bins to which each value in input array belongs.
 
@@ -340,7 +341,7 @@ def digitize(
 
     Returns
     -------
-    indices : jax.Array of int
+    indices : Array of int
         Output array of bin indices, same shape as ``x``.
 
     Examples
@@ -404,9 +405,9 @@ def all(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     keepdims: bool = False,
-    where: Optional[jax.Array] = None,
+    where: Optional[Array] = None,
     **kwargs,
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Test whether all array elements along a given axis evaluate to True.
 
@@ -427,7 +428,7 @@ def all(
 
     Returns
     -------
-    all : jax.Array or bool
+    all : Array or bool
         Boolean result of the AND reduction.
 
     Examples
@@ -451,9 +452,9 @@ def any(
     x: Union[Quantity, ArrayLike],
     axis: Optional[int] = None,
     keepdims: bool = False,
-    where: Optional[jax.Array] = None,
+    where: Optional[Array] = None,
     **kwargs,
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Test whether any array element along a given axis evaluates to True.
 
@@ -474,7 +475,7 @@ def any(
 
     Returns
     -------
-    any : jax.Array or bool
+    any : Array or bool
         Boolean result of the OR reduction.
 
     Examples
@@ -495,7 +496,7 @@ def any(
 def logical_not(
     x: Union[Quantity, ArrayLike],
     **kwargs,
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Compute the truth value of NOT x element-wise.
 
@@ -509,7 +510,7 @@ def logical_not(
 
     Returns
     -------
-    out : jax.Array or bool
+    out : Array or bool
         Boolean result of the NOT operation applied element-wise.
 
     Examples
@@ -573,7 +574,7 @@ def equal(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Return ``(x == y)`` element-wise.
 
@@ -590,7 +591,7 @@ def equal(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise equality comparison.
 
     Examples
@@ -615,7 +616,7 @@ def not_equal(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Return ``(x != y)`` element-wise.
 
@@ -631,7 +632,7 @@ def not_equal(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise inequality comparison.
 
     Examples
@@ -652,7 +653,7 @@ def greater(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Return ``(x > y)`` element-wise.
 
@@ -668,7 +669,7 @@ def greater(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise greater-than comparison.
 
     Examples
@@ -694,7 +695,7 @@ def greater_equal(
     *args,
     **kwargs
 ) -> Union[
-    bool, jax.Array]:
+    bool, Array]:
     """
     Return ``(x >= y)`` element-wise.
 
@@ -710,7 +711,7 @@ def greater_equal(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise greater-than-or-equal comparison.
 
     Examples
@@ -731,7 +732,7 @@ def less(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Return ``(x < y)`` element-wise.
 
@@ -747,7 +748,7 @@ def less(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise less-than comparison.
 
     Examples
@@ -769,7 +770,7 @@ def less_equal(
     *args,
     **kwargs
 ) -> Union[
-    bool, jax.Array]:
+    bool, Array]:
     """
     Return ``(x <= y)`` element-wise.
 
@@ -785,7 +786,7 @@ def less_equal(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Element-wise less-than-or-equal comparison.
 
     Examples
@@ -807,7 +808,7 @@ def array_equal(
     *args,
     **kwargs
 ) -> Union[
-    bool, jax.Array]:
+    bool, Array]:
     """
     Return True if two arrays have the same shape and elements.
 
@@ -848,7 +849,7 @@ def isclose(
     atol: float | Quantity | None = None,
     equal_nan: bool = False,
     **kwargs,
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Returns a boolean array where two arrays are element-wise equal within a
     tolerance.
@@ -872,7 +873,7 @@ def isclose(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Boolean array where ``x`` and ``y`` are equal within tolerance.
 
     Examples
@@ -925,7 +926,7 @@ def allclose(
     atol: float | Quantity | None = None,
     equal_nan: bool = False,
     **kwargs,
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Returns True if two arrays are element-wise equal within a tolerance.
 
@@ -1011,7 +1012,7 @@ def logical_and(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Compute the truth value of ``x AND y`` element-wise.
 
@@ -1027,7 +1028,7 @@ def logical_and(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Boolean AND result.
 
     Examples
@@ -1049,7 +1050,7 @@ def logical_or(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Compute the truth value of ``x OR y`` element-wise.
 
@@ -1065,7 +1066,7 @@ def logical_or(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Boolean OR result.
 
     Examples
@@ -1087,7 +1088,7 @@ def logical_xor(
     y: Union[Quantity, ArrayLike],
     *args,
     **kwargs
-) -> Union[bool, jax.Array]:
+) -> Union[bool, Array]:
     """
     Compute the truth value of ``x XOR y`` element-wise.
 
@@ -1103,7 +1104,7 @@ def logical_xor(
 
     Returns
     -------
-    out : jax.Array of bool
+    out : Array of bool
         Boolean XOR result.
 
     Examples
@@ -1134,7 +1135,7 @@ def argsort(
     stable: bool = True,
     descending: bool = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the indices that would sort an array or Quantity.
 
@@ -1158,7 +1159,7 @@ def argsort(
 
     Returns
     -------
-    indices : jax.Array
+    indices : Array
         Array of indices that would sort the input.
 
     Examples
@@ -1187,7 +1188,7 @@ def argmax(
     a: Union[ArrayLike, Quantity],
     axis: Optional[int] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the index of the maximum value along an axis.
 
@@ -1203,7 +1204,7 @@ def argmax(
 
     Returns
     -------
-    index : jax.Array
+    index : Array
         Index of the maximum value.
 
     Examples
@@ -1227,7 +1228,7 @@ def argmin(
     axis: Optional[int] = None,
     keepdims: Optional[bool] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the index of the minimum value along an axis.
 
@@ -1245,7 +1246,7 @@ def argmin(
 
     Returns
     -------
-    index : jax.Array
+    index : Array
         Index of the minimum value.
 
     Examples
@@ -1266,7 +1267,7 @@ def nanargmax(
     axis: int | None = None,
     keepdims: bool = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the index of the maximum value, ignoring NaNs.
 
@@ -1284,7 +1285,7 @@ def nanargmax(
 
     Returns
     -------
-    index : jax.Array
+    index : Array
         Index of the maximum value (NaNs ignored).
 
     Examples
@@ -1308,7 +1309,7 @@ def nanargmin(
     axis: int | None = None,
     keepdims: bool = False,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return the index of the minimum value, ignoring NaNs.
 
@@ -1326,7 +1327,7 @@ def nanargmin(
 
     Returns
     -------
-    index : jax.Array
+    index : Array
         Index of the minimum value (NaNs ignored).
 
     Examples
@@ -1351,7 +1352,7 @@ def argwhere(
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Find the indices of array elements that are non-zero.
 
@@ -1368,7 +1369,7 @@ def argwhere(
 
     Returns
     -------
-    indices : jax.Array
+    indices : Array
         Array of shape ``(N, a.ndim)`` containing the indices of
         non-zero elements.
 
@@ -1398,7 +1399,7 @@ def nonzero(
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike] = None,
     **kwargs,
-) -> Sequence[jax.Array]:
+) -> Sequence[Array]:
     """
     Return the indices of non-zero elements.
 
@@ -1415,7 +1416,7 @@ def nonzero(
 
     Returns
     -------
-    indices : tuple of jax.Array
+    indices : tuple of Array
         Tuple of arrays, one per dimension, containing the indices of
         non-zero elements.
 
@@ -1444,7 +1445,7 @@ def flatnonzero(
     size: Optional[int] = None,
     fill_value: Optional[ArrayLike] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Return indices that are non-zero in the flattened input.
 
@@ -1461,7 +1462,7 @@ def flatnonzero(
 
     Returns
     -------
-    indices : jax.Array
+    indices : Array
         Indices of non-zero elements in the flattened array.
 
     Examples
@@ -1491,7 +1492,7 @@ def count_nonzero(
     axis: Optional[int] = None,
     keepdims: Optional[bool] = None,
     **kwargs,
-) -> jax.Array:
+) -> Array:
     """
     Count the number of non-zero values in the input.
 
@@ -1508,7 +1509,7 @@ def count_nonzero(
 
     Returns
     -------
-    count : jax.Array
+    count : Array
         Number of non-zero values along the given axis.
 
     Examples
@@ -1528,11 +1529,11 @@ def searchsorted(
     a: Union[ArrayLike, Quantity],
     v: Union[ArrayLike, Quantity],
     side: str = 'left',
-    sorter: Optional[jax.Array] = None,
+    sorter: Optional[Array] = None,
     *,
     method: Optional[str] = 'scan',
     **kwargs,
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """
     Find indices where elements should be inserted to maintain order.
 
@@ -1555,7 +1556,7 @@ def searchsorted(
 
     Returns
     -------
-    indices : jax.Array
+    indices : Array
         Insertion points with the same shape as ``v``.
 
     Examples
@@ -1580,7 +1581,7 @@ def searchsorted(
 def diag_indices_from(
     arr: Union[ArrayLike, Quantity],
     **kwargs,
-) -> tuple[jax.Array, ...]:
+) -> tuple[Array, ...]:
     """
     Return indices for accessing the main diagonal of a given array.
 
@@ -1593,7 +1594,7 @@ def diag_indices_from(
 
     Returns
     -------
-    indices : tuple of jax.Array
+    indices : tuple of Array
         Index arrays to access the main diagonal.
 
     Examples

--- a/saiunit/math/_misc.py
+++ b/saiunit/math/_misc.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import (Union, TypeVar, Any)
 
-from saiunit._jax_compat import jax, jnp, ArrayLike
+from saiunit._jax_compat import jax, jnp
+from saiunit._typing import Array, ArrayLike
 import numpy as np
 
 from saiunit._base_unit import Unit
@@ -252,7 +253,7 @@ def ndim(a: Union[Quantity, ArrayLike]) -> int:
 
 
 @set_module_as('saiunit.math')
-def isreal(a: Union[Quantity, ArrayLike]) -> jax.Array:
+def isreal(a: Union[Quantity, ArrayLike]) -> Array:
     """Test element-wise whether each element is real (has zero imaginary part).
 
     Parameters
@@ -262,7 +263,7 @@ def isreal(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Boolean array of the same shape as *a*.
 
     Examples
@@ -314,7 +315,7 @@ def isscalar(a: Union[Quantity, ArrayLike]) -> bool:
 
 
 @set_module_as('saiunit.math')
-def isfinite(a: Union[Quantity, ArrayLike]) -> jax.Array:
+def isfinite(a: Union[Quantity, ArrayLike]) -> Array:
     """Test element-wise for finiteness (not inf and not NaN).
 
     Parameters
@@ -324,7 +325,7 @@ def isfinite(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Boolean array of the same shape as *a*.
 
     Examples
@@ -344,7 +345,7 @@ def isfinite(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def isinf(a: Union[Quantity, ArrayLike]) -> jax.Array:
+def isinf(a: Union[Quantity, ArrayLike]) -> Array:
     """Test element-wise for positive or negative infinity.
 
     Parameters
@@ -354,7 +355,7 @@ def isinf(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Boolean array of the same shape as *a*.
 
     Examples
@@ -374,7 +375,7 @@ def isinf(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
 
 @set_module_as('saiunit.math')
-def isnan(a: Union[Quantity, ArrayLike]) -> jax.Array:
+def isnan(a: Union[Quantity, ArrayLike]) -> Array:
     """Test element-wise for NaN.
 
     Parameters
@@ -384,7 +385,7 @@ def isnan(a: Union[Quantity, ArrayLike]) -> jax.Array:
 
     Returns
     -------
-    out : jax.Array
+    out : Array
         Boolean array of the same shape as *a*.
 
     Examples
@@ -438,7 +439,7 @@ def shape(a: Union[Quantity, ArrayLike]) -> tuple[int, ...]:
 
     """
     a = maybe_custom_array(a)
-    if isinstance(a, (Quantity, jax.Array, np.ndarray)):
+    if isinstance(a, (Quantity, Array, np.ndarray)):
         return a.shape
     else:
         return np.shape(a)
@@ -479,7 +480,7 @@ def size(a: Union[Quantity, ArrayLike], axis: int | None = None) -> int:
     2
     """
     a = maybe_custom_array(a)
-    if isinstance(a, (Quantity, jax.Array, np.ndarray)):
+    if isinstance(a, (Quantity, Array, np.ndarray)):
         if axis is None:
             return a.size
         else:
@@ -644,7 +645,7 @@ def gradient(
     *varargs: Union[ArrayLike, Quantity],
     axis: Union[int, Sequence[int], None] = None,
     edge_order: Union[int, None] = None,
-) -> Union[jax.Array, list[jax.Array], Quantity, list[Quantity]]:
+) -> Union[Array, list[Array], Quantity, list[Quantity]]:
     """
     Computes the gradient of a scalar field.
 

--- a/saiunit/sparse/_coo.py
+++ b/saiunit/sparse/_coo.py
@@ -32,7 +32,7 @@ from saiunit._base_getters import (
     maybe_decimal,
     split_mantissa_unit,
 )
-from saiunit._jax_compat import ArrayLike
+from saiunit._typing import Array, ArrayLike, DTypeLike
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
 from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
@@ -47,7 +47,7 @@ Dtype = Any
 Shape = tuple[int, ...]
 
 
-def _const_like(x: jax.Array, value: int) -> jax.Array:
+def _const_like(x: Array, value: int) -> Array:
     return jnp.asarray(value, dtype=x.dtype)
 
 
@@ -68,7 +68,7 @@ class COO(SparseMatrix):
     Parameters
     ----------
     args : tuple of (data, row, col)
-        ``data`` contains the non-zero values (``jax.Array`` or ``Quantity``),
+        ``data`` contains the non-zero values (``Array`` or ``Quantity``),
         ``row`` contains the row indices, and ``col`` contains the column
         indices.
     shape : tuple of int
@@ -80,11 +80,11 @@ class COO(SparseMatrix):
 
     Attributes
     ----------
-    data : jax.Array or Quantity
+    data : Array or Quantity
         Non-zero values of shape ``(nse,)``.
-    row : jax.Array
+    row : Array
         Row indices of shape ``(nse,)``.
-    col : jax.Array
+    col : Array
         Column indices of shape ``(nse,)``.
     shape : tuple of int
         Shape of the matrix ``(nrows, ncols)``.
@@ -123,9 +123,9 @@ class COO(SparseMatrix):
         Array([[1., 0., 2.],
                [0., 0., 3.]], dtype=float32)
     """
-    data: jax.Array
-    row: jax.Array
-    col: jax.Array
+    data: Array
+    row: Array
+    col: Array
     shape: tuple[int, int]
     nse = property(lambda self: self.data.size)
     dtype = property(lambda self: self.data.dtype)
@@ -141,7 +141,7 @@ class COO(SparseMatrix):
 
     def __init__(
         self,
-        args: Tuple[jax.Array | Quantity, jax.Array, jax.Array],
+        args: Tuple[Array | Quantity, Array, Array],
         *,
         shape: Shape,
         rows_sorted: bool = False,
@@ -155,10 +155,10 @@ class COO(SparseMatrix):
     @classmethod
     def fromdense(
         cls,
-        mat: jax.Array,
+        mat: Array,
         *,
         nse: int | None = None,
-        index_dtype: jax.typing.DTypeLike = np.int32
+        index_dtype: DTypeLike = np.int32
     ) -> COO:
         return coo_fromdense(mat, nse=nse, index_dtype=index_dtype)
 
@@ -188,8 +188,8 @@ class COO(SparseMatrix):
         cls,
         shape: Sequence[int],
         *,
-        dtype: jax.typing.DTypeLike | None = None,
-        index_dtype: jax.typing.DTypeLike = 'int32'
+        dtype: DTypeLike | None = None,
+        index_dtype: DTypeLike = 'int32'
     ) -> COO:
         """Create an empty COO instance. Public method is sparse.empty()."""
         shape = tuple(shape)
@@ -211,8 +211,8 @@ class COO(SparseMatrix):
         M: int,
         k: int,
         *,
-        dtype: jax.typing.DTypeLike | None = None,
-        index_dtype: jax.typing.DTypeLike = 'int32'
+        dtype: DTypeLike | None = None,
+        index_dtype: DTypeLike = 'int32'
     ) -> COO:
         if k > 0:
             diag_size = min(N, M - k)
@@ -236,13 +236,13 @@ class COO(SparseMatrix):
             cols_sorted=True
         )
 
-    def with_data(self, data: jax.Array | Quantity) -> COO:  # type: ignore[override]
+    def with_data(self, data: Array | Quantity) -> COO:  # type: ignore[override]
         """
         Create a new COO matrix with the same sparsity structure but different data.
 
         Parameters
         ----------
-        data : jax.Array or Quantity
+        data : Array or Quantity
             New non-zero values. Must have the same shape, dtype, and unit as
             the current ``self.data``.
 
@@ -279,13 +279,13 @@ class COO(SparseMatrix):
             cols_sorted=self._cols_sorted
         )
 
-    def todense(self) -> jax.Array:
+    def todense(self) -> Array:
         """
         Convert this COO matrix to a dense array.
 
         Returns
         -------
-        jax.Array or Quantity
+        Array or Quantity
             Dense 2-D array equivalent to this sparse matrix.
 
         Examples
@@ -314,7 +314,7 @@ class COO(SparseMatrix):
         )
 
     def tree_flatten(self) -> Tuple[
-        Tuple[jax.Array | Quantity,], dict[str, Any]
+        Tuple[Array | Quantity,], dict[str, Any]
     ]:
         aux = self._info._asdict()
         aux['row'] = self.row
@@ -444,16 +444,16 @@ class COO(SparseMatrix):
         else:
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
-    def __mul__(self, other: jax.Array | Quantity) -> COO:
+    def __mul__(self, other: Array | Quantity) -> COO:
         return self._binary_op(other, operator.mul)
 
-    def __rmul__(self, other: jax.Array | Quantity) -> COO:
+    def __rmul__(self, other: Array | Quantity) -> COO:
         return self._binary_rop(other, operator.mul)
 
-    def __div__(self, other: jax.Array | Quantity) -> COO:
+    def __div__(self, other: Array | Quantity) -> COO:
         return self._binary_op(other, operator.truediv)
 
-    def __rdiv__(self, other: jax.Array | Quantity) -> COO:
+    def __rdiv__(self, other: Array | Quantity) -> COO:
         return self._binary_rop(other, operator.truediv)
 
     def __truediv__(self, other) -> COO:
@@ -482,7 +482,7 @@ class COO(SparseMatrix):
 
     def __matmul__(
         self, other: ArrayLike
-    ) -> jax.Array | Quantity:
+    ) -> Array | Quantity:
         if isinstance(other, (JAXSparse, SparseMatrix)):
             raise NotImplementedError("matmul between two sparse objects.")
         other = asarray(other)
@@ -505,7 +505,7 @@ class COO(SparseMatrix):
     def __rmatmul__(
         self,
         other: ArrayLike
-    ) -> jax.Array | Quantity:
+    ) -> Array | Quantity:
         if isinstance(other, (JAXSparse, SparseMatrix)):
             raise NotImplementedError("matmul between two sparse objects.")
         other = asarray(other)
@@ -527,7 +527,7 @@ class COO(SparseMatrix):
             raise NotImplementedError(f"matmul with object of shape {other.shape}")
 
 
-def coo_todense(mat: COO) -> jax.Array | Quantity:
+def coo_todense(mat: COO) -> Array | Quantity:
     """
     Convert a COO-format sparse matrix to a dense matrix.
 
@@ -538,7 +538,7 @@ def coo_todense(mat: COO) -> jax.Array | Quantity:
 
     Returns
     -------
-    jax.Array or Quantity
+    Array or Quantity
         Dense 2-D array equivalent to ``mat``.
 
     Examples
@@ -558,17 +558,17 @@ def coo_todense(mat: COO) -> jax.Array | Quantity:
 
 
 def coo_fromdense(
-    mat: jax.Array | Quantity,
+    mat: Array | Quantity,
     *,
     nse: int | None = None,
-    index_dtype: jax.typing.DTypeLike = jnp.int32
+    index_dtype: DTypeLike = jnp.int32
 ) -> COO:
     """
     Create a COO-format sparse matrix from a dense matrix.
 
     Parameters
     ----------
-    mat : jax.Array or Quantity
+    mat : Array or Quantity
         Dense 2-D array to be converted to COO format.
     nse : int or None, optional
         Number of specified (non-zero) entries in ``mat``. If ``None``
@@ -607,12 +607,12 @@ def coo_fromdense(
 
 
 def _coo_todense(
-    data: jax.Array | Quantity,
-    row: jax.Array,
-    col: jax.Array,
+    data: Array | Quantity,
+    row: Array,
+    col: Array,
     *,
     spinfo: COOInfo
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Convert CSR-format sparse matrix to a dense matrix.
 
     Args:
@@ -630,11 +630,11 @@ def _coo_todense(
 
 
 def _coo_fromdense(
-    mat: jax.Array | Quantity,
+    mat: Array | Quantity,
     *,
     nse: int,
-    index_dtype: jax.typing.DTypeLike = jnp.int32
-) -> Tuple[jax.Array | Quantity, jax.Array, jax.Array]:
+    index_dtype: DTypeLike = jnp.int32
+) -> Tuple[Array | Quantity, Array, Array]:
     """Create COO-format sparse matrix from a dense matrix.
 
     Args:
@@ -658,9 +658,9 @@ def _coo_fromdense(
 
 def coo_matvec(
     mat: COO,
-    v: jax.Array | Quantity,
+    v: Array | Quantity,
     transpose: bool = False
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Product of COO sparse matrix and a dense vector.
 
     Args:
@@ -679,14 +679,14 @@ def coo_matvec(
 
 
 def _coo_matvec(
-    data: jax.Array | Quantity,
-    row: jax.Array,
-    col: jax.Array,
-    v: jax.Array | Quantity,
+    data: Array | Quantity,
+    row: Array,
+    col: Array,
+    v: Array | Quantity,
     *,
     spinfo: COOInfo,
     transpose: bool = False
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Product of COO sparse matrix and a dense vector.
 
     Args:
@@ -711,10 +711,10 @@ def _coo_matvec(
 
 def coo_matmat(
     mat: COO,
-    B: jax.Array | Quantity,
+    B: Array | Quantity,
     *,
     transpose: bool = False
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Product of COO sparse matrix and a dense matrix.
 
     Args:
@@ -733,14 +733,14 @@ def coo_matmat(
 
 
 def _coo_matmat(
-    data: jax.Array | Quantity,
-    row: jax.Array,
-    col: jax.Array,
-    B: jax.Array | Quantity,
+    data: Array | Quantity,
+    row: Array,
+    col: Array,
+    B: Array | Quantity,
     *,
     spinfo: COOInfo,
     transpose: bool = False
-) -> jax.Array:
+) -> Array:
     """Product of COO sparse matrix and a dense matrix.
 
     Args:

--- a/saiunit/sparse/_csr.py
+++ b/saiunit/sparse/_csr.py
@@ -32,6 +32,7 @@ from saiunit._base_getters import (
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
 from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
+from saiunit._typing import Array, DTypeLike
 from saiunit.math._fun_array_creation import asarray
 from saiunit.math._fun_keep_unit import promote_dtypes
 
@@ -44,7 +45,7 @@ __all__ = [
 Shape = tuple[int, ...]
 
 
-def _const_like(x: jax.Array, value: int) -> jax.Array:
+def _const_like(x: Array, value: int) -> Array:
     return jnp.asarray(value, dtype=x.dtype)
 
 
@@ -59,7 +60,7 @@ class CSR(SparseMatrix):
     Parameters
     ----------
     args : tuple of (data, indices, indptr)
-        ``data`` contains the non-zero values (``jax.Array`` or ``Quantity``),
+        ``data`` contains the non-zero values (``Array`` or ``Quantity``),
         ``indices`` contains the column indices, and ``indptr`` contains the
         row pointer array.
     shape : tuple of int
@@ -67,11 +68,11 @@ class CSR(SparseMatrix):
 
     Attributes
     ----------
-    data : jax.Array or Quantity
+    data : Array or Quantity
         Non-zero values of shape ``(nse,)``.
-    indices : jax.Array
+    indices : Array
         Column indices of shape ``(nse,)``.
-    indptr : jax.Array
+    indptr : Array
         Row pointer array of shape ``(nrows + 1,)``.
     shape : tuple of int
         Shape of the matrix ``(nrows, ncols)``.
@@ -101,9 +102,9 @@ class CSR(SparseMatrix):
         Array([[1., 0., 2.],
                [0., 0., 3.]], dtype=float32)
     """
-    data: jax.Array | Quantity  # type: ignore[assignment]
-    indices: jax.Array
-    indptr: jax.Array
+    data: Array | Quantity  # type: ignore[assignment]
+    indices: Array
+    indptr: Array
     shape: tuple[int, int]
     nse = property(lambda self: self.data.size)
     dtype = property(lambda self: self.data.dtype)
@@ -155,13 +156,13 @@ class CSR(SparseMatrix):
             jnp.cumsum(jnp.bincount(row, length=N).astype(index_dtype)))
         return cls((data, indices, indptr), shape=(N, M))
 
-    def with_data(self, data: jax.Array | Quantity) -> CSR:  # type: ignore[override]
+    def with_data(self, data: Array | Quantity) -> CSR:  # type: ignore[override]
         """
         Create a new CSR matrix with the same sparsity structure but different data.
 
         Parameters
         ----------
-        data : jax.Array or Quantity
+        data : Array or Quantity
             New non-zero values. Must have the same shape, dtype, and unit as
             the current ``self.data``.
 
@@ -199,7 +200,7 @@ class CSR(SparseMatrix):
 
         Returns
         -------
-        jax.Array or Quantity
+        Array or Quantity
             Dense 2-D array equivalent to this sparse matrix.
 
         Examples
@@ -293,16 +294,16 @@ class CSR(SparseMatrix):
         else:
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
-    def __mul__(self, other: jax.Array | Quantity) -> CSR:
+    def __mul__(self, other: Array | Quantity) -> CSR:
         return self._binary_op(other, operator.mul)
 
-    def __rmul__(self, other: jax.Array | Quantity) -> CSR:
+    def __rmul__(self, other: Array | Quantity) -> CSR:
         return self._binary_rop(other, operator.mul)
 
-    def __div__(self, other: jax.Array | Quantity) -> CSR:
+    def __div__(self, other: Array | Quantity) -> CSR:
         return self._binary_op(other, operator.truediv)
 
-    def __rdiv__(self, other: jax.Array | Quantity) -> CSR:
+    def __rdiv__(self, other: Array | Quantity) -> CSR:
         return self._binary_rop(other, operator.truediv)
 
     def __truediv__(self, other) -> CSR:
@@ -407,7 +408,7 @@ class CSC(SparseMatrix):
     Parameters
     ----------
     args : tuple of (data, indices, indptr)
-        ``data`` contains the non-zero values (``jax.Array`` or ``Quantity``),
+        ``data`` contains the non-zero values (``Array`` or ``Quantity``),
         ``indices`` contains the row indices, and ``indptr`` contains the
         column pointer array.
     shape : tuple of int
@@ -415,11 +416,11 @@ class CSC(SparseMatrix):
 
     Attributes
     ----------
-    data : jax.Array or Quantity
+    data : Array or Quantity
         Non-zero values of shape ``(nse,)``.
-    indices : jax.Array
+    indices : Array
         Row indices of shape ``(nse,)``.
-    indptr : jax.Array
+    indptr : Array
         Column pointer array of shape ``(ncols + 1,)``.
     shape : tuple of int
         Shape of the matrix ``(nrows, ncols)``.
@@ -449,9 +450,9 @@ class CSC(SparseMatrix):
         Array([[1., 0., 2.],
                [0., 0., 3.]], dtype=float32)
     """
-    data: jax.Array
-    indices: jax.Array
-    indptr: jax.Array
+    data: Array
+    indices: Array
+    indptr: Array
     shape: tuple[int, int]
     nse = property(lambda self: self.data.size)
     dtype = property(lambda self: self.data.dtype)
@@ -481,13 +482,13 @@ class CSC(SparseMatrix):
     def _eye(cls, N, M, k, *, dtype=None, index_dtype='int32'):
         return CSR._eye(M, N, -k, dtype=dtype, index_dtype=index_dtype).T
 
-    def with_data(self, data: jax.Array | Quantity) -> CSC:  # type: ignore[override]
+    def with_data(self, data: Array | Quantity) -> CSC:  # type: ignore[override]
         """
         Create a new CSC matrix with the same sparsity structure but different data.
 
         Parameters
         ----------
-        data : jax.Array or Quantity
+        data : Array or Quantity
             New non-zero values. Must have the same shape, dtype, and unit as
             the current ``self.data``.
 
@@ -525,7 +526,7 @@ class CSC(SparseMatrix):
 
         Returns
         -------
-        jax.Array or Quantity
+        Array or Quantity
             Dense 2-D array equivalent to this sparse matrix.
 
         Examples
@@ -639,16 +640,16 @@ class CSC(SparseMatrix):
         else:
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
-    def __mul__(self, other: jax.Array | Quantity) -> CSC:
+    def __mul__(self, other: Array | Quantity) -> CSC:
         return self._binary_op(other, operator.mul)
 
-    def __rmul__(self, other: jax.Array | Quantity) -> CSC:
+    def __rmul__(self, other: Array | Quantity) -> CSC:
         return self._binary_rop(other, operator.mul)
 
-    def __div__(self, other: jax.Array | Quantity) -> CSC:
+    def __div__(self, other: Array | Quantity) -> CSC:
         return self._binary_op(other, operator.truediv)
 
-    def __rdiv__(self, other: jax.Array | Quantity) -> CSC:
+    def __rdiv__(self, other: Array | Quantity) -> CSC:
         return self._binary_rop(other, operator.truediv)
 
     def __truediv__(self, other) -> CSC:
@@ -743,22 +744,22 @@ class CSC(SparseMatrix):
         return obj
 
 
-Data = Union[jax.Array, Quantity]
-Indices = jax.Array
-Indptr = jax.Array
+Data = Union[Array, Quantity]
+Indices = Array
+Indptr = Array
 
 
 def csr_fromdense(
-    mat: jax.Array | Quantity,
+    mat: Array | Quantity,
     *, nse: int | None = None,
-    index_dtype: jax.typing.DTypeLike = np.int32
+    index_dtype: DTypeLike = np.int32
 ) -> CSR:
     """
     Create a CSR-format sparse matrix from a dense matrix.
 
     Parameters
     ----------
-    mat : jax.Array or Quantity
+    mat : Array or Quantity
         Dense 2-D array to be converted to CSR format.
     nse : int or None, optional
         Number of specified (non-zero) entries in ``mat``. If ``None``
@@ -792,7 +793,7 @@ def csr_fromdense(
     return CSR(_csr_fromdense(mat, nse=nse_int, index_dtype=index_dtype), shape=mat.shape)
 
 
-def csr_todense(mat: CSR) -> jax.Array | Quantity:
+def csr_todense(mat: CSR) -> Array | Quantity:
     """
     Convert a CSR-format sparse matrix to a dense matrix.
 
@@ -803,7 +804,7 @@ def csr_todense(mat: CSR) -> jax.Array | Quantity:
 
     Returns
     -------
-    jax.Array or Quantity
+    Array or Quantity
         Dense 2-D array equivalent to ``mat``.
 
     Raises
@@ -829,7 +830,7 @@ def csr_todense(mat: CSR) -> jax.Array | Quantity:
     return _csr_todense(mat.data, mat.indices, mat.indptr, shape=mat.shape)
 
 
-def csc_todense(mat: CSC) -> jax.Array | Quantity:
+def csc_todense(mat: CSC) -> Array | Quantity:
     """
     Convert a CSC-format sparse matrix to a dense matrix.
 
@@ -840,7 +841,7 @@ def csc_todense(mat: CSC) -> jax.Array | Quantity:
 
     Returns
     -------
-    jax.Array or Quantity
+    Array or Quantity
         Dense 2-D array equivalent to ``mat``.
 
     Raises
@@ -867,17 +868,17 @@ def csc_todense(mat: CSC) -> jax.Array | Quantity:
 
 
 def csc_fromdense(
-    mat: jax.Array | Quantity,
+    mat: Array | Quantity,
     *,
     nse: int | None = None,
-    index_dtype: jax.typing.DTypeLike = np.int32
+    index_dtype: DTypeLike = np.int32
 ) -> CSC:
     """
     Create a CSC-format sparse matrix from a dense matrix.
 
     Parameters
     ----------
-    mat : jax.Array or Quantity
+    mat : Array or Quantity
         Dense 2-D array to be converted to CSC format.
     nse : int or None, optional
         Number of specified (non-zero) entries in ``mat``. If ``None``
@@ -911,10 +912,10 @@ def csc_fromdense(
 
 
 def _csr_fromdense(
-    mat: jax.Array | Quantity,
+    mat: Array | Quantity,
     *,
     nse: int,
-    index_dtype: jax.typing.DTypeLike = np.int32
+    index_dtype: DTypeLike = np.int32
 ) -> Tuple[Data, Indices, Indptr]:
     """Create CSR-format sparse matrix from a dense matrix.
 
@@ -939,11 +940,11 @@ def _csr_fromdense(
 
 
 def _csr_todense(
-    data: jax.Array | Quantity,
-    indices: jax.Array,
-    indptr: jax.Array, *,
+    data: Array | Quantity,
+    indices: Array,
+    indptr: Array, *,
     shape: Shape
-) -> jax.Array:
+) -> Array:
     """Convert CSR-format sparse matrix to a dense matrix.
 
     Args:
@@ -961,14 +962,14 @@ def _csr_todense(
 
 
 def _csr_matvec(
-    data: jax.Array | Quantity,
-    indices: jax.Array,
-    indptr: jax.Array,
-    v: jax.Array | Quantity,
+    data: Array | Quantity,
+    indices: Array,
+    indptr: Array,
+    v: Array | Quantity,
     *,
     shape: Shape,
     transpose: bool = False
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Product of CSR sparse matrix and a dense vector.
 
     Args:
@@ -992,14 +993,14 @@ def _csr_matvec(
 
 
 def _csr_matmat(
-    data: jax.Array | Quantity,
-    indices: jax.Array,
-    indptr: jax.Array,
-    B: jax.Array | Quantity,
+    data: Array | Quantity,
+    indices: Array,
+    indptr: Array,
+    B: Array | Quantity,
     *,
     shape: Shape,
     transpose: bool = False
-) -> jax.Array | Quantity:
+) -> Array | Quantity:
     """Product of CSR sparse matrix and a dense matrix.
 
     Args:
@@ -1023,6 +1024,6 @@ def _csr_matmat(
 
 
 @jax.jit
-def _csr_to_coo(indices: jax.Array, indptr: jax.Array) -> Tuple[jax.Array, jax.Array]:
+def _csr_to_coo(indices: Array, indptr: Array) -> Tuple[Array, Array]:
     """Given CSR (indices, indptr) return COO (row, col)"""
     return jnp.cumsum(jnp.zeros_like(indices).at[indptr].add(1)) - 1, indices

--- a/saiunit/typing.py
+++ b/saiunit/typing.py
@@ -94,8 +94,16 @@ from typing import TYPE_CHECKING, Annotated, Any, Union, get_type_hints, get_ori
 
 import numpy as np
 
-from ._jax_compat import Array as _JaxArray
-from ._jax_compat import ArrayLike, ScalarOrArrayLike
+from ._typing import (
+    Array,
+    ArrayLike,
+    ScalarOrArrayLike,
+    DTypeLike,
+    Shape,
+    Axis,
+    Axes,
+    PyTree,
+)
 
 from ._base_dimension import Dimension, UnitMismatchError, DimensionMismatchError
 from ._base_dimension import get_or_create_dimension
@@ -107,9 +115,15 @@ __all__ = [
     'PhysicalType',
     'is_physical_type',
 
-    # Core type aliases
+    # Core type aliases (re-exported from saiunit._typing)
+    'Array',
     'ArrayLike',
     'ScalarOrArrayLike',
+    'DTypeLike',
+    'Shape',
+    'Axis',
+    'Axes',
+    'PyTree',
     'QuantityLike',
     'UnitLike',
     'DimensionLike',
@@ -397,7 +411,7 @@ QuantityLike = Union[
     complex,
     np.number,
     np.ndarray,
-    _JaxArray,
+    Array,
     "Quantity",
 ]
 

--- a/saiunit/typing_test.py
+++ b/saiunit/typing_test.py
@@ -256,6 +256,63 @@ class TestTypeAliases:
         from saiunit.typing import DimensionLike
         assert DimensionLike is not None
 
+    def test_array_alias_importable(self):
+        from saiunit.typing import Array
+        assert Array is not None
+
+    def test_array_like_alias_importable(self):
+        from saiunit.typing import ArrayLike
+        assert ArrayLike is not None
+
+    def test_scalar_or_array_like_importable(self):
+        from saiunit.typing import ScalarOrArrayLike
+        assert ScalarOrArrayLike is not None
+
+    def test_dtype_like_importable(self):
+        from saiunit.typing import DTypeLike
+        assert DTypeLike is not None
+
+    def test_shape_alias(self):
+        from saiunit.typing import Shape
+        # Shape is Sequence[int]; the origin is collections.abc.Sequence
+        import collections.abc
+        import typing
+        assert typing.get_origin(Shape) is collections.abc.Sequence
+
+    def test_axis_alias(self):
+        from saiunit.typing import Axis
+        assert Axis is int
+
+    def test_axes_alias(self):
+        from saiunit.typing import Axes
+        import typing
+        # Axes = Union[int, Sequence[int]]
+        assert typing.get_origin(Axes) is typing.Union
+
+    def test_pytree_alias(self):
+        from saiunit.typing import PyTree
+        import typing
+        assert PyTree is typing.Any
+
+    def test_typing_array_matches_jax_array_when_jax_installed(self):
+        try:
+            import jax
+        except ImportError:
+            pytest.skip("JAX not installed")
+        from saiunit.typing import Array
+        assert Array is jax.Array
+
+    def test_typing_array_isinstance_false_without_jax(self):
+        """Without JAX, isinstance(anything, Array) is False (sentinel)."""
+        try:
+            import jax  # noqa: F401
+            pytest.skip("JAX is installed; sentinel path not exercised")
+        except ImportError:
+            from saiunit.typing import Array
+            assert not isinstance(1.0, Array)
+            assert not isinstance("string", Array)
+            assert not isinstance([1, 2, 3], Array)
+
 
 # =========================================================================
 # validate_units decorator


### PR DESCRIPTION
## Summary

- New `saiunit/_typing.py` is the single internal source of truth for `Array`, `ArrayLike`, `ScalarOrArrayLike`, `DTypeLike`, `Shape`, `Axis`, `Axes`, `PyTree`. Handles JAX-installed and JAX-absent paths (sentinel class for `Array`).
- `saiunit/_jax_compat.py` no longer owns or exports type aliases — it keeps only runtime JAX symbols (`jax`, `jnp`, `tree`, `register_pytree_node_class`, …).
- `saiunit/typing.py` re-exports everything from `_typing`, so `from saiunit.typing import ArrayLike, DTypeLike, …` continues to work for external users. The new aliases (`Array`, `DTypeLike`, `Shape`, `Axis`, `Axes`, `PyTree`) are now part of the public surface.
- 33 production source files migrated: imports of `ArrayLike`/`DTypeLike`/`Array` switched from `_jax_compat` to `_typing`; every `jax.Array` and `jax.typing.DTypeLike` reference (in annotations *and* docstrings) replaced with the new aliases. One intentional cross-reference docstring in `custom_array.py` is preserved.
- Removed redundant local `Shape = Sequence[int]` in `fft/_fft_change_unit.py`. Other local `Shape` definitions in `lax`/`math`/`sparse` (which use semantically-different types like `Union[int, Sequence[int]]` or `tuple[int, ...]`) are left untouched.
- Design spec committed alongside the refactor: `docs/superpowers/specs/2026-05-24-saiunit-typing-consolidation-design.md`.

## Test plan

- [x] `python -m pytest saiunit/` — **3327 passed**
- [x] `python -m mypy saiunit/` — **0 errors**
- [x] `from saiunit.typing import Array, ArrayLike, ScalarOrArrayLike, DTypeLike, Shape, Axis, Axes, PyTree` works
- [x] No remaining `jax.typing` or `jax.Array` references in production code (except one intentional `See Also` docstring cross-reference and the `_typing.py` definition itself)
- [x] No production imports of `ArrayLike`/`DTypeLike`/`Array` from `saiunit._jax_compat`