### PR TITLE
chore: remove Equinox compatibility shim

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,6 +182,11 @@ jobs:
           # another array backend.
           python -m pip install absl-py brainstate --no-cache-dir
           pip install . --no-cache-dir
+          # Replace the brainstate-pulled PyPI brainunit with the local one,
+          # so it tracks the in-tree saiunit (PyPI brainunit may import names
+          # this PR has removed).
+          python make_brainunit_setup.py
+          pip install ./brainunit --force-reinstall --no-deps --no-cache-dir
       - name: Verify only jax backend is installed
         run: |
           python -c "import importlib.util as u

--- a/brainunit/brainunit/__init__.py
+++ b/brainunit/brainunit/__init__.py
@@ -67,7 +67,7 @@ from ._base_getters import (
     split_mantissa_unit,
     unit_scale_align_to_first,
 )
-from ._base_quantity import Quantity, compatible_with_equinox
+from ._base_quantity import Quantity
 from ._base_unit import UNITLESS, Unit, add_standard_unit, parse_unit
 from ._celsius import celsius2kelvin, kelvin2celsius, fahrenheit2kelvin, kelvin2fahrenheit
 from ._misc import maybe_custom_array, maybe_custom_array_tree
@@ -157,7 +157,6 @@ __all__ = [
 
               # _base_quantity
               'Quantity',
-              'compatible_with_equinox',
 
               # _base_decorators
               'check_dims',

--- a/docs/apis/saiunit.rst
+++ b/docs/apis/saiunit.rst
@@ -146,13 +146,3 @@ These customized arrays can seamlessly interact with the unit-aware mathematical
    :template: classtemplate.rst
 
     CustomArray
-
-
-Equinox Compatibility
----------------------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-    compatible_with_equinox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,6 @@ module = [
     "matplotlib.*",
     "opt_einsum",
     "opt_einsum.*",
-    "equinox",
-    "equinox.*",
     "jax.util",
 ]
 ignore_missing_imports = true

--- a/saiunit/__init__.py
+++ b/saiunit/__init__.py
@@ -102,7 +102,7 @@ from ._base_getters import (
     split_mantissa_unit,
     unit_scale_align_to_first,
 )
-from ._base_quantity import Quantity, compatible_with_equinox
+from ._base_quantity import Quantity
 from ._base_unit import UNITLESS, Unit, add_standard_unit, parse_unit
 from ._celsius import celsius2kelvin, kelvin2celsius, fahrenheit2kelvin, kelvin2fahrenheit
 from ._misc import maybe_custom_array, maybe_custom_array_tree
@@ -193,7 +193,6 @@ __all__ = [
 
               # _base_quantity
               'Quantity',
-              'compatible_with_equinox',
 
               # _base_decorators
               'check_dims',

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -57,7 +57,6 @@ from ._sparse_base import SparseMatrix
 
 __all__ = [
     'Quantity',
-    'compatible_with_equinox',
 ]
 
 # ---------------------------------------------------------------------------
@@ -70,7 +69,6 @@ StaticScalar = (
 )
 PyTree = Any
 _all_slice = slice(None, None, None)
-compat_with_equinox = False
 
 
 def _xp_attr(name: str):
@@ -84,36 +82,6 @@ def _xp_attr(name: str):
     if HAS_JAX:
         return getattr(jnp, name)
     return getattr(np, name)
-
-
-def compatible_with_equinox(mode: bool = True):
-    """
-    Enable or disable compatibility with the Equinox library.
-
-    When enabled, ``Quantity`` objects interact correctly with Equinox
-    transformations such as those used in
-    `unit-aware diffrax <https://github.com/chaoming0625/diffrax>`_.
-
-    Parameters
-    ----------
-    mode : bool, optional
-        If ``True`` (default), enable Equinox compatibility.
-        If ``False``, disable it.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        >>> import saiunit as u
-        >>> u.compatible_with_equinox(True)   # enable
-        >>> u.compatible_with_equinox(False)  # disable
-
-    See Also
-    --------
-    Quantity : The core physical-quantity class affected by this setting.
-    """
-    global compat_with_equinox
-    compat_with_equinox = mode
 
 
 # ---------------------------------------------------------------------------
@@ -506,7 +474,6 @@ class Quantity:
     See Also
     --------
     Unit : Represents a physical unit (dimension + scale).
-    compatible_with_equinox : Toggle Equinox interoperability.
     """
 
     __module__ = "saiunit"
@@ -2207,13 +2174,6 @@ class Quantity:
 
     def __pow__(self, oc):
         self = self.factorless()
-        if compat_with_equinox:
-            try:
-                from equinox.internal._omega import ω  # noqa
-                if isinstance(oc, ω):
-                    return ω(self)
-            except (ImportError, ModuleNotFoundError):
-                pass
         if isinstance(oc, Quantity):
             if not oc.is_unitless:
                 raise ValueError(f"Cannot calculate {self} ** {oc}, the exponent has to be dimensionless")

--- a/saiunit/_base_quantity_test.py
+++ b/saiunit/_base_quantity_test.py
@@ -36,8 +36,6 @@ from saiunit._base_quantity import (
     _wrap_function_keep_unit,
     _wrap_function_remove_unit,
     _zoom_values_with_units,
-    compat_with_equinox,
-    compatible_with_equinox,
 )
 from saiunit._base_unit import UNITLESS, Unit
 from saiunit._base_getters import (
@@ -527,25 +525,6 @@ class TestReplaceWithArray:
         assert isinstance(result, list)
         assert all(isinstance(r, Quantity) for r in result)
         assert all(r.unit == _metre for r in result)
-
-
-# =========================================================================
-# compatible_with_equinox
-# =========================================================================
-
-class TestCompatibleWithEquinox:
-    def test_default_false(self):
-        # Reset to default
-        compatible_with_equinox(False)
-        from saiunit._base_quantity import compat_with_equinox
-        assert not compat_with_equinox
-
-    def test_set_true(self):
-        compatible_with_equinox(True)
-        from saiunit._base_quantity import compat_with_equinox
-        assert compat_with_equinox
-        # Reset
-        compatible_with_equinox(False)
 
 
 # =========================================================================
@@ -1644,18 +1623,6 @@ def test_docstring_example_with_unit():
     q = u.Quantity.with_unit(2.0, unit=u.metre)
     assert jnp.allclose(q.mantissa, 2.0)
     assert q.unit == u.metre
-
-
-def test_docstring_example_compatible_with_equinox():
-    """Test compatible_with_equinox() function from the docstring."""
-    import saiunit as u
-    import saiunit._base_quantity as bq
-
-    u.compatible_with_equinox(True)
-    assert bq.compat_with_equinox is True
-
-    u.compatible_with_equinox(False)
-    assert bq.compat_with_equinox is False
 
 
 def test_docstring_example_mantissa():

--- a/saiunit/_jax_compat.py
+++ b/saiunit/_jax_compat.py
@@ -165,7 +165,7 @@ else:
     # -- Minimal pytree implementation over Python containers -----------------
     #
     # Real ``jax.tree.map`` understands registered pytree nodes (Quantity,
-    # equinox modules, dataclasses, …). Without JAX, registration is skipped,
+    # dataclasses, …). Without JAX, registration is skipped,
     # so every saiunit type is a leaf already. This fallback only needs to
     # traverse the standard Python containers — list, tuple, dict, None — plus
     # honour the caller's ``is_leaf`` predicate.


### PR DESCRIPTION
## Summary
- Removes `compatible_with_equinox`, the `compat_with_equinox` global, and the equinox branch in `Quantity.__pow__`
- Drops the corresponding tests, the `Equinox Compatibility` docs section, and the equinox entries from mypy `ignore_missing_imports`
- `brainunit` re-exports propagate automatically; its `__init__.py` is updated to drop the now-missing symbol

## Test plan
- [ ] `pytest saiunit/_base_quantity_test.py`
- [ ] Import smoke: `python -c "import saiunit; import brainunit"`
- [ ] Docs build (saiunit + brainunit targets)

## Summary by Sourcery

Remove legacy Equinox compatibility shim from saiunit and brainunit APIs and configuration.

Enhancements:
- Drop Equinox-specific compatibility handling from Quantity.__pow__ and remove the public compatible_with_equinox API and related re-exports.

Documentation:
- Remove the Equinox compatibility section from the saiunit API documentation.

Tests:
- Delete tests that covered the compatible_with_equinox toggle and its docstring example.

Chores:
- Clean up mypy configuration by removing Equinox entries from ignore_missing_imports and update comments referencing Equinox in JAX compatibility code.