### PR TITLE
docs(installation): rewrite installation guide for completeness and clarity

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -1,149 +1,422 @@
 Installation
 ============
 
-``saiunit`` is published on PyPI. The core package depends only on NumPy.
-JAX and every other array library are *optional* extras — install only
-what you need.
+``saiunit`` is distributed on PyPI and supports Linux, macOS, and
+Windows. The core package depends only on NumPy; every array backend
+beyond NumPy — JAX (CPU, CUDA, TPU), CuPy, PyTorch, Dask, ndonnx — is
+an optional extra that you opt into through ``pip``.
+
+This page walks through:
+
+- :ref:`install-requirements`
+- :ref:`install-quick`
+- :ref:`install-options` — backend-by-backend install matrix
+- :ref:`install-combining` — combining extras safely
+- :ref:`install-source` — editable / source install
+- :ref:`install-verify` — confirming the install works
+- :ref:`install-upgrade` — upgrading and uninstalling
+- :ref:`install-troubleshoot` — common issues
+- :ref:`install-ecosystem` — installing the wider BrainX stack
+
+
+.. _install-requirements:
 
 Requirements
 ------------
 
-- Python ≥ 3.10 (CI tests on 3.13)
-- NumPy
-- Optional: JAX, CuPy, PyTorch, Dask, or ndonnx (any combination)
+============  ================================================================
+Python        ≥ 3.10 (officially tested on 3.10, 3.11, 3.12, 3.13, 3.14)
+OS            Linux, macOS, Windows
+Core deps     ``numpy``, ``typing_extensions``, ``array_api_compat ≥ 1.9``,
+              ``opt_einsum`` — installed automatically with ``saiunit``
+Optional      JAX, CuPy, PyTorch, Dask, ndonnx — install any combination
+              via extras (see below)
+============  ================================================================
 
-Without JAX, the NumPy backend is selected automatically and the JAX-only
-submodules (``saiunit.autograd``, ``saiunit.lax``, ``saiunit.sparse``) and
-the custom ``exprel`` primitive raise :class:`saiunit.BackendError` on
-access. The CuPy, PyTorch, Dask, and ndonnx extras are independent of JAX
-and can be combined freely.
+The NumPy backend is always available. Without JAX, the JAX-only
+submodules — ``saiunit.autograd``, ``saiunit.lax``, ``saiunit.sparse``
+— and the custom ``exprel`` primitive raise
+:class:`saiunit.BackendError` on access, with the install hint included
+in the message. The CuPy, PyTorch, Dask, and ndonnx extras are
+independent of JAX and of each other; mix and match freely.
+
+.. tip::
+
+   We strongly recommend installing into a fresh virtual environment to
+   avoid clashing with system NumPy / JAX wheels::
+
+      python -m venv .venv
+      source .venv/bin/activate          # Windows: .venv\Scripts\activate
+      pip install -U pip
 
 
-Choosing an install command
----------------------------
+.. _install-quick:
 
-.. tab-set::
+Quick install
+-------------
 
-    .. tab-item:: NumPy only (no JAX)
+Pick the line that matches how you plan to use ``saiunit``:
 
-       Smallest install. ``saiunit.math``, ``saiunit.linalg``, and
-       ``saiunit.fft`` work on the NumPy backend; JAX-only submodules
-       raise :class:`saiunit.BackendError`.
+.. code-block:: bash
 
-       .. code-block:: bash
+   pip install -U saiunit               # NumPy backend only
+   pip install -U saiunit[cpu]          # + JAX (CPU build)
+   pip install -U "saiunit[cuda12]"     # + JAX (CUDA 12 build)
+   pip install -U "saiunit[cuda13]"     # + JAX (CUDA 13 build)
+   pip install -U "saiunit[tpu]"        # + JAX (TPU build)
+   pip install -U "saiunit[all]"        # + cupy, torch, dask, ndonnx (no JAX accelerator pin)
 
-          pip install -U saiunit
+Already know what you need? Skip ahead to :ref:`install-verify`.
 
-    .. tab-item:: JAX (CPU)
 
-       Adds the pinned JAX CPU build. Enables ``saiunit.autograd``,
-       ``saiunit.lax``, ``saiunit.sparse``, and JIT / ``vmap`` /
-       ``pmap`` over quantities.
+.. _install-options:
 
-       .. code-block:: bash
+Installation options
+--------------------
 
-          pip install -U saiunit[cpu]
+The table below summarises every supported extra. Each tab below
+explains *why* you might pick that option and what it enables.
 
-    .. tab-item:: JAX (GPU / CUDA)
+.. list-table::
+   :header-rows: 1
+   :widths: 22 28 50
 
-       Adds the JAX CUDA build. Pick the line that matches your CUDA
-       toolkit.
+   * - Extra
+     - Adds
+     - When to choose it
+   * - *(none)*
+     - core only
+     - Lightweight; NumPy backend; scipy / pandas / sklearn interop
+   * - ``[jax]``
+     - ``jax``
+     - You manage your own JAX accelerator wheel
+   * - ``[cpu]``
+     - ``jax[cpu]``
+     - Pinned JAX CPU wheel — autograd, JIT, vmap
+   * - ``[cuda12]``
+     - ``jax[cuda12]``
+     - NVIDIA GPU, CUDA 12 toolkit
+   * - ``[cuda13]``
+     - ``jax[cuda13]``
+     - NVIDIA GPU, CUDA 13 toolkit
+   * - ``[tpu]``
+     - ``jax[tpu]``
+     - Google Cloud TPU
+   * - ``[cupy]``
+     - ``cupy-cuda12x ≥ 13``
+     - NVIDIA GPU arrays as a drop-in NumPy replacement
+   * - ``[torch]``
+     - ``torch ≥ 2.0``
+     - Integrate with PyTorch models / autograd
+   * - ``[dask]``
+     - ``dask[array] ≥ 2024.1``
+     - Out-of-core, parallel, or lazy compute
+   * - ``[ndonnx]``
+     - ``ndonnx ≥ 0.9``
+     - Symbolic graph building / ONNX export
+   * - ``[all]``
+     - ``cupy + torch + dask + ndonnx`` (and ``jax``)
+     - Everything except a pinned JAX accelerator build
 
-       .. code-block:: bash
+NumPy only
+~~~~~~~~~~
 
-          pip install -U saiunit[cuda12]
-          pip install -U saiunit[cuda13]
+Smallest install. ``saiunit.math``, ``saiunit.linalg``, and
+``saiunit.fft`` work on the NumPy backend; the JAX-only submodules
+raise :class:`saiunit.BackendError` on access.
 
-    .. tab-item:: JAX (TPU)
+.. code-block:: bash
 
-       Adds the JAX TPU build (Google Cloud TPU).
+   pip install -U saiunit
 
-       .. code-block:: bash
+JAX (CPU)
+~~~~~~~~~
 
-          pip install -U saiunit[tpu]
+Adds the pinned JAX CPU build. Enables ``saiunit.autograd``,
+``saiunit.lax``, ``saiunit.sparse``, and ``jit`` / ``vmap`` / ``pmap``
+over quantities.
 
-    .. tab-item:: Plain JAX
+.. code-block:: bash
 
-       Adds JAX without pinning an accelerator build — use this if you
-       manage the JAX accelerator wheel yourself.
+   pip install -U "saiunit[cpu]"
 
-       .. code-block:: bash
+JAX (GPU / CUDA)
+~~~~~~~~~~~~~~~~
 
-          pip install -U saiunit[jax]
+Adds the JAX CUDA build. Match the line to your CUDA toolkit; the two
+CUDA extras are mutually exclusive.
 
-    .. tab-item:: CuPy
+.. code-block:: bash
 
-       Adds ``cupy-cuda12x`` for the CuPy backend (NVIDIA GPU,
-       drop-in NumPy replacement). Requires a CUDA toolkit.
+   pip install -U "saiunit[cuda12]"   # CUDA 12.x
+   pip install -U "saiunit[cuda13]"   # CUDA 13.x
 
-       .. code-block:: bash
+The CUDA wheels are large (~1 GB). If you already manage CUDA outside
+``pip``, prefer ``saiunit[jax]`` and install JAX yourself per the
+`JAX install guide <https://docs.jax.dev/en/latest/installation.html>`_.
 
-          pip install -U saiunit[cupy]
+JAX (TPU)
+~~~~~~~~~
 
-    .. tab-item:: PyTorch
+Adds the JAX TPU build. Run on a `Google Cloud TPU VM
+<https://cloud.google.com/tpu/docs>`_.
 
-       Adds ``torch>=2.0`` for the PyTorch backend. ``torch.autograd``
-       on the mantissa is preserved through ``saiunit`` ops.
+.. code-block:: bash
 
-       .. code-block:: bash
+   pip install -U "saiunit[tpu]"
 
-          pip install -U saiunit[torch]
+Plain JAX
+~~~~~~~~~
 
-    .. tab-item:: Dask
+Adds JAX without pinning an accelerator build — use this when you
+manage the JAX accelerator wheel yourself (custom CUDA, ROCm, Apple
+Metal, conda-forge, etc.).
 
-       Adds ``dask[array]`` for out-of-core / parallel arrays.
-       Operations stay lazy until ``.compute()``.
+.. code-block:: bash
 
-       .. code-block:: bash
+   pip install -U "saiunit[jax]"
 
-          pip install -U saiunit[dask]
+CuPy
+~~~~
 
-    .. tab-item:: ndonnx
+Adds ``cupy-cuda12x`` for the CuPy backend (NVIDIA GPU, drop-in NumPy
+replacement). Requires a working CUDA toolkit on the host. See the
+`CuPy install guide <https://docs.cupy.dev/en/stable/install.html>`_
+for CUDA 11 or ROCm wheels.
 
-       Adds ``ndonnx`` for symbolic graph building / ONNX export.
+.. code-block:: bash
 
-       .. code-block:: bash
+   pip install -U "saiunit[cupy]"
 
-          pip install -U saiunit[ndonnx]
+PyTorch
+~~~~~~~
 
-    .. tab-item:: All optional backends
+Adds ``torch ≥ 2.0`` for the PyTorch backend. ``torch.autograd`` on the
+mantissa is preserved through every ``saiunit`` operation. For
+specific CUDA / ROCm builds, install ``torch`` from
+`pytorch.org <https://pytorch.org/get-started/locally/>`_ *before*
+``saiunit``.
 
-       Shorthand for ``[cupy,torch,dask,ndonnx]``. Does *not* pin a JAX
-       accelerator build — combine with ``[cpu]`` / ``[cuda12]`` /
-       ``[cuda13]`` / ``[tpu]`` if you want one.
+.. code-block:: bash
 
-       .. code-block:: bash
+   pip install -U "saiunit[torch]"
 
-          pip install -U saiunit[all]
+Dask
+~~~~
 
+Adds ``dask[array]`` for out-of-core / parallel arrays. Operations
+stay lazy until you call ``.compute()`` or ``.persist()``.
+
+.. code-block:: bash
+
+   pip install -U "saiunit[dask]"
+
+ndonnx
+~~~~~~
+
+Adds ``ndonnx`` for symbolic graph building and ONNX export.
+
+.. code-block:: bash
+
+   pip install -U "saiunit[ndonnx]"
+
+All optional backends
+~~~~~~~~~~~~~~~~~~~~~
+
+Shorthand for ``[jax,cupy,torch,dask,ndonnx]``. Does *not* pin a JAX
+accelerator build — combine with ``[cpu]`` / ``[cuda12]`` /
+``[cuda13]`` / ``[tpu]`` if you need one.
+
+.. code-block:: bash
+
+   pip install -U "saiunit[all]"
+   pip install -U "saiunit[all,cuda12]"   # add CUDA 12 JAX on top
+
+
+.. _install-combining:
 
 Combining extras
 ----------------
 
 The JAX accelerator extras — ``[cpu]``, ``[cuda12]``, ``[cuda13]``,
-``[tpu]`` — are mutually exclusive: pick at most one. The remaining
-extras (``[cupy]``, ``[torch]``, ``[dask]``, ``[ndonnx]``) are
-independent and can be combined in a single command:
+``[tpu]`` — are mutually exclusive: choose at most one per
+environment. The remaining extras (``[cupy]``, ``[torch]``, ``[dask]``,
+``[ndonnx]``) are independent and can be combined freely in a single
+command:
 
 .. code-block:: bash
 
    pip install -U "saiunit[cuda12,torch,dask]"
+   pip install -U "saiunit[cpu,cupy,ndonnx]"
 
+.. note::
+
+   Always quote the bracketed extras (``"saiunit[...]"``) on
+   ``zsh`` / ``bash``; the shells otherwise interpret ``[`` and ``]``
+   as glob characters and the install will fail with
+   *"no matches found"*.
+
+
+.. _install-source:
+
+Installing from source
+----------------------
+
+To track ``main`` or hack on ``saiunit`` itself, install in editable
+mode from a local clone:
+
+.. code-block:: bash
+
+   git clone https://github.com/chaobrain/saiunit.git
+   cd saiunit
+   pip install -e ".[cpu]"            # core + JAX CPU + editable
+   pip install -e ".[cpu,torch]"      # add any extras you need
+
+Run the test suite to confirm the dev install:
+
+.. code-block:: bash
+
+   pip install -e ".[testing]"
+   pytest
+
+
+.. _install-verify:
 
 Verifying the install
 ---------------------
+
+A two-line smoke test exercises the core, NumPy backend, and unit
+algebra:
 
 .. code-block:: python
 
    import saiunit as u
    print(u.__version__)
-   q = 9.81 * u.meter / u.second ** 2
-   print(q)
+
+   q = 9.81 * u.meter / u.second ** 2     # gravitational acceleration
+   print(q)                               # 9.81 * meter / second ** 2
+
+If you installed a JAX extra, confirm the autograd path is wired up:
+
+.. code-block:: python
+
+   import saiunit as u
+
+   x = 3.0 * u.meter
+   f = lambda x: x ** 3
+   print(u.autograd.grad(f)(x))           # 27. * meter ** 2
+
+For any non-default backend, check that it is selectable:
+
+.. code-block:: python
+
+   import saiunit as u
+
+   with u.using_backend("torch"):          # or "jax", "cupy", "dask", "ndonnx"
+       q = u.math.arange(0., 5.) * u.second
+       print(q)
+
+Requesting a backend whose array library is not installed raises
+:class:`saiunit.BackendError` with the exact ``pip install`` command to
+fix it — never a bare ``ImportError``.
+
+
+.. _install-upgrade:
+
+Upgrading and uninstalling
+--------------------------
+
+Upgrade to the latest release (and preserve any extras you previously
+selected by re-specifying them):
+
+.. code-block:: bash
+
+   pip install -U "saiunit[cuda12,torch]"
+
+Uninstall the package and any editable install:
+
+.. code-block:: bash
+
+   pip uninstall saiunit
+
+``pip uninstall`` does **not** remove the optional dependencies
+(``jax``, ``torch``, ``cupy``, …); remove them individually if you no
+longer need them.
+
+
+.. _install-troubleshoot:
+
+Troubleshooting
+---------------
+
+**“zsh: no matches found: saiunit[cpu]”**
+    Quote the extras: ``pip install -U "saiunit[cpu]"``.
+
+**``BackendError`` on import of ``saiunit.autograd`` / ``.lax`` / ``.sparse``**
+    These submodules require JAX. Install with one of ``saiunit[cpu]``,
+    ``saiunit[cuda12]``, ``saiunit[cuda13]``, ``saiunit[tpu]``, or
+    ``saiunit[jax]``. The error message includes the recommended
+    install command.
+
+**``saiunit.BackendError: backend 'cupy' is not installed``**
+    The selected backend's array library is missing. Install the
+    matching extra — for example ``pip install -U "saiunit[cupy]"`` —
+    or call :func:`saiunit.using_backend` with a backend you have.
+
+**JAX picks the wrong accelerator (CPU instead of GPU, or vice versa)**
+    ``pip`` may have resolved a JAX wheel that does not match your
+    hardware. Reinstall with the explicit accelerator extra
+    (``"saiunit[cuda12]"`` for CUDA 12, etc.) and check
+    ``jax.devices()`` to confirm.
+
+**CuPy import fails with “libcudart not found”**
+    The CuPy wheel needs a matching CUDA runtime on the host. Install
+    a CUDA 12.x toolkit, or follow the `CuPy install guide
+    <https://docs.cupy.dev/en/stable/install.html>`_ for CUDA 11 / ROCm
+    wheels.
+
+**PyTorch installs the CPU wheel on a GPU host**
+    Install ``torch`` from `pytorch.org
+    <https://pytorch.org/get-started/locally/>`_ with the correct CUDA
+    selector *before* installing ``saiunit[torch]``; ``pip`` will then
+    keep your GPU build.
+
+**Windows ``pip install`` fails on ``cupy-cuda12x``**
+    ``cupy-cuda12x`` ships Linux and Windows wheels but requires the
+    NVIDIA driver and CUDA runtime to be installed system-wide. Verify
+    with ``nvidia-smi``.
+
+Still stuck? File an issue at
+https://github.com/chaobrain/saiunit/issues with the output of
+``python -c "import saiunit, sys; print(saiunit.__version__, sys.version)"``
+and the failing command.
+
+
+.. _install-ecosystem:
+
+Installing the BrainX ecosystem
+-------------------------------
+
+``saiunit`` is part of `BrainX <https://github.com/chaobrain>`_, a
+family of compatible JAX-based tools for brain dynamics and scientific
+computing. The ``BrainX`` meta-package bundles ``saiunit`` together
+with :mod:`brainstate`, :mod:`brainunit`, :mod:`braintools`,
+:mod:`braintaichi`, :mod:`dendritex`, and friends:
+
+.. code-block:: bash
+
+   pip install -U BrainX
+
+Pick this if you want the full stack in one command; pick plain
+``saiunit`` (with the extras you need) if you only want unit-aware
+arrays.
 
 
 See also
 --------
 
-- :doc:`../backends/overview` — full backend matrix, selection rules,
-  and per-backend capability notes.
+- :doc:`../backends/overview` — full backend matrix, selection
+  rules, and per-backend capability notes.
+- :doc:`../backends/feature_support_matrix` — function-level support
+  table for every backend.
 - :doc:`quickstart` — first steps with ``Quantity`` and units.


### PR DESCRIPTION
## Summary
- Rewrites `docs/getting_started/installation.rst` into a complete, anchored installation reference covering requirements, quick install, per-extra options, combining rules, source/editable install, verification, upgrade/uninstall, troubleshooting, and BrainX ecosystem install.
- Drops the `.. tab-set::` directive in favor of plain subsections.
- Adds a summary table for every extra defined in `pyproject.toml` (`jax`, `cpu`, `cuda12`, `cuda13`, `tpu`, `cupy`, `torch`, `dask`, `ndonnx`, `all`), spells out the mutually exclusive JAX-accelerator extras vs freely combinable backend extras, and notes the zsh quoting gotcha.
- Adds troubleshooting entries for the common `BackendError`, CUDA mismatch, CuPy runtime, and PyTorch wheel pitfalls.

## Test plan
- [x] `sphinx-build` of the page produces `installation.html` with no warnings other than the unrelated index/toctree noise from isolated builds.
- [ ] Read the Docs preview renders the new structure correctly.

## Summary by Sourcery

Documentation:
- Overhaul the installation guide to cover requirements, quick install, extras combinations, source/editable installs, verification, upgrade/uninstall, troubleshooting, and BrainX ecosystem installs in a single anchored page.