### PR TITLE
fix(backends): make tril_indices, triu_indices, astype, arange pass on every backend

### DIFF
--- a/dev/backend_support_data.json
+++ b/dev/backend_support_data.json
@@ -1396,24 +1396,24 @@
     },
     "saiunit.math.arange": {
       "dask": {
-        "detail": "TypeError: An error occurred while calling the arange method registered to the numpy backend.\nOriginal Message: unsupported operand type(s) for /: 'int' and 'NoneType'",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "jax": {
         "detail": "",
         "status": "pass"
       },
       "ndonnx": {
-        "detail": "ValueError: 'arange' is not implemented for the provided inputs",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "numpy": {
         "detail": "",
         "status": "pass"
       },
       "torch": {
-        "detail": "TypeError: '>' not supported between instances of 'NoneType' and 'int'",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       }
     },
     "saiunit.math.arccos": {
@@ -1822,16 +1822,16 @@
         "status": "pass"
       },
       "ndonnx": {
-        "detail": "AttributeError: type object 'numpy.float32' has no attribute '__ndx_cast_from__'",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "numpy": {
         "detail": "",
         "status": "pass"
       },
       "torch": {
-        "detail": "TypeError: to() received an invalid combination of arguments - got (copy=bool, dtype=type, ), but expected one of:\n * (torch.device device = None, torch.dtype dtype = None, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n * (torch.dtype dtype, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n * (Tensor tensor, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       }
     },
     "saiunit.math.atleast_1d": {
@@ -3310,7 +3310,7 @@
     },
     "saiunit.math.einsum": {
       "dask": {
-        "detail": "TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2]\nThe error occurred while tracing the function _einsum at /mnt/d/codes/projects/saiunit/.claude/worktrees/scalable-discovering-key/saiunit/math/_einops.py:843 for jit. This concrete value was not available in Python because it depends on the value of the argument operands[0].\nSee https://docs.jax.dev/en/latest/errors.html#jax.errors.TracerArrayConversionError",
+        "detail": "TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2]\nThe error occurred while tracing the function _einsum at /mnt/d/codes/projects/saiunit/.claude/worktrees/idempotent-seeking-clarke/saiunit/math/_einops.py:843 for jit. This concrete value was not available in Python because it depends on the value of the argument operands[0].\nSee https://docs.jax.dev/en/latest/errors.html#jax.errors.TracerArrayConversionError",
         "status": "skip"
       },
       "jax": {
@@ -3322,7 +3322,7 @@
         "status": "skip"
       },
       "numpy": {
-        "detail": "TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2]\nThe error occurred while tracing the function _einsum at /mnt/d/codes/projects/saiunit/.claude/worktrees/scalable-discovering-key/saiunit/math/_einops.py:843 for jit. This concrete value was not available in Python because it depends on the value of the argument operands[0].\nSee https://docs.jax.dev/en/latest/errors.html#jax.errors.TracerArrayConversionError",
+        "detail": "TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2]\nThe error occurred while tracing the function _einsum at /mnt/d/codes/projects/saiunit/.claude/worktrees/idempotent-seeking-clarke/saiunit/math/_einops.py:843 for jit. This concrete value was not available in Python because it depends on the value of the argument operands[0].\nSee https://docs.jax.dev/en/latest/errors.html#jax.errors.TracerArrayConversionError",
         "status": "skip"
       },
       "torch": {
@@ -8114,8 +8114,8 @@
         "status": "pass"
       },
       "ndonnx": {
-        "detail": "AttributeError: module 'ndonnx' has no attribute `tril_indices`",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "numpy": {
         "detail": "",
@@ -8180,8 +8180,8 @@
         "status": "pass"
       },
       "ndonnx": {
-        "detail": "AttributeError: module 'ndonnx' has no attribute `triu_indices`",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "numpy": {
         "detail": "",
@@ -9019,16 +9019,16 @@
         "status": "pass"
       },
       "ndonnx": {
-        "detail": "AttributeError: type object 'numpy.float32' has no attribute '__ndx_cast_from__'",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       },
       "numpy": {
         "detail": "",
         "status": "pass"
       },
       "torch": {
-        "detail": "TypeError: to() received an invalid combination of arguments - got (copy=bool, dtype=type, ), but expected one of:\n * (torch.device device = None, torch.dtype dtype = None, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n * (torch.dtype dtype, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n * (Tensor tensor, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)\n",
-        "status": "skip"
+        "detail": "",
+        "status": "pass"
       }
     },
     "Quantity.clip": {

--- a/docs/backends/feature_support_matrix.rst
+++ b/docs/backends/feature_support_matrix.rst
@@ -369,14 +369,14 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-1]_
+     - ✓
    * - ``triu_indices``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-2]_
+     - ✓
 
 ``keep_unit`` — Unit-preserving
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -396,9 +396,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-3]_
      - ✓
-     - ⊘ [#fn-4]_
+     - ✓
+     - ✓
 
 ``change_unit`` — Unit-changing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -442,7 +442,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-5]_
+     - ⊘ [#fn-1]_
    * - ``add``
      - ✓
      - ✓
@@ -463,7 +463,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-6]_
+     - ⊘ [#fn-2]_
    * - ``alltrue``
      - ✓
      - ✓
@@ -491,7 +491,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-7]_
+     - ✗ [#fn-3]_
    * - ``any``
      - ✓
      - ✓
@@ -503,65 +503,65 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-8]_
+     - ⊘ [#fn-4]_
      - ✓
-     - ⊘ [#fn-9]_
+     - ⊘ [#fn-5]_
    * - ``arange``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-10]_
-     - ⊘ [#fn-11]_
-     - ⊘ [#fn-12]_
+     - ✓
+     - ✓
+     - ✓
    * - ``arccos``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-13]_
+     - ⊘ [#fn-6]_
    * - ``arccosh``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-14]_
+     - ⊘ [#fn-7]_
    * - ``arcsin``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-15]_
+     - ⊘ [#fn-8]_
    * - ``arcsinh``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-16]_
+     - ⊘ [#fn-9]_
    * - ``arctan``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-17]_
+     - ⊘ [#fn-10]_
    * - ``arctan2``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-18]_
+     - ⊘ [#fn-11]_
    * - ``arctanh``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-19]_
+     - ⊘ [#fn-12]_
    * - ``argmax``
      - ✓
      - ✓
@@ -589,14 +589,14 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-20]_
+     - ⊘ [#fn-13]_
    * - ``around``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-21]_
+     - ⊘ [#fn-14]_
      - ✓
-     - ⊘ [#fn-22]_
+     - ⊘ [#fn-15]_
    * - ``array``
      - ✓
      - ✓
@@ -608,16 +608,16 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-23]_
-     - ⊘ [#fn-24]_
-     - ⊘ [#fn-25]_
+     - ⊘ [#fn-16]_
+     - ⊘ [#fn-17]_
+     - ⊘ [#fn-18]_
    * - ``array_split``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-26]_
-     - ⊘ [#fn-27]_
+     - ⊘ [#fn-19]_
+     - ⊘ [#fn-20]_
    * - ``as_numpy``
      - ✓
      - ✓
@@ -638,35 +638,35 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-28]_
+     - ⊘ [#fn-21]_
    * - ``atleast_2d``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-29]_
+     - ⊘ [#fn-22]_
    * - ``atleast_3d``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-30]_
+     - ⊘ [#fn-23]_
    * - ``average``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-31]_
+     - ⊘ [#fn-24]_
      - ✓
-     - ⊘ [#fn-32]_
+     - ⊘ [#fn-25]_
    * - ``bincount``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-33]_
+     - ⊘ [#fn-26]_
    * - ``bitwise_and``
      - ✓
      - ✓
@@ -680,7 +680,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-34]_
+     - ⊘ [#fn-27]_
    * - ``bitwise_or``
      - ✓
      - ✓
@@ -699,9 +699,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-35]_
+     - ⊘ [#fn-28]_
      - ✓
-     - ⊘ [#fn-36]_
+     - ⊘ [#fn-29]_
    * - ``broadcast_arrays``
      - ✓
      - ✓
@@ -727,9 +727,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-37]_
+     - ⊘ [#fn-30]_
      - ✓
-     - ⊘ [#fn-38]_
+     - ⊘ [#fn-31]_
    * - ``ceil``
      - ✓
      - ✓
@@ -748,9 +748,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-39]_
+     - ⊘ [#fn-32]_
      - ✓
-     - ⊘ [#fn-40]_
+     - ⊘ [#fn-33]_
    * - ``clip``
      - ✓
      - ✓
@@ -763,64 +763,64 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-41]_
-     - ⊘ [#fn-42]_
+     - ⊘ [#fn-34]_
+     - ⊘ [#fn-35]_
    * - ``compress``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-43]_
+     - ⊘ [#fn-36]_
      - ✓
-     - ⊘ [#fn-44]_
+     - ⊘ [#fn-37]_
    * - ``concatenate``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-45]_
+     - ⊘ [#fn-38]_
    * - ``conj``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-7]_
+     - ✗ [#fn-3]_
    * - ``conjugate``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-46]_
-     - ⊘ [#fn-47]_
-     - ✗ [#fn-7]_
+     - ⊘ [#fn-39]_
+     - ⊘ [#fn-40]_
+     - ✗ [#fn-3]_
    * - ``convolve``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-48]_
-     - ⊘ [#fn-49]_
-     - ⊘ [#fn-50]_
+     - ⊘ [#fn-41]_
+     - ⊘ [#fn-42]_
+     - ⊘ [#fn-43]_
    * - ``copysign``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``corrcoef``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-52]_
+     - ⊘ [#fn-45]_
    * - ``correlate``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-53]_
-     - ⊘ [#fn-54]_
-     - ⊘ [#fn-55]_
+     - ⊘ [#fn-46]_
+     - ⊘ [#fn-47]_
+     - ⊘ [#fn-48]_
    * - ``cos``
      - ✓
      - ✓
@@ -848,77 +848,77 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-56]_
+     - ⊘ [#fn-49]_
    * - ``cross``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-57]_
-     - ⊘ [#fn-58]_
+     - ⊘ [#fn-50]_
+     - ⊘ [#fn-51]_
    * - ``cumprod``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-59]_
+     - ⊘ [#fn-52]_
    * - ``cumproduct``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-59]_
+     - ⊘ [#fn-52]_
    * - ``cumsum``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-60]_
+     - ⊘ [#fn-53]_
    * - ``deg2rad``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-61]_
+     - ⊘ [#fn-54]_
    * - ``degrees``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-62]_
+     - ⊘ [#fn-55]_
      - ✓
-     - ⊘ [#fn-63]_
+     - ⊘ [#fn-56]_
    * - ``diag``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-64]_
+     - ⊘ [#fn-57]_
    * - ``diag_indices_from``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-65]_
-     - ⊘ [#fn-66]_
-     - ⊘ [#fn-67]_
+     - ⊘ [#fn-58]_
+     - ⊘ [#fn-59]_
+     - ⊘ [#fn-60]_
    * - ``diagflat``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-68]_
-     - ⊘ [#fn-69]_
+     - ⊘ [#fn-61]_
+     - ⊘ [#fn-62]_
    * - ``diagonal``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-70]_
+     - ⊘ [#fn-63]_
    * - ``diff``
      - ✓
      - ✓
@@ -930,9 +930,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-71]_
+     - ⊘ [#fn-64]_
      - ✓
-     - ⊘ [#fn-72]_
+     - ⊘ [#fn-65]_
    * - ``divide``
      - ✓
      - ✓
@@ -944,44 +944,44 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-73]_
+     - ⊘ [#fn-66]_
      - ✓
-     - ⊘ [#fn-74]_
+     - ⊘ [#fn-67]_
    * - ``dot``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-75]_
+     - ⊘ [#fn-68]_
    * - ``dsplit``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-76]_
-     - ⊘ [#fn-77]_
+     - ⊘ [#fn-69]_
+     - ⊘ [#fn-70]_
    * - ``dstack``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-78]_
+     - ⊘ [#fn-71]_
    * - ``ediff1d``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-79]_
+     - ⊘ [#fn-72]_
      - ✓
-     - ⊘ [#fn-80]_
+     - ⊘ [#fn-73]_
    * - ``einsum``
-     - ⊘ [#fn-81]_
+     - ⊘ [#fn-74]_
      - ✓
      - ?
-     - ⊘ [#fn-82]_
-     - ⊘ [#fn-81]_
-     - ⊘ [#fn-83]_
+     - ⊘ [#fn-75]_
+     - ⊘ [#fn-74]_
+     - ⊘ [#fn-76]_
    * - ``elu``
      - ✓
      - ✓
@@ -1023,7 +1023,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-84]_
+     - ⊘ [#fn-77]_
    * - ``expand_dims``
      - ✓
      - ✓
@@ -1037,7 +1037,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``exprel``
      - ✓
      - ✓
@@ -1049,9 +1049,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-85]_
+     - ⊘ [#fn-78]_
      - ✓
-     - ⊘ [#fn-86]_
+     - ⊘ [#fn-79]_
    * - ``eye``
      - ✓
      - ✓
@@ -1063,16 +1063,16 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-87]_
+     - ⊘ [#fn-80]_
      - ✓
-     - ⊘ [#fn-88]_
+     - ⊘ [#fn-81]_
    * - ``fill_diagonal``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-89]_
-     - ⊘ [#fn-90]_
-     - ⊘ [#fn-91]_
+     - ⊘ [#fn-82]_
+     - ⊘ [#fn-83]_
+     - ⊘ [#fn-84]_
    * - ``finfo``
      - ✓
      - ✓
@@ -1091,9 +1091,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-92]_
+     - ⊘ [#fn-85]_
      - ✓
-     - ⊘ [#fn-93]_
+     - ⊘ [#fn-86]_
    * - ``flatten``
      - ✓
      - ✓
@@ -1114,21 +1114,21 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-94]_
+     - ⊘ [#fn-87]_
    * - ``flipud``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-95]_
+     - ⊘ [#fn-88]_
    * - ``float_power``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-96]_
+     - ⊘ [#fn-89]_
    * - ``floor``
      - ✓
      - ✓
@@ -1149,28 +1149,28 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-97]_
+     - ⊘ [#fn-90]_
    * - ``fmin``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-98]_
+     - ⊘ [#fn-91]_
    * - ``fmod``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-99]_
+     - ⊘ [#fn-92]_
    * - ``frexp``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-100]_
+     - ⊘ [#fn-93]_
    * - ``from_numpy``
      - ✓
      - ✓
@@ -1197,15 +1197,15 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ✗ [#fn-101]_
-     - ⊘ [#fn-102]_
+     - ✗ [#fn-94]_
+     - ⊘ [#fn-95]_
    * - ``gcd``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-103]_
-     - ⊘ [#fn-104]_
+     - ⊘ [#fn-96]_
+     - ⊘ [#fn-97]_
    * - ``gelu``
      - ✓
      - ✓
@@ -1233,7 +1233,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-105]_
+     - ⊘ [#fn-98]_
    * - ``greater``
      - ✓
      - ✓
@@ -1281,43 +1281,43 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-106]_
-     - ⊘ [#fn-107]_
+     - ⊘ [#fn-99]_
+     - ⊘ [#fn-100]_
    * - ``histogram``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-108]_
+     - ⊘ [#fn-101]_
    * - ``hsplit``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-109]_
-     - ⊘ [#fn-110]_
+     - ⊘ [#fn-102]_
+     - ⊘ [#fn-103]_
    * - ``hstack``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-111]_
+     - ⊘ [#fn-104]_
    * - ``hypot``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``identity``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-112]_
-     - ⊘ [#fn-113]_
-     - ⊘ [#fn-114]_
+     - ⊘ [#fn-105]_
+     - ⊘ [#fn-106]_
+     - ⊘ [#fn-107]_
    * - ``iinfo``
      - ✓
      - ✓
@@ -1331,49 +1331,49 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-7]_
+     - ✗ [#fn-3]_
    * - ``inner``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-115]_
-     - ⊘ [#fn-116]_
+     - ⊘ [#fn-108]_
+     - ⊘ [#fn-109]_
    * - ``interp``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-117]_
-     - ⊘ [#fn-118]_
-     - ⊘ [#fn-119]_
+     - ⊘ [#fn-110]_
+     - ⊘ [#fn-111]_
+     - ⊘ [#fn-112]_
    * - ``intersect1d``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-120]_
-     - ⊘ [#fn-121]_
-     - ⊘ [#fn-122]_
+     - ⊘ [#fn-113]_
+     - ⊘ [#fn-114]_
+     - ⊘ [#fn-115]_
    * - ``invert``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-123]_
+     - ⊘ [#fn-116]_
      - ✓
-     - ⊘ [#fn-124]_
+     - ⊘ [#fn-117]_
    * - ``isclose``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-125]_
+     - ⊘ [#fn-118]_
    * - ``iscomplexobj``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-126]_
-     - ⊘ [#fn-127]_
-     - ⊘ [#fn-128]_
+     - ⊘ [#fn-119]_
+     - ⊘ [#fn-120]_
+     - ⊘ [#fn-121]_
    * - ``isfinite``
      - ✓
      - ✓
@@ -1401,7 +1401,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-129]_
+     - ⊘ [#fn-122]_
    * - ``isscalar``
      - ✓
      - ✓
@@ -1421,22 +1421,22 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-130]_
-     - ⊘ [#fn-131]_
+     - ⊘ [#fn-123]_
+     - ⊘ [#fn-124]_
    * - ``lcm``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-132]_
-     - ⊘ [#fn-133]_
+     - ⊘ [#fn-125]_
+     - ⊘ [#fn-126]_
    * - ``ldexp``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-134]_
+     - ⊘ [#fn-127]_
    * - ``leaky_relu``
      - ✓
      - ✓
@@ -1448,9 +1448,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-135]_
+     - ⊘ [#fn-128]_
      - ✓
-     - ⊘ [#fn-136]_
+     - ⊘ [#fn-129]_
    * - ``less``
      - ✓
      - ✓
@@ -1492,7 +1492,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``log2``
      - ✓
      - ✓
@@ -1520,7 +1520,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-137]_
+     - ⊘ [#fn-130]_
    * - ``logical_and``
      - ✓
      - ✓
@@ -1553,9 +1553,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-138]_
-     - ⊘ [#fn-139]_
-     - ⊘ [#fn-140]_
+     - ⊘ [#fn-131]_
+     - ⊘ [#fn-132]_
+     - ⊘ [#fn-133]_
    * - ``matmul``
      - ✓
      - ✓
@@ -1568,8 +1568,8 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-141]_
-     - ⊘ [#fn-142]_
+     - ⊘ [#fn-134]_
+     - ⊘ [#fn-135]_
    * - ``max``
      - ✓
      - ✓
@@ -1596,15 +1596,15 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ✗ [#fn-143]_
-     - ⊘ [#fn-144]_
+     - ✗ [#fn-136]_
+     - ⊘ [#fn-137]_
    * - ``meshgrid``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-145]_
+     - ⊘ [#fn-138]_
    * - ``min``
      - ✓
      - ✓
@@ -1630,16 +1630,16 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-146]_
+     - ⊘ [#fn-139]_
      - ✓
-     - ⊘ [#fn-147]_
+     - ⊘ [#fn-140]_
    * - ``modf``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-148]_
+     - ⊘ [#fn-141]_
      - ✓
-     - ⊘ [#fn-149]_
+     - ⊘ [#fn-142]_
    * - ``moveaxis``
      - ✓
      - ✓
@@ -1652,8 +1652,8 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-150]_
-     - ⊘ [#fn-151]_
+     - ⊘ [#fn-143]_
+     - ⊘ [#fn-144]_
    * - ``multiply``
      - ✓
      - ✓
@@ -1667,105 +1667,105 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-152]_
+     - ⊘ [#fn-145]_
    * - ``nanargmax``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-153]_
+     - ⊘ [#fn-146]_
      - ✓
-     - ⊘ [#fn-154]_
+     - ⊘ [#fn-147]_
    * - ``nanargmin``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-155]_
+     - ⊘ [#fn-148]_
      - ✓
-     - ⊘ [#fn-156]_
+     - ⊘ [#fn-149]_
    * - ``nancumprod``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-157]_
+     - ⊘ [#fn-150]_
      - ✓
-     - ⊘ [#fn-158]_
+     - ⊘ [#fn-151]_
    * - ``nancumsum``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-159]_
+     - ⊘ [#fn-152]_
      - ✓
-     - ⊘ [#fn-160]_
+     - ⊘ [#fn-153]_
    * - ``nanmax``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-161]_
+     - ⊘ [#fn-154]_
      - ✓
-     - ⊘ [#fn-162]_
+     - ⊘ [#fn-155]_
    * - ``nanmean``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-163]_
+     - ⊘ [#fn-156]_
    * - ``nanmedian``
      - ✓
      - ✓
      - ?
      - ✓
-     - ✗ [#fn-164]_
-     - ⊘ [#fn-165]_
+     - ✗ [#fn-157]_
+     - ⊘ [#fn-158]_
    * - ``nanmin``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-166]_
+     - ⊘ [#fn-159]_
      - ✓
-     - ⊘ [#fn-167]_
+     - ⊘ [#fn-160]_
    * - ``nanpercentile``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-168]_
+     - ⊘ [#fn-161]_
      - ✓
-     - ⊘ [#fn-169]_
+     - ⊘ [#fn-162]_
    * - ``nanprod``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-170]_
+     - ⊘ [#fn-163]_
      - ✓
-     - ⊘ [#fn-171]_
+     - ⊘ [#fn-164]_
    * - ``nanquantile``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-172]_
+     - ⊘ [#fn-165]_
      - ✓
-     - ⊘ [#fn-173]_
+     - ⊘ [#fn-166]_
    * - ``nanstd``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-174]_
+     - ⊘ [#fn-167]_
      - ✓
-     - ⊘ [#fn-175]_
+     - ⊘ [#fn-168]_
    * - ``nansum``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-176]_
+     - ⊘ [#fn-169]_
    * - ``nanvar``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-177]_
+     - ⊘ [#fn-170]_
      - ✓
-     - ⊘ [#fn-178]_
+     - ⊘ [#fn-171]_
    * - ``ndim``
      - ✓
      - ✓
@@ -1786,7 +1786,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``nonzero``
      - ✓
      - ✓
@@ -1821,14 +1821,14 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-179]_
+     - ⊘ [#fn-172]_
    * - ``percentile``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-180]_
+     - ⊘ [#fn-173]_
      - ✓
-     - ⊘ [#fn-181]_
+     - ⊘ [#fn-174]_
    * - ``positive``
      - ✓
      - ✓
@@ -1840,9 +1840,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-182]_
+     - ⊘ [#fn-175]_
      - ✓
-     - ⊘ [#fn-183]_
+     - ⊘ [#fn-176]_
    * - ``prod``
      - ✓
      - ✓
@@ -1868,44 +1868,44 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-184]_
+     - ⊘ [#fn-177]_
      - ✓
-     - ⊘ [#fn-185]_
+     - ⊘ [#fn-178]_
    * - ``quantile``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-186]_
+     - ⊘ [#fn-179]_
      - ✓
-     - ⊘ [#fn-187]_
+     - ⊘ [#fn-180]_
    * - ``rad2deg``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-188]_
+     - ⊘ [#fn-181]_
    * - ``radians``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-189]_
+     - ⊘ [#fn-182]_
      - ✓
-     - ⊘ [#fn-190]_
+     - ⊘ [#fn-183]_
    * - ``ravel``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-191]_
+     - ⊘ [#fn-184]_
    * - ``real``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-7]_
+     - ✗ [#fn-3]_
    * - ``reciprocal``
      - ✓
      - ✓
@@ -1940,7 +1940,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-192]_
+     - ⊘ [#fn-185]_
    * - ``repeat``
      - ✓
      - ✓
@@ -1966,16 +1966,16 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-193]_
+     - ⊘ [#fn-186]_
      - ✓
-     - ⊘ [#fn-194]_
+     - ⊘ [#fn-187]_
    * - ``rint``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-195]_
+     - ⊘ [#fn-188]_
      - ✓
-     - ⊘ [#fn-196]_
+     - ⊘ [#fn-189]_
    * - ``roll``
      - ✓
      - ✓
@@ -1989,7 +1989,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-197]_
+     - ⊘ [#fn-190]_
    * - ``round``
      - ✓
      - ✓
@@ -2003,7 +2003,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-198]_
+     - ⊘ [#fn-191]_
    * - ``searchsorted``
      - ✓
      - ✓
@@ -2015,9 +2015,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-199]_
+     - ⊘ [#fn-192]_
      - ✓
-     - ⊘ [#fn-200]_
+     - ⊘ [#fn-193]_
    * - ``selu``
      - ✓
      - ✓
@@ -2052,7 +2052,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``silu``
      - ✓
      - ✓
@@ -2073,7 +2073,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-201]_
+     - ⊘ [#fn-194]_
    * - ``sinh``
      - ✓
      - ✓
@@ -2135,8 +2135,8 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-26]_
-     - ⊘ [#fn-27]_
+     - ⊘ [#fn-19]_
+     - ⊘ [#fn-20]_
    * - ``sqrt``
      - ✓
      - ✓
@@ -2162,9 +2162,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-202]_
+     - ⊘ [#fn-195]_
      - ✓
-     - ⊘ [#fn-202]_
+     - ⊘ [#fn-195]_
    * - ``stack``
      - ✓
      - ✓
@@ -2199,7 +2199,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-203]_
+     - ⊘ [#fn-196]_
    * - ``swish``
      - ✓
      - ✓
@@ -2248,14 +2248,14 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-204]_
+     - ⊘ [#fn-197]_
    * - ``transpose``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-205]_
+     - ⊘ [#fn-198]_
      - ✓
-     - ⊘ [#fn-206]_
+     - ⊘ [#fn-199]_
    * - ``tree_ones_like``
      - ✓
      - ✓
@@ -2274,9 +2274,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-207]_
+     - ⊘ [#fn-200]_
      - ✓
-     - ⊘ [#fn-208]_
+     - ⊘ [#fn-201]_
    * - ``tril``
      - ✓
      - ✓
@@ -2288,9 +2288,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-209]_
+     - ⊘ [#fn-202]_
      - ✓
-     - ⊘ [#fn-210]_
+     - ⊘ [#fn-203]_
    * - ``triu``
      - ✓
      - ✓
@@ -2302,16 +2302,16 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-211]_
+     - ⊘ [#fn-204]_
      - ✓
-     - ⊘ [#fn-212]_
+     - ⊘ [#fn-205]_
    * - ``true_divide``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-213]_
+     - ⊘ [#fn-206]_
    * - ``trunc``
      - ✓
      - ✓
@@ -2332,14 +2332,14 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-214]_
+     - ⊘ [#fn-207]_
    * - ``vander``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-215]_
-     - ⊘ [#fn-216]_
+     - ⊘ [#fn-208]_
+     - ⊘ [#fn-209]_
    * - ``var``
      - ✓
      - ✓
@@ -2353,7 +2353,7 @@ dispatcher.  Grouped by source submodule for readability.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-217]_
+     - ⊘ [#fn-210]_
    * - ``vecdot``
      - ✓
      - ✓
@@ -2366,15 +2366,15 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-218]_
-     - ⊘ [#fn-219]_
+     - ⊘ [#fn-211]_
+     - ⊘ [#fn-212]_
    * - ``vstack``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-198]_
+     - ⊘ [#fn-191]_
    * - ``where``
      - ✓
      - ✓
@@ -2487,9 +2487,9 @@ dispatcher.  Grouped by source submodule for readability.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-220]_
+     - ⊘ [#fn-213]_
      - ✓
-     - ⊘ [#fn-206]_
+     - ⊘ [#fn-199]_
    * - ``einreduce``
      - ✓
      - ✓
@@ -2592,98 +2592,98 @@ saiunit.linalg
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-221]_
+     - ⊘ [#fn-214]_
    * - ``cond``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-222]_
-     - ⊘ [#fn-223]_
+     - ⊘ [#fn-215]_
+     - ⊘ [#fn-216]_
    * - ``cross``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-57]_
-     - ⊘ [#fn-58]_
+     - ⊘ [#fn-50]_
+     - ⊘ [#fn-51]_
    * - ``det``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-224]_
-     - ⊘ [#fn-225]_
+     - ⊘ [#fn-217]_
+     - ⊘ [#fn-218]_
    * - ``diagonal``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-70]_
+     - ⊘ [#fn-63]_
    * - ``dot``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-75]_
+     - ⊘ [#fn-68]_
    * - ``eig``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-226]_
-     - ⊘ [#fn-227]_
-     - ⊘ [#fn-228]_
+     - ⊘ [#fn-219]_
+     - ⊘ [#fn-220]_
+     - ⊘ [#fn-221]_
    * - ``eigh``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-229]_
-     - ⊘ [#fn-230]_
-     - ⊘ [#fn-231]_
+     - ⊘ [#fn-222]_
+     - ⊘ [#fn-223]_
+     - ⊘ [#fn-224]_
    * - ``eigvals``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-226]_
-     - ⊘ [#fn-227]_
-     - ⊘ [#fn-228]_
+     - ⊘ [#fn-219]_
+     - ⊘ [#fn-220]_
+     - ⊘ [#fn-221]_
    * - ``eigvalsh``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-229]_
-     - ⊘ [#fn-230]_
-     - ⊘ [#fn-231]_
+     - ⊘ [#fn-222]_
+     - ⊘ [#fn-223]_
+     - ⊘ [#fn-224]_
    * - ``inner``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-115]_
-     - ⊘ [#fn-116]_
+     - ⊘ [#fn-108]_
+     - ⊘ [#fn-109]_
    * - ``inv``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-232]_
+     - ⊘ [#fn-225]_
    * - ``kron``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-130]_
-     - ⊘ [#fn-131]_
+     - ⊘ [#fn-123]_
+     - ⊘ [#fn-124]_
    * - ``lstsq``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-233]_
-     - ⊘ [#fn-234]_
+     - ⊘ [#fn-226]_
+     - ⊘ [#fn-227]_
    * - ``matmul``
      - ✓
      - ✓
@@ -2697,91 +2697,91 @@ saiunit.linalg
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-235]_
+     - ⊘ [#fn-228]_
    * - ``matrix_power``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-141]_
-     - ⊘ [#fn-142]_
+     - ⊘ [#fn-134]_
+     - ⊘ [#fn-135]_
    * - ``matrix_rank``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-236]_
-     - ⊘ [#fn-237]_
+     - ⊘ [#fn-229]_
+     - ⊘ [#fn-230]_
    * - ``matrix_transpose``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-238]_
+     - ⊘ [#fn-231]_
    * - ``multi_dot``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-150]_
-     - ⊘ [#fn-151]_
+     - ⊘ [#fn-143]_
+     - ⊘ [#fn-144]_
    * - ``norm``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-239]_
+     - ⊘ [#fn-232]_
    * - ``outer``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-179]_
+     - ⊘ [#fn-172]_
    * - ``pinv``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-240]_
-     - ⊘ [#fn-241]_
+     - ⊘ [#fn-233]_
+     - ⊘ [#fn-234]_
    * - ``qr``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-234]_
+     - ⊘ [#fn-227]_
    * - ``slogdet``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-242]_
-     - ⊘ [#fn-234]_
+     - ⊘ [#fn-235]_
+     - ⊘ [#fn-227]_
    * - ``solve``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-243]_
+     - ⊘ [#fn-236]_
    * - ``svd``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-244]_
-     - ⊘ [#fn-245]_
-     - ⊘ [#fn-246]_
+     - ⊘ [#fn-237]_
+     - ⊘ [#fn-238]_
+     - ⊘ [#fn-239]_
    * - ``svdvals``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-244]_
-     - ⊘ [#fn-245]_
-     - ⊘ [#fn-246]_
+     - ⊘ [#fn-237]_
+     - ⊘ [#fn-238]_
+     - ⊘ [#fn-239]_
    * - ``tensordot``
      - ✓
      - ✓
@@ -2794,29 +2794,29 @@ saiunit.linalg
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-247]_
-     - ⊘ [#fn-248]_
+     - ⊘ [#fn-240]_
+     - ⊘ [#fn-241]_
    * - ``tensorsolve``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-249]_
-     - ⊘ [#fn-250]_
+     - ⊘ [#fn-242]_
+     - ⊘ [#fn-243]_
    * - ``trace``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-204]_
+     - ⊘ [#fn-197]_
    * - ``vdot``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-217]_
+     - ⊘ [#fn-210]_
    * - ``vecdot``
      - ✓
      - ✓
@@ -2830,7 +2830,7 @@ saiunit.linalg
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-251]_
+     - ⊘ [#fn-244]_
 
 saiunit.fft
 -----------
@@ -2857,112 +2857,112 @@ package's ``_fun_keep_unit_unary`` helper and inherits its dispatch.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-252]_
+     - ⊘ [#fn-245]_
    * - ``fft2``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-253]_
+     - ⊘ [#fn-246]_
    * - ``fftfreq``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-254]_
+     - ⊘ [#fn-247]_
    * - ``fftn``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-255]_
+     - ⊘ [#fn-248]_
    * - ``fftshift``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-256]_
+     - ⊘ [#fn-249]_
    * - ``ifft``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-257]_
+     - ⊘ [#fn-250]_
    * - ``ifft2``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-258]_
+     - ⊘ [#fn-251]_
    * - ``ifftn``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-259]_
+     - ⊘ [#fn-252]_
    * - ``ifftshift``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-260]_
+     - ⊘ [#fn-253]_
    * - ``irfft``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-261]_
+     - ⊘ [#fn-254]_
    * - ``irfft2``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-262]_
+     - ⊘ [#fn-255]_
    * - ``irfftn``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-263]_
+     - ⊘ [#fn-256]_
    * - ``rfft``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-264]_
+     - ⊘ [#fn-257]_
    * - ``rfft2``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-265]_
+     - ⊘ [#fn-258]_
    * - ``rfftfreq``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-254]_
+     - ⊘ [#fn-247]_
    * - ``rfftn``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-266]_
+     - ⊘ [#fn-259]_
 
 Quantity methods
 ----------------
@@ -3027,9 +3027,9 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-3]_
      - ✓
-     - ⊘ [#fn-4]_
+     - ✓
+     - ✓
    * - ``clip``
      - ✓
      - ✓
@@ -3041,79 +3041,79 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-267]_
-     - ⊘ [#fn-268]_
-     - ⊘ [#fn-269]_
+     - ⊘ [#fn-260]_
+     - ⊘ [#fn-261]_
+     - ⊘ [#fn-262]_
    * - ``conj``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``conjugate``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-51]_
+     - ✗ [#fn-44]_
    * - ``copy``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-267]_
-     - ⊘ [#fn-268]_
-     - ⊘ [#fn-269]_
+     - ⊘ [#fn-260]_
+     - ⊘ [#fn-261]_
+     - ⊘ [#fn-262]_
    * - ``cpu``
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
-     - ✗ [#fn-271]_
-     - ✗ [#fn-272]_
+     - ✗ [#fn-263]_
+     - ✗ [#fn-264]_
+     - ✗ [#fn-265]_
    * - ``cross``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-273]_
-     - ⊘ [#fn-274]_
-     - ⊘ [#fn-275]_
+     - ⊘ [#fn-266]_
+     - ⊘ [#fn-267]_
+     - ⊘ [#fn-268]_
    * - ``cuda``
-     - ⊘ [#fn-276]_
-     - ⊘ [#fn-276]_
+     - ⊘ [#fn-269]_
+     - ⊘ [#fn-269]_
      - ?
-     - ⊘ [#fn-276]_
-     - ⊘ [#fn-276]_
-     - ⊘ [#fn-276]_
+     - ⊘ [#fn-269]_
+     - ⊘ [#fn-269]_
+     - ⊘ [#fn-269]_
    * - ``cumprod``
-     - ⊘ [#fn-277]_
-     - ⊘ [#fn-277]_
+     - ⊘ [#fn-270]_
+     - ⊘ [#fn-270]_
      - ?
-     - ⊘ [#fn-277]_
-     - ⊘ [#fn-277]_
-     - ⊘ [#fn-277]_
+     - ⊘ [#fn-270]_
+     - ⊘ [#fn-270]_
+     - ⊘ [#fn-270]_
    * - ``cumsum``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-278]_
+     - ⊘ [#fn-271]_
      - ✓
-     - ⊘ [#fn-60]_
+     - ⊘ [#fn-53]_
    * - ``diagonal``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-279]_
+     - ⊘ [#fn-272]_
      - ✓
-     - ⊘ [#fn-280]_
+     - ⊘ [#fn-273]_
    * - ``dot``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-281]_
+     - ⊘ [#fn-274]_
    * - ``double``
      - ✓
      - ✓
@@ -3146,9 +3146,9 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
-     - ✗ [#fn-282]_
-     - ✗ [#fn-283]_
+     - ✗ [#fn-263]_
+     - ✗ [#fn-275]_
+     - ✗ [#fn-276]_
    * - ``flatten``
      - ✓
      - ✓
@@ -3168,7 +3168,7 @@ object does not expose ``.item()``.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-284]_
+     - ⊘ [#fn-277]_
      - ✓
    * - ``has_same_unit``
      - ✓
@@ -3189,8 +3189,8 @@ object does not expose ``.item()``.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-285]_
-     - ⊘ [#fn-285]_
+     - ⊘ [#fn-278]_
+     - ⊘ [#fn-278]_
    * - ``max``
      - ✓
      - ✓
@@ -3213,19 +3213,19 @@ object does not expose ``.item()``.
      - ✓
      - ✓
    * - ``nancumprod``
-     - ⊘ [#fn-286]_
-     - ⊘ [#fn-286]_
+     - ⊘ [#fn-279]_
+     - ⊘ [#fn-279]_
      - ?
-     - ⊘ [#fn-286]_
-     - ⊘ [#fn-286]_
-     - ⊘ [#fn-286]_
+     - ⊘ [#fn-279]_
+     - ⊘ [#fn-279]_
+     - ⊘ [#fn-279]_
    * - ``nanprod``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-170]_
+     - ⊘ [#fn-163]_
      - ✓
-     - ⊘ [#fn-171]_
+     - ⊘ [#fn-164]_
    * - ``nonzero``
      - ✓
      - ✓
@@ -3239,7 +3239,7 @@ object does not expose ``.item()``.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-287]_
+     - ⊘ [#fn-280]_
    * - ``pow``
      - ✓
      - ✓
@@ -3258,23 +3258,23 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-184]_
+     - ⊘ [#fn-177]_
      - ✓
-     - ⊘ [#fn-185]_
+     - ⊘ [#fn-178]_
    * - ``put``
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
-     - ⊘ [#fn-288]_
-     - ✗ [#fn-283]_
+     - ✗ [#fn-263]_
+     - ⊘ [#fn-281]_
+     - ✗ [#fn-276]_
    * - ``ravel``
      - ✓
      - ✓
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-191]_
+     - ⊘ [#fn-184]_
    * - ``repeat``
      - ✓
      - ✓
@@ -3300,9 +3300,9 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
+     - ✗ [#fn-263]_
+     - ✗ [#fn-275]_
      - ✗ [#fn-282]_
-     - ✗ [#fn-289]_
    * - ``round``
      - ✓
      - ✓
@@ -3315,43 +3315,43 @@ object does not expose ``.item()``.
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-290]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-283]_
+     - ✗ [#fn-276]_
    * - ``scatter_div``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-291]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-284]_
+     - ✗ [#fn-276]_
    * - ``scatter_max``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-292]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-285]_
+     - ✗ [#fn-276]_
    * - ``scatter_min``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-293]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-286]_
+     - ✗ [#fn-276]_
    * - ``scatter_mul``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-294]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-287]_
+     - ✗ [#fn-276]_
    * - ``scatter_sub``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⊘ [#fn-290]_
-     - ✗ [#fn-283]_
+     - ⊘ [#fn-283]_
+     - ✗ [#fn-276]_
    * - ``searchsorted``
      - ✓
      - ✓
@@ -3363,23 +3363,23 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
-     - ✗ [#fn-282]_
-     - ✗ [#fn-272]_
+     - ✗ [#fn-263]_
+     - ✗ [#fn-275]_
+     - ✗ [#fn-265]_
    * - ``split``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-295]_
+     - ⊘ [#fn-288]_
      - ✓
-     - ✗ [#fn-296]_
+     - ✗ [#fn-289]_
    * - ``squeeze``
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-297]_
+     - ✗ [#fn-290]_
      - ✓
-     - ✗ [#fn-298]_
+     - ✗ [#fn-291]_
    * - ``std``
      - ✓
      - ✓
@@ -3400,21 +3400,21 @@ object does not expose ``.item()``.
      - ?
      - ✓
      - ✓
-     - ⊘ [#fn-299]_
+     - ⊘ [#fn-292]_
    * - ``take``
      - ✓
      - ✓
      - ?
      - ✓
-     - ✗ [#fn-300]_
+     - ✗ [#fn-293]_
      - ✓
    * - ``tile``
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-301]_
+     - ✗ [#fn-294]_
      - ✓
-     - ✗ [#fn-302]_
+     - ✗ [#fn-295]_
    * - ``to``
      - ✓
      - ✓
@@ -3423,19 +3423,19 @@ object does not expose ``.item()``.
      - ✓
      - ✓
    * - ``to_cupy``
-     - ⊘ [#fn-303]_
-     - ⊘ [#fn-303]_
+     - ⊘ [#fn-296]_
+     - ⊘ [#fn-296]_
      - ?
-     - ⊘ [#fn-303]_
-     - ⊘ [#fn-303]_
-     - ⊘ [#fn-303]_
+     - ⊘ [#fn-296]_
+     - ⊘ [#fn-296]_
+     - ⊘ [#fn-296]_
    * - ``to_dask``
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
+     - ✗ [#fn-263]_
      - ✓
-     - ✗ [#fn-272]_
+     - ✗ [#fn-265]_
    * - ``to_decimal``
      - ✓
      - ✓
@@ -3449,13 +3449,13 @@ object does not expose ``.item()``.
      - ?
      - ✓
      - ✓
-     - ✗ [#fn-304]_
+     - ✗ [#fn-297]_
    * - ``to_ndonnx``
      - ✓
-     - ⊘ [#fn-305]_
+     - ⊘ [#fn-298]_
      - ?
-     - ⊘ [#fn-306]_
-     - ⊘ [#fn-307]_
+     - ⊘ [#fn-299]_
+     - ⊘ [#fn-300]_
      - ✓
    * - ``to_numpy``
      - ✓
@@ -3469,29 +3469,29 @@ object does not expose ``.item()``.
      - ✓
      - ?
      - ✓
-     - ✗ [#fn-308]_
-     - ✗ [#fn-309]_
+     - ✗ [#fn-301]_
+     - ✗ [#fn-302]_
    * - ``tolist``
      - ✓
      - ✓
      - ?
      - ✓
-     - ⚠ [#fn-310]_
-     - ⊘ [#fn-311]_
+     - ⚠ [#fn-303]_
+     - ⊘ [#fn-304]_
    * - ``trace``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-312]_
+     - ⊘ [#fn-305]_
      - ✓
-     - ⊘ [#fn-313]_
+     - ⊘ [#fn-306]_
    * - ``transpose``
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-205]_
+     - ⊘ [#fn-198]_
      - ✓
-     - ⊘ [#fn-314]_
+     - ⊘ [#fn-307]_
    * - ``tree_flatten``
      - ✓
      - ✓
@@ -3517,9 +3517,9 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ✗ [#fn-270]_
-     - ✗ [#fn-282]_
-     - ✗ [#fn-272]_
+     - ✗ [#fn-263]_
+     - ✗ [#fn-275]_
+     - ✗ [#fn-265]_
    * - ``var``
      - ✓
      - ✓
@@ -3531,9 +3531,9 @@ object does not expose ``.item()``.
      - ✓
      - ✓
      - ?
-     - ⊘ [#fn-315]_
+     - ⊘ [#fn-308]_
      - ✓
-     - ⊘ [#fn-316]_
+     - ⊘ [#fn-309]_
    * - ``with_unit``
      - ✓
      - ✓
@@ -3606,319 +3606,312 @@ Footnotes
 ---------
 
 
-.. [#fn-1] AttributeError: module 'ndonnx' has no attribute `tril_indices`
-.. [#fn-2] AttributeError: module 'ndonnx' has no attribute `triu_indices`
-.. [#fn-3] TypeError: to() received an invalid combination of arguments - got (copy=bool, dtype=type, ), but expected one of: \* (torch.device device = None, torch.dtype dtype = None, bool non_blocking = False...
-.. [#fn-4] AttributeError: type object 'numpy.float32' has no attribute '__ndx_cast_from__'
-.. [#fn-5] AttributeError: saiunit: backend 'ndonnx' has no operation 'absolute'
-.. [#fn-6] AttributeError: module 'ndonnx' has no attribute `allclose`
-.. [#fn-7] ValueError: 'complex128' does not have a corresponding ndonnx data type
-.. [#fn-8] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'append'
-.. [#fn-9] AttributeError: saiunit: backend 'ndonnx' has no operation 'append'
-.. [#fn-10] TypeError: '>' not supported between instances of 'NoneType' and 'int'
-.. [#fn-11] TypeError: An error occurred while calling the arange method registered to the numpy backend. Original Message: unsupported operand type(s) for /: 'int' and 'NoneType'
-.. [#fn-12] ValueError: 'arange' is not implemented for the provided inputs
-.. [#fn-13] AttributeError: saiunit: backend 'ndonnx' has no operation 'arccos'
-.. [#fn-14] AttributeError: saiunit: backend 'ndonnx' has no operation 'arccosh'
-.. [#fn-15] AttributeError: saiunit: backend 'ndonnx' has no operation 'arcsin'
-.. [#fn-16] AttributeError: saiunit: backend 'ndonnx' has no operation 'arcsinh'
-.. [#fn-17] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctan'
-.. [#fn-18] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctan2'
-.. [#fn-19] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctanh'
-.. [#fn-20] AttributeError: saiunit: backend 'ndonnx' has no operation 'argwhere'
-.. [#fn-21] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'around'
-.. [#fn-22] AttributeError: saiunit: backend 'ndonnx' has no operation 'around'
-.. [#fn-23] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'array_equal'
-.. [#fn-24] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'array_equal'
-.. [#fn-25] AttributeError: saiunit: backend 'ndonnx' has no operation 'array_equal'
-.. [#fn-26] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'split'
-.. [#fn-27] AttributeError: saiunit: backend 'ndonnx' has no operation 'split'
-.. [#fn-28] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_1d'
-.. [#fn-29] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_2d'
-.. [#fn-30] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_3d'
-.. [#fn-31] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'average'
-.. [#fn-32] AttributeError: saiunit: backend 'ndonnx' has no operation 'average'
-.. [#fn-33] AttributeError: saiunit: backend 'ndonnx' has no operation 'bincount'
-.. [#fn-34] AttributeError: saiunit: backend 'ndonnx' has no operation 'bitwise_not'
-.. [#fn-35] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'block'
-.. [#fn-36] AttributeError: saiunit: backend 'ndonnx' has no operation 'block'
-.. [#fn-37] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'cbrt'
-.. [#fn-38] AttributeError: saiunit: backend 'ndonnx' has no operation 'cbrt'
-.. [#fn-39] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'choose'
-.. [#fn-40] AttributeError: saiunit: backend 'ndonnx' has no operation 'choose'
-.. [#fn-41] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'column_stack'
-.. [#fn-42] AttributeError: saiunit: backend 'ndonnx' has no operation 'column_stack'
-.. [#fn-43] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'compress'
-.. [#fn-44] AttributeError: saiunit: backend 'ndonnx' has no operation 'compress'
-.. [#fn-45] AttributeError: saiunit: backend 'ndonnx' has no operation 'concatenate'
-.. [#fn-46] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'conjugate'
-.. [#fn-47] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'conjugate'
-.. [#fn-48] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'convolve'
-.. [#fn-49] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'convolve'
-.. [#fn-50] AttributeError: saiunit: backend 'ndonnx' has no operation 'convolve'
-.. [#fn-51] NotImplementedError:
-.. [#fn-52] AttributeError: saiunit: backend 'ndonnx' has no operation 'corrcoef'
-.. [#fn-53] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'correlate'
-.. [#fn-54] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'correlate'
-.. [#fn-55] AttributeError: saiunit: backend 'ndonnx' has no operation 'correlate'
-.. [#fn-56] AttributeError: saiunit: backend 'ndonnx' has no operation 'cov'
-.. [#fn-57] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'cross'
-.. [#fn-58] AttributeError: saiunit: backend 'ndonnx' has no operation 'cross'
-.. [#fn-59] AttributeError: saiunit: backend 'ndonnx' has no operation 'cumprod'
-.. [#fn-60] AttributeError: saiunit: backend 'ndonnx' has no operation 'cumsum'
-.. [#fn-61] AttributeError: saiunit: backend 'ndonnx' has no operation 'deg2rad'
-.. [#fn-62] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'degrees'
-.. [#fn-63] AttributeError: saiunit: backend 'ndonnx' has no operation 'degrees'
-.. [#fn-64] AttributeError: module 'ndonnx' has no attribute `diag`
-.. [#fn-65] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'diag_indices_from'
-.. [#fn-66] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'diag_indices_from'
-.. [#fn-67] AttributeError: saiunit: backend 'ndonnx' has no operation 'diag_indices_from'
-.. [#fn-68] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'diagflat'
-.. [#fn-69] AttributeError: saiunit: backend 'ndonnx' has no operation 'diagflat'
-.. [#fn-70] AttributeError: saiunit: backend 'ndonnx' has no operation 'diagonal'
-.. [#fn-71] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'digitize'
-.. [#fn-72] AttributeError: saiunit: backend 'ndonnx' has no operation 'digitize'
-.. [#fn-73] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'divmod'
-.. [#fn-74] AttributeError: saiunit: backend 'ndonnx' has no operation 'divmod'
-.. [#fn-75] AttributeError: saiunit: backend 'ndonnx' has no operation 'dot'
-.. [#fn-76] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'dsplit'
-.. [#fn-77] AttributeError: saiunit: backend 'ndonnx' has no operation 'dsplit'
-.. [#fn-78] AttributeError: saiunit: backend 'ndonnx' has no operation 'dstack'
-.. [#fn-79] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'ediff1d'
-.. [#fn-80] AttributeError: saiunit: backend 'ndonnx' has no operation 'ediff1d'
-.. [#fn-81] TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2] The error occurred while tracing the function _einsum at /mnt/d/codes/...
-.. [#fn-82] TypeError: Error interpreting argument to <function _einsum at 0x...> as an abstract array. The problematic value is of type <class 'torch.Tensor'> and was passed to the function at path operands[0...
-.. [#fn-83] TypeError: Error interpreting argument to <function _einsum at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path ope...
-.. [#fn-84] AttributeError: saiunit: backend 'ndonnx' has no operation 'exp2'
-.. [#fn-85] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'extract'
-.. [#fn-86] AttributeError: saiunit: backend 'ndonnx' has no operation 'extract'
-.. [#fn-87] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'fabs'
-.. [#fn-88] AttributeError: saiunit: backend 'ndonnx' has no operation 'fabs'
-.. [#fn-89] AttributeError: module 'array_api_compat.torch' has no attribute 'fill_diagonal'
-.. [#fn-90] AttributeError: module 'array_api_compat.dask.array' has no attribute 'fill_diagonal'
-.. [#fn-91] AttributeError: module 'ndonnx' has no attribute `fill_diagonal`
-.. [#fn-92] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'flatnonzero'
-.. [#fn-93] AttributeError: saiunit: backend 'ndonnx' has no operation 'flatnonzero'
-.. [#fn-94] AttributeError: saiunit: backend 'ndonnx' has no operation 'fliplr'
-.. [#fn-95] AttributeError: saiunit: backend 'ndonnx' has no operation 'flipud'
-.. [#fn-96] AttributeError: saiunit: backend 'ndonnx' has no operation 'float_power'
-.. [#fn-97] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmax'
-.. [#fn-98] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmin'
-.. [#fn-99] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmod'
-.. [#fn-100] AttributeError: saiunit: backend 'ndonnx' has no operation 'frexp'
-.. [#fn-101] NotImplementedError: Don't yet support nd fancy indexing
-.. [#fn-102] AttributeError: 'Array' object has no attribute 'reshape'
-.. [#fn-103] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'gcd'
-.. [#fn-104] AttributeError: saiunit: backend 'ndonnx' has no operation 'gcd'
-.. [#fn-105] AttributeError: module 'ndonnx' has no attribute `gradient`
-.. [#fn-106] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'heaviside'
-.. [#fn-107] AttributeError: saiunit: backend 'ndonnx' has no operation 'heaviside'
-.. [#fn-108] AttributeError: saiunit: backend 'ndonnx' has no operation 'histogram'
-.. [#fn-109] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'hsplit'
-.. [#fn-110] AttributeError: saiunit: backend 'ndonnx' has no operation 'hsplit'
-.. [#fn-111] AttributeError: saiunit: backend 'ndonnx' has no operation 'hstack'
-.. [#fn-112] AttributeError: module 'array_api_compat.torch' has no attribute 'identity'
-.. [#fn-113] AttributeError: module 'array_api_compat.dask.array' has no attribute 'identity'
-.. [#fn-114] AttributeError: module 'ndonnx' has no attribute `identity`
-.. [#fn-115] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'inner'
-.. [#fn-116] AttributeError: saiunit: backend 'ndonnx' has no operation 'inner'
-.. [#fn-117] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'interp'
-.. [#fn-118] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'interp'
-.. [#fn-119] AttributeError: saiunit: backend 'ndonnx' has no operation 'interp'
-.. [#fn-120] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'intersect1d'
-.. [#fn-121] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'intersect1d'
-.. [#fn-122] AttributeError: saiunit: backend 'ndonnx' has no operation 'intersect1d'
-.. [#fn-123] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'invert'
-.. [#fn-124] AttributeError: saiunit: backend 'ndonnx' has no operation 'invert'
-.. [#fn-125] AttributeError: saiunit: backend 'ndonnx' has no operation 'isclose'
-.. [#fn-126] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'iscomplexobj'
-.. [#fn-127] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'iscomplexobj'
-.. [#fn-128] AttributeError: saiunit: backend 'ndonnx' has no operation 'iscomplexobj'
-.. [#fn-129] AttributeError: module 'ndonnx' has no attribute `isreal`
-.. [#fn-130] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'kron'
-.. [#fn-131] AttributeError: saiunit: backend 'ndonnx' has no operation 'kron'
-.. [#fn-132] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'lcm'
-.. [#fn-133] AttributeError: saiunit: backend 'ndonnx' has no operation 'lcm'
-.. [#fn-134] AttributeError: saiunit: backend 'ndonnx' has no operation 'ldexp'
-.. [#fn-135] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'left_shift'
-.. [#fn-136] AttributeError: saiunit: backend 'ndonnx' has no operation 'left_shift'
-.. [#fn-137] AttributeError: saiunit: backend 'ndonnx' has no operation 'logaddexp2'
-.. [#fn-138] TypeError: logspace() received an invalid combination of arguments - got (float, float), but expected one of: \* (Tensor start, Tensor end, int steps, float base = 10.0, \*, Tensor out = None, torch....
-.. [#fn-139] AttributeError: module 'array_api_compat.dask.array' has no attribute 'logspace'
-.. [#fn-140] AttributeError: module 'ndonnx' has no attribute `logspace`
-.. [#fn-141] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.matrix_power'
-.. [#fn-142] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_power'
-.. [#fn-143] NotImplementedError: The da.median function only works along an axis. The full algorithm is difficult to do in parallel
-.. [#fn-144] AttributeError: saiunit: backend 'ndonnx' has no operation 'median'
-.. [#fn-145] AttributeError: 'list' object has no attribute 'ndim'
-.. [#fn-146] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'mod'
-.. [#fn-147] AttributeError: saiunit: backend 'ndonnx' has no operation 'mod'
-.. [#fn-148] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'modf'
-.. [#fn-149] AttributeError: saiunit: backend 'ndonnx' has no operation 'modf'
-.. [#fn-150] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.multi_dot'
-.. [#fn-151] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.multi_dot'
-.. [#fn-152] AttributeError: saiunit: backend 'ndonnx' has no operation 'nan_to_num'
-.. [#fn-153] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanargmax'
-.. [#fn-154] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanargmax'
-.. [#fn-155] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanargmin'
-.. [#fn-156] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanargmin'
-.. [#fn-157] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nancumprod'
-.. [#fn-158] AttributeError: saiunit: backend 'ndonnx' has no operation 'nancumprod'
-.. [#fn-159] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nancumsum'
-.. [#fn-160] AttributeError: saiunit: backend 'ndonnx' has no operation 'nancumsum'
-.. [#fn-161] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanmax'
-.. [#fn-162] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmax'
-.. [#fn-163] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmean'
-.. [#fn-164] NotImplementedError: The da.nanmedian function only works along an axis or a subset of axes. The full algorithm is difficult to do in parallel
-.. [#fn-165] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmedian'
-.. [#fn-166] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanmin'
-.. [#fn-167] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmin'
-.. [#fn-168] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanpercentile'
-.. [#fn-169] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanpercentile'
-.. [#fn-170] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanprod'
-.. [#fn-171] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanprod'
-.. [#fn-172] TypeError: nanquantile() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, Tensor q, int dim = None, bool keepdim = False, \*, str interpolation = "l...
-.. [#fn-173] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanquantile'
-.. [#fn-174] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanstd'
-.. [#fn-175] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanstd'
-.. [#fn-176] AttributeError: saiunit: backend 'ndonnx' has no operation 'nansum'
-.. [#fn-177] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanvar'
-.. [#fn-178] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanvar'
-.. [#fn-179] AttributeError: saiunit: backend 'ndonnx' has no operation 'outer'
-.. [#fn-180] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'percentile'
-.. [#fn-181] AttributeError: saiunit: backend 'ndonnx' has no operation 'percentile'
-.. [#fn-182] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'power'
-.. [#fn-183] AttributeError: saiunit: backend 'ndonnx' has no operation 'power'
-.. [#fn-184] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'ptp'
-.. [#fn-185] AttributeError: saiunit: backend 'ndonnx' has no operation 'ptp'
-.. [#fn-186] TypeError: quantile() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, Tensor q, int dim = None, bool keepdim = False, \*, str interpolation = "line...
-.. [#fn-187] AttributeError: saiunit: backend 'ndonnx' has no operation 'quantile'
-.. [#fn-188] AttributeError: saiunit: backend 'ndonnx' has no operation 'rad2deg'
-.. [#fn-189] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'radians'
-.. [#fn-190] AttributeError: saiunit: backend 'ndonnx' has no operation 'radians'
-.. [#fn-191] AttributeError: saiunit: backend 'ndonnx' has no operation 'ravel'
-.. [#fn-192] AttributeError: type object 'bool' has no attribute '__ndx_create__'
-.. [#fn-193] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'right_shift'
-.. [#fn-194] AttributeError: saiunit: backend 'ndonnx' has no operation 'right_shift'
-.. [#fn-195] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'rint'
-.. [#fn-196] AttributeError: saiunit: backend 'ndonnx' has no operation 'rint'
-.. [#fn-197] AttributeError: saiunit: backend 'ndonnx' has no operation 'rot90'
-.. [#fn-198] AttributeError: saiunit: backend 'ndonnx' has no operation 'vstack'
-.. [#fn-199] TypeError: select() received an invalid combination of arguments - got (list, list), but expected one of: \* (Tensor input, name dim, int index) \* (Tensor input, int dim, int index)
-.. [#fn-200] AttributeError: saiunit: backend 'ndonnx' has no operation 'select'
-.. [#fn-201] AttributeError: saiunit: backend 'ndonnx' has no operation 'sinc'
-.. [#fn-202] TypeError: squeeze() missing 1 required positional argument: 'axis'
-.. [#fn-203] AttributeError: saiunit: backend 'ndonnx' has no operation 'swapaxes'
-.. [#fn-204] AttributeError: saiunit: backend 'ndonnx' has no operation 'trace'
-.. [#fn-205] TypeError: transpose() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, int dim0, int dim1) \* (Tensor input, name dim0, name dim1)
-.. [#fn-206] AttributeError: saiunit: backend 'ndonnx' has no operation 'transpose'
-.. [#fn-207] AttributeError: module 'array_api_compat.torch' has no attribute 'tri'
-.. [#fn-208] AttributeError: module 'ndonnx' has no attribute `tri`
-.. [#fn-209] AttributeError: module 'array_api_compat.torch' has no attribute 'tril_indices_from'
-.. [#fn-210] AttributeError: module 'ndonnx' has no attribute `tril_indices_from`
-.. [#fn-211] AttributeError: module 'array_api_compat.torch' has no attribute 'triu_indices_from'
-.. [#fn-212] AttributeError: module 'ndonnx' has no attribute `triu_indices_from`
-.. [#fn-213] AttributeError: saiunit: backend 'ndonnx' has no operation 'true_divide'
-.. [#fn-214] AttributeError: saiunit: backend 'ndonnx' has no operation 'unique'
-.. [#fn-215] AttributeError: module 'array_api_compat.dask.array' has no attribute 'vander'
-.. [#fn-216] AttributeError: module 'ndonnx' has no attribute `vander`
-.. [#fn-217] AttributeError: saiunit: backend 'ndonnx' has no operation 'vdot'
-.. [#fn-218] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'vsplit'
-.. [#fn-219] AttributeError: saiunit: backend 'ndonnx' has no operation 'vsplit'
-.. [#fn-220] TypeError: transpose() received an invalid combination of arguments - got (Tensor, list), but expected one of: \* (Tensor input, int dim0, int dim1) \* (Tensor input, name dim0, name dim1)
-.. [#fn-221] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.cholesky'
-.. [#fn-222] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.cond'
-.. [#fn-223] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.cond'
-.. [#fn-224] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.det'
-.. [#fn-225] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.det'
-.. [#fn-226] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to eig at position 0.
-.. [#fn-227] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to eig at position 0.
-.. [#fn-228] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to eig at position 0.
-.. [#fn-229] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to transpose at position 0.
-.. [#fn-230] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to transpose at position 0.
-.. [#fn-231] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to transpose at position 0.
-.. [#fn-232] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.inv'
-.. [#fn-233] TypeError: lstsq() got an unexpected keyword argument 'rcond'
-.. [#fn-234] AttributeError: module 'ndonnx' has no attribute `linalg`
-.. [#fn-235] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_norm'
-.. [#fn-236] TypeError: svd() got an unexpected keyword argument 'compute_uv'
-.. [#fn-237] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_rank'
-.. [#fn-238] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_transpose'
-.. [#fn-239] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.norm'
-.. [#fn-240] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.pinv'
-.. [#fn-241] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.pinv'
-.. [#fn-242] AttributeError: module 'array_api_compat.dask.array.linalg' has no attribute 'slogdet'
-.. [#fn-243] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.solve'
-.. [#fn-244] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to svd at position 0.
-.. [#fn-245] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to svd at position 0.
-.. [#fn-246] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to svd at position 0.
-.. [#fn-247] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.tensorinv'
-.. [#fn-248] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.tensorinv'
-.. [#fn-249] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.tensorsolve'
-.. [#fn-250] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.tensorsolve'
-.. [#fn-251] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.vector_norm'
-.. [#fn-252] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fft'
-.. [#fn-253] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fft2'
-.. [#fn-254] AttributeError: module 'ndonnx' has no attribute `fft`
-.. [#fn-255] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fftn'
-.. [#fn-256] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fftshift'
-.. [#fn-257] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifft'
-.. [#fn-258] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifft2'
-.. [#fn-259] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifftn'
-.. [#fn-260] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifftshift'
-.. [#fn-261] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfft'
-.. [#fn-262] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfft2'
-.. [#fn-263] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfftn'
-.. [#fn-264] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfft'
-.. [#fn-265] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfft2'
-.. [#fn-266] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfftn'
-.. [#fn-267] AttributeError: module 'array_api_compat.torch' has no attribute 'copy'
-.. [#fn-268] AttributeError: module 'array_api_compat.dask.array' has no attribute 'copy'
-.. [#fn-269] AttributeError: module 'ndonnx' has no attribute `copy`
-.. [#fn-270] TypeError: Cannot interpret 'torch.float64' as a data type
-.. [#fn-271] InvalidInputException: Argument 'dask.array<array, shape=(3,), dtype=float64, chunksize=(3,), chunktype=numpy.ndarray>' of type <class 'dask.array.core.Array'> is not a valid JAX type.
-.. [#fn-272] TypeError: Cannot interpret 'Float64' as a data type
-.. [#fn-273] TypeError: cross() got an unexpected keyword argument 'axisa'
-.. [#fn-274] AttributeError: module 'array_api_compat.dask.array' has no attribute 'cross'
-.. [#fn-275] AttributeError: module 'ndonnx' has no attribute `cross`
-.. [#fn-276] RuntimeError: Unknown backend cuda. Available backends are ['cpu']
-.. [#fn-277] TypeError: cumprod is not supported for quantities with units (has unit m), because each element of the result would have a different unit exponent. Use .prod() for a single reduction, or convert t...
-.. [#fn-278] TypeError: cumsum() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, int dim, \*, torch.dtype dtype = None, Tensor out = None) \* (Tensor input, name...
-.. [#fn-279] TypeError: diagonal() received an invalid combination of arguments - got (Tensor, axis1=int, axis2=int, offset=int), but expected one of: \* (Tensor input, \*, name outdim, name dim1, name dim2, int ...
-.. [#fn-280] AttributeError: module 'ndonnx' has no attribute `diagonal`
-.. [#fn-281] TypeError: Error interpreting argument to <function dot at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path a. This...
-.. [#fn-282] ValueError: The dtype of the original data is float32, while we got float64.
-.. [#fn-283] BackendError: Quantity.at indexed-update is not supported on the ndonnx backend. Call .to_numpy() (or another concrete backend) on the input first.
-.. [#fn-284] AttributeError: module 'array_api_compat.dask.array' has no attribute 'float16'
-.. [#fn-285] AttributeError: 'Array' object has no attribute 'item'
-.. [#fn-286] TypeError: nancumprod is not supported for quantities with units (has unit m), because each element of the result would have a different unit exponent. Use .nanprod() for a single reduction, or con...
-.. [#fn-287] TypeError: Error interpreting argument to <function outer at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path a. Th...
-.. [#fn-288] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'set'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
-.. [#fn-289] ValueError: found array with object dtype but it contains non-string elements
-.. [#fn-290] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'add'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
-.. [#fn-291] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'divide'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy()...
-.. [#fn-292] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'max'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
-.. [#fn-293] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'min'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
-.. [#fn-294] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'multiply'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy...
-.. [#fn-295] TypeError: split() got an unexpected keyword argument 'axis'
-.. [#fn-296] AxisError: axis1: axis 0 is out of bounds for array of dimension 0
-.. [#fn-297] TypeError: 'NoneType' object is not iterable
-.. [#fn-298] TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
-.. [#fn-299] AttributeError: module 'ndonnx' has no attribute `swapaxes`
-.. [#fn-300] TypeError: Axis value must be an integer, got None
-.. [#fn-301] TypeError: tile(): argument 'dims' (position 2) must be tuple of ints, not int
-.. [#fn-302] TypeError: object of type 'int' has no len()
-.. [#fn-303] cupy backend not installed
-.. [#fn-304] TypeError: Value 'array(data: [1.0, 2.0, 3.0], dtype=float64)' with dtype object is not a valid JAX array type. Only arrays of numeric types are supported by JAX.
-.. [#fn-305] ValueError: unable to infer dtype from `[1. 2. 3.]`
-.. [#fn-306] ValueError: unable to infer dtype from `tensor([1., 2., 3.], dtype=torch.float64)`
-.. [#fn-307] ValueError: unable to infer dtype from `dask.array<array, shape=(3,), dtype=float64, chunksize=(3,), chunktype=numpy.ndarray>`
-.. [#fn-308] TypeError: len() of unsized object
-.. [#fn-309] ValueError: ONNX provides no control over the used device
-.. [#fn-310] BackendError (expected): Quantity.tolist() would materialize a dask-backed Quantity. Call `q.mantissa.compute()` first.
-.. [#fn-311] AttributeError: 'Array' object has no attribute 'tolist'
-.. [#fn-312] TypeError: trace() got an unexpected keyword argument 'offset'
-.. [#fn-313] AttributeError: module 'ndonnx' has no attribute `trace`
-.. [#fn-314] AttributeError: module 'ndonnx' has no attribute `transpose`
-.. [#fn-315] TypeError: view() received an invalid combination of arguments - got (type), but expected one of: \* (torch.dtype dtype) didn't match because some of the arguments have invalid types: (!type!) \* (tu...
-.. [#fn-316] AttributeError: 'Array' object has no attribute 'view'
+.. [#fn-1] AttributeError: saiunit: backend 'ndonnx' has no operation 'absolute'
+.. [#fn-2] AttributeError: module 'ndonnx' has no attribute `allclose`
+.. [#fn-3] ValueError: 'complex128' does not have a corresponding ndonnx data type
+.. [#fn-4] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'append'
+.. [#fn-5] AttributeError: saiunit: backend 'ndonnx' has no operation 'append'
+.. [#fn-6] AttributeError: saiunit: backend 'ndonnx' has no operation 'arccos'
+.. [#fn-7] AttributeError: saiunit: backend 'ndonnx' has no operation 'arccosh'
+.. [#fn-8] AttributeError: saiunit: backend 'ndonnx' has no operation 'arcsin'
+.. [#fn-9] AttributeError: saiunit: backend 'ndonnx' has no operation 'arcsinh'
+.. [#fn-10] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctan'
+.. [#fn-11] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctan2'
+.. [#fn-12] AttributeError: saiunit: backend 'ndonnx' has no operation 'arctanh'
+.. [#fn-13] AttributeError: saiunit: backend 'ndonnx' has no operation 'argwhere'
+.. [#fn-14] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'around'
+.. [#fn-15] AttributeError: saiunit: backend 'ndonnx' has no operation 'around'
+.. [#fn-16] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'array_equal'
+.. [#fn-17] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'array_equal'
+.. [#fn-18] AttributeError: saiunit: backend 'ndonnx' has no operation 'array_equal'
+.. [#fn-19] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'split'
+.. [#fn-20] AttributeError: saiunit: backend 'ndonnx' has no operation 'split'
+.. [#fn-21] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_1d'
+.. [#fn-22] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_2d'
+.. [#fn-23] AttributeError: saiunit: backend 'ndonnx' has no operation 'atleast_3d'
+.. [#fn-24] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'average'
+.. [#fn-25] AttributeError: saiunit: backend 'ndonnx' has no operation 'average'
+.. [#fn-26] AttributeError: saiunit: backend 'ndonnx' has no operation 'bincount'
+.. [#fn-27] AttributeError: saiunit: backend 'ndonnx' has no operation 'bitwise_not'
+.. [#fn-28] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'block'
+.. [#fn-29] AttributeError: saiunit: backend 'ndonnx' has no operation 'block'
+.. [#fn-30] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'cbrt'
+.. [#fn-31] AttributeError: saiunit: backend 'ndonnx' has no operation 'cbrt'
+.. [#fn-32] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'choose'
+.. [#fn-33] AttributeError: saiunit: backend 'ndonnx' has no operation 'choose'
+.. [#fn-34] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'column_stack'
+.. [#fn-35] AttributeError: saiunit: backend 'ndonnx' has no operation 'column_stack'
+.. [#fn-36] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'compress'
+.. [#fn-37] AttributeError: saiunit: backend 'ndonnx' has no operation 'compress'
+.. [#fn-38] AttributeError: saiunit: backend 'ndonnx' has no operation 'concatenate'
+.. [#fn-39] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'conjugate'
+.. [#fn-40] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'conjugate'
+.. [#fn-41] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'convolve'
+.. [#fn-42] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'convolve'
+.. [#fn-43] AttributeError: saiunit: backend 'ndonnx' has no operation 'convolve'
+.. [#fn-44] NotImplementedError:
+.. [#fn-45] AttributeError: saiunit: backend 'ndonnx' has no operation 'corrcoef'
+.. [#fn-46] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'correlate'
+.. [#fn-47] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'correlate'
+.. [#fn-48] AttributeError: saiunit: backend 'ndonnx' has no operation 'correlate'
+.. [#fn-49] AttributeError: saiunit: backend 'ndonnx' has no operation 'cov'
+.. [#fn-50] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'cross'
+.. [#fn-51] AttributeError: saiunit: backend 'ndonnx' has no operation 'cross'
+.. [#fn-52] AttributeError: saiunit: backend 'ndonnx' has no operation 'cumprod'
+.. [#fn-53] AttributeError: saiunit: backend 'ndonnx' has no operation 'cumsum'
+.. [#fn-54] AttributeError: saiunit: backend 'ndonnx' has no operation 'deg2rad'
+.. [#fn-55] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'degrees'
+.. [#fn-56] AttributeError: saiunit: backend 'ndonnx' has no operation 'degrees'
+.. [#fn-57] AttributeError: module 'ndonnx' has no attribute `diag`
+.. [#fn-58] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'diag_indices_from'
+.. [#fn-59] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'diag_indices_from'
+.. [#fn-60] AttributeError: saiunit: backend 'ndonnx' has no operation 'diag_indices_from'
+.. [#fn-61] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'diagflat'
+.. [#fn-62] AttributeError: saiunit: backend 'ndonnx' has no operation 'diagflat'
+.. [#fn-63] AttributeError: saiunit: backend 'ndonnx' has no operation 'diagonal'
+.. [#fn-64] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'digitize'
+.. [#fn-65] AttributeError: saiunit: backend 'ndonnx' has no operation 'digitize'
+.. [#fn-66] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'divmod'
+.. [#fn-67] AttributeError: saiunit: backend 'ndonnx' has no operation 'divmod'
+.. [#fn-68] AttributeError: saiunit: backend 'ndonnx' has no operation 'dot'
+.. [#fn-69] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'dsplit'
+.. [#fn-70] AttributeError: saiunit: backend 'ndonnx' has no operation 'dsplit'
+.. [#fn-71] AttributeError: saiunit: backend 'ndonnx' has no operation 'dstack'
+.. [#fn-72] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'ediff1d'
+.. [#fn-73] AttributeError: saiunit: backend 'ndonnx' has no operation 'ediff1d'
+.. [#fn-74] TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on traced array with shape float32[2,2] The error occurred while tracing the function _einsum at /mnt/d/codes/...
+.. [#fn-75] TypeError: Error interpreting argument to <function _einsum at 0x...> as an abstract array. The problematic value is of type <class 'torch.Tensor'> and was passed to the function at path operands[0...
+.. [#fn-76] TypeError: Error interpreting argument to <function _einsum at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path ope...
+.. [#fn-77] AttributeError: saiunit: backend 'ndonnx' has no operation 'exp2'
+.. [#fn-78] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'extract'
+.. [#fn-79] AttributeError: saiunit: backend 'ndonnx' has no operation 'extract'
+.. [#fn-80] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'fabs'
+.. [#fn-81] AttributeError: saiunit: backend 'ndonnx' has no operation 'fabs'
+.. [#fn-82] AttributeError: module 'array_api_compat.torch' has no attribute 'fill_diagonal'
+.. [#fn-83] AttributeError: module 'array_api_compat.dask.array' has no attribute 'fill_diagonal'
+.. [#fn-84] AttributeError: module 'ndonnx' has no attribute `fill_diagonal`
+.. [#fn-85] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'flatnonzero'
+.. [#fn-86] AttributeError: saiunit: backend 'ndonnx' has no operation 'flatnonzero'
+.. [#fn-87] AttributeError: saiunit: backend 'ndonnx' has no operation 'fliplr'
+.. [#fn-88] AttributeError: saiunit: backend 'ndonnx' has no operation 'flipud'
+.. [#fn-89] AttributeError: saiunit: backend 'ndonnx' has no operation 'float_power'
+.. [#fn-90] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmax'
+.. [#fn-91] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmin'
+.. [#fn-92] AttributeError: saiunit: backend 'ndonnx' has no operation 'fmod'
+.. [#fn-93] AttributeError: saiunit: backend 'ndonnx' has no operation 'frexp'
+.. [#fn-94] NotImplementedError: Don't yet support nd fancy indexing
+.. [#fn-95] AttributeError: 'Array' object has no attribute 'reshape'
+.. [#fn-96] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'gcd'
+.. [#fn-97] AttributeError: saiunit: backend 'ndonnx' has no operation 'gcd'
+.. [#fn-98] AttributeError: module 'ndonnx' has no attribute `gradient`
+.. [#fn-99] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'heaviside'
+.. [#fn-100] AttributeError: saiunit: backend 'ndonnx' has no operation 'heaviside'
+.. [#fn-101] AttributeError: saiunit: backend 'ndonnx' has no operation 'histogram'
+.. [#fn-102] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'hsplit'
+.. [#fn-103] AttributeError: saiunit: backend 'ndonnx' has no operation 'hsplit'
+.. [#fn-104] AttributeError: saiunit: backend 'ndonnx' has no operation 'hstack'
+.. [#fn-105] AttributeError: module 'array_api_compat.torch' has no attribute 'identity'
+.. [#fn-106] AttributeError: module 'array_api_compat.dask.array' has no attribute 'identity'
+.. [#fn-107] AttributeError: module 'ndonnx' has no attribute `identity`
+.. [#fn-108] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'inner'
+.. [#fn-109] AttributeError: saiunit: backend 'ndonnx' has no operation 'inner'
+.. [#fn-110] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'interp'
+.. [#fn-111] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'interp'
+.. [#fn-112] AttributeError: saiunit: backend 'ndonnx' has no operation 'interp'
+.. [#fn-113] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'intersect1d'
+.. [#fn-114] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'intersect1d'
+.. [#fn-115] AttributeError: saiunit: backend 'ndonnx' has no operation 'intersect1d'
+.. [#fn-116] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'invert'
+.. [#fn-117] AttributeError: saiunit: backend 'ndonnx' has no operation 'invert'
+.. [#fn-118] AttributeError: saiunit: backend 'ndonnx' has no operation 'isclose'
+.. [#fn-119] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'iscomplexobj'
+.. [#fn-120] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'iscomplexobj'
+.. [#fn-121] AttributeError: saiunit: backend 'ndonnx' has no operation 'iscomplexobj'
+.. [#fn-122] AttributeError: module 'ndonnx' has no attribute `isreal`
+.. [#fn-123] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'kron'
+.. [#fn-124] AttributeError: saiunit: backend 'ndonnx' has no operation 'kron'
+.. [#fn-125] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'lcm'
+.. [#fn-126] AttributeError: saiunit: backend 'ndonnx' has no operation 'lcm'
+.. [#fn-127] AttributeError: saiunit: backend 'ndonnx' has no operation 'ldexp'
+.. [#fn-128] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'left_shift'
+.. [#fn-129] AttributeError: saiunit: backend 'ndonnx' has no operation 'left_shift'
+.. [#fn-130] AttributeError: saiunit: backend 'ndonnx' has no operation 'logaddexp2'
+.. [#fn-131] TypeError: logspace() received an invalid combination of arguments - got (float, float), but expected one of: \* (Tensor start, Tensor end, int steps, float base = 10.0, \*, Tensor out = None, torch....
+.. [#fn-132] AttributeError: module 'array_api_compat.dask.array' has no attribute 'logspace'
+.. [#fn-133] AttributeError: module 'ndonnx' has no attribute `logspace`
+.. [#fn-134] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.matrix_power'
+.. [#fn-135] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_power'
+.. [#fn-136] NotImplementedError: The da.median function only works along an axis. The full algorithm is difficult to do in parallel
+.. [#fn-137] AttributeError: saiunit: backend 'ndonnx' has no operation 'median'
+.. [#fn-138] AttributeError: 'list' object has no attribute 'ndim'
+.. [#fn-139] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'mod'
+.. [#fn-140] AttributeError: saiunit: backend 'ndonnx' has no operation 'mod'
+.. [#fn-141] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'modf'
+.. [#fn-142] AttributeError: saiunit: backend 'ndonnx' has no operation 'modf'
+.. [#fn-143] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.multi_dot'
+.. [#fn-144] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.multi_dot'
+.. [#fn-145] AttributeError: saiunit: backend 'ndonnx' has no operation 'nan_to_num'
+.. [#fn-146] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanargmax'
+.. [#fn-147] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanargmax'
+.. [#fn-148] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanargmin'
+.. [#fn-149] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanargmin'
+.. [#fn-150] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nancumprod'
+.. [#fn-151] AttributeError: saiunit: backend 'ndonnx' has no operation 'nancumprod'
+.. [#fn-152] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nancumsum'
+.. [#fn-153] AttributeError: saiunit: backend 'ndonnx' has no operation 'nancumsum'
+.. [#fn-154] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanmax'
+.. [#fn-155] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmax'
+.. [#fn-156] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmean'
+.. [#fn-157] NotImplementedError: The da.nanmedian function only works along an axis or a subset of axes. The full algorithm is difficult to do in parallel
+.. [#fn-158] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmedian'
+.. [#fn-159] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanmin'
+.. [#fn-160] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanmin'
+.. [#fn-161] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanpercentile'
+.. [#fn-162] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanpercentile'
+.. [#fn-163] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanprod'
+.. [#fn-164] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanprod'
+.. [#fn-165] TypeError: nanquantile() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, Tensor q, int dim = None, bool keepdim = False, \*, str interpolation = "l...
+.. [#fn-166] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanquantile'
+.. [#fn-167] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanstd'
+.. [#fn-168] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanstd'
+.. [#fn-169] AttributeError: saiunit: backend 'ndonnx' has no operation 'nansum'
+.. [#fn-170] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'nanvar'
+.. [#fn-171] AttributeError: saiunit: backend 'ndonnx' has no operation 'nanvar'
+.. [#fn-172] AttributeError: saiunit: backend 'ndonnx' has no operation 'outer'
+.. [#fn-173] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'percentile'
+.. [#fn-174] AttributeError: saiunit: backend 'ndonnx' has no operation 'percentile'
+.. [#fn-175] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'power'
+.. [#fn-176] AttributeError: saiunit: backend 'ndonnx' has no operation 'power'
+.. [#fn-177] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'ptp'
+.. [#fn-178] AttributeError: saiunit: backend 'ndonnx' has no operation 'ptp'
+.. [#fn-179] TypeError: quantile() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, Tensor q, int dim = None, bool keepdim = False, \*, str interpolation = "line...
+.. [#fn-180] AttributeError: saiunit: backend 'ndonnx' has no operation 'quantile'
+.. [#fn-181] AttributeError: saiunit: backend 'ndonnx' has no operation 'rad2deg'
+.. [#fn-182] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'radians'
+.. [#fn-183] AttributeError: saiunit: backend 'ndonnx' has no operation 'radians'
+.. [#fn-184] AttributeError: saiunit: backend 'ndonnx' has no operation 'ravel'
+.. [#fn-185] AttributeError: type object 'bool' has no attribute '__ndx_create__'
+.. [#fn-186] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'right_shift'
+.. [#fn-187] AttributeError: saiunit: backend 'ndonnx' has no operation 'right_shift'
+.. [#fn-188] AttributeError: saiunit: backend 'array_api_compat.torch' has no operation 'rint'
+.. [#fn-189] AttributeError: saiunit: backend 'ndonnx' has no operation 'rint'
+.. [#fn-190] AttributeError: saiunit: backend 'ndonnx' has no operation 'rot90'
+.. [#fn-191] AttributeError: saiunit: backend 'ndonnx' has no operation 'vstack'
+.. [#fn-192] TypeError: select() received an invalid combination of arguments - got (list, list), but expected one of: \* (Tensor input, name dim, int index) \* (Tensor input, int dim, int index)
+.. [#fn-193] AttributeError: saiunit: backend 'ndonnx' has no operation 'select'
+.. [#fn-194] AttributeError: saiunit: backend 'ndonnx' has no operation 'sinc'
+.. [#fn-195] TypeError: squeeze() missing 1 required positional argument: 'axis'
+.. [#fn-196] AttributeError: saiunit: backend 'ndonnx' has no operation 'swapaxes'
+.. [#fn-197] AttributeError: saiunit: backend 'ndonnx' has no operation 'trace'
+.. [#fn-198] TypeError: transpose() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, int dim0, int dim1) \* (Tensor input, name dim0, name dim1)
+.. [#fn-199] AttributeError: saiunit: backend 'ndonnx' has no operation 'transpose'
+.. [#fn-200] AttributeError: module 'array_api_compat.torch' has no attribute 'tri'
+.. [#fn-201] AttributeError: module 'ndonnx' has no attribute `tri`
+.. [#fn-202] AttributeError: module 'array_api_compat.torch' has no attribute 'tril_indices_from'
+.. [#fn-203] AttributeError: module 'ndonnx' has no attribute `tril_indices_from`
+.. [#fn-204] AttributeError: module 'array_api_compat.torch' has no attribute 'triu_indices_from'
+.. [#fn-205] AttributeError: module 'ndonnx' has no attribute `triu_indices_from`
+.. [#fn-206] AttributeError: saiunit: backend 'ndonnx' has no operation 'true_divide'
+.. [#fn-207] AttributeError: saiunit: backend 'ndonnx' has no operation 'unique'
+.. [#fn-208] AttributeError: module 'array_api_compat.dask.array' has no attribute 'vander'
+.. [#fn-209] AttributeError: module 'ndonnx' has no attribute `vander`
+.. [#fn-210] AttributeError: saiunit: backend 'ndonnx' has no operation 'vdot'
+.. [#fn-211] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'vsplit'
+.. [#fn-212] AttributeError: saiunit: backend 'ndonnx' has no operation 'vsplit'
+.. [#fn-213] TypeError: transpose() received an invalid combination of arguments - got (Tensor, list), but expected one of: \* (Tensor input, int dim0, int dim1) \* (Tensor input, name dim0, name dim1)
+.. [#fn-214] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.cholesky'
+.. [#fn-215] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.cond'
+.. [#fn-216] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.cond'
+.. [#fn-217] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.det'
+.. [#fn-218] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.det'
+.. [#fn-219] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to eig at position 0.
+.. [#fn-220] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to eig at position 0.
+.. [#fn-221] TypeError: Error interpreting argument to eig as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to eig at position 0.
+.. [#fn-222] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to transpose at position 0.
+.. [#fn-223] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to transpose at position 0.
+.. [#fn-224] TypeError: Error interpreting argument to transpose as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to transpose at position 0.
+.. [#fn-225] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.inv'
+.. [#fn-226] TypeError: lstsq() got an unexpected keyword argument 'rcond'
+.. [#fn-227] AttributeError: module 'ndonnx' has no attribute `linalg`
+.. [#fn-228] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_norm'
+.. [#fn-229] TypeError: svd() got an unexpected keyword argument 'compute_uv'
+.. [#fn-230] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_rank'
+.. [#fn-231] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.matrix_transpose'
+.. [#fn-232] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.norm'
+.. [#fn-233] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.pinv'
+.. [#fn-234] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.pinv'
+.. [#fn-235] AttributeError: module 'array_api_compat.dask.array.linalg' has no attribute 'slogdet'
+.. [#fn-236] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.solve'
+.. [#fn-237] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'torch.Tensor'> and was passed to svd at position 0.
+.. [#fn-238] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'dask.array.core.Array'> and was passed to svd at position 0.
+.. [#fn-239] TypeError: Error interpreting argument to svd as a JAX value. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to svd at position 0.
+.. [#fn-240] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.tensorinv'
+.. [#fn-241] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.tensorinv'
+.. [#fn-242] AttributeError: saiunit: backend 'array_api_compat.dask.array' has no operation 'linalg.tensorsolve'
+.. [#fn-243] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.tensorsolve'
+.. [#fn-244] AttributeError: saiunit: backend 'ndonnx' has no operation 'linalg.vector_norm'
+.. [#fn-245] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fft'
+.. [#fn-246] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fft2'
+.. [#fn-247] AttributeError: module 'ndonnx' has no attribute `fft`
+.. [#fn-248] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fftn'
+.. [#fn-249] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.fftshift'
+.. [#fn-250] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifft'
+.. [#fn-251] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifft2'
+.. [#fn-252] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifftn'
+.. [#fn-253] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.ifftshift'
+.. [#fn-254] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfft'
+.. [#fn-255] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfft2'
+.. [#fn-256] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.irfftn'
+.. [#fn-257] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfft'
+.. [#fn-258] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfft2'
+.. [#fn-259] AttributeError: saiunit: backend 'ndonnx' has no operation 'fft.rfftn'
+.. [#fn-260] AttributeError: module 'array_api_compat.torch' has no attribute 'copy'
+.. [#fn-261] AttributeError: module 'array_api_compat.dask.array' has no attribute 'copy'
+.. [#fn-262] AttributeError: module 'ndonnx' has no attribute `copy`
+.. [#fn-263] TypeError: Cannot interpret 'torch.float64' as a data type
+.. [#fn-264] InvalidInputException: Argument 'dask.array<array, shape=(3,), dtype=float64, chunksize=(3,), chunktype=numpy.ndarray>' of type <class 'dask.array.core.Array'> is not a valid JAX type.
+.. [#fn-265] TypeError: Cannot interpret 'Float64' as a data type
+.. [#fn-266] TypeError: cross() got an unexpected keyword argument 'axisa'
+.. [#fn-267] AttributeError: module 'array_api_compat.dask.array' has no attribute 'cross'
+.. [#fn-268] AttributeError: module 'ndonnx' has no attribute `cross`
+.. [#fn-269] RuntimeError: Unknown backend cuda. Available backends are ['cpu']
+.. [#fn-270] TypeError: cumprod is not supported for quantities with units (has unit m), because each element of the result would have a different unit exponent. Use .prod() for a single reduction, or convert t...
+.. [#fn-271] TypeError: cumsum() received an invalid combination of arguments - got (Tensor), but expected one of: \* (Tensor input, int dim, \*, torch.dtype dtype = None, Tensor out = None) \* (Tensor input, name...
+.. [#fn-272] TypeError: diagonal() received an invalid combination of arguments - got (Tensor, axis1=int, axis2=int, offset=int), but expected one of: \* (Tensor input, \*, name outdim, name dim1, name dim2, int ...
+.. [#fn-273] AttributeError: module 'ndonnx' has no attribute `diagonal`
+.. [#fn-274] TypeError: Error interpreting argument to <function dot at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path a. This...
+.. [#fn-275] ValueError: The dtype of the original data is float32, while we got float64.
+.. [#fn-276] BackendError: Quantity.at indexed-update is not supported on the ndonnx backend. Call .to_numpy() (or another concrete backend) on the input first.
+.. [#fn-277] AttributeError: module 'array_api_compat.dask.array' has no attribute 'float16'
+.. [#fn-278] AttributeError: 'Array' object has no attribute 'item'
+.. [#fn-279] TypeError: nancumprod is not supported for quantities with units (has unit m), because each element of the result would have a different unit exponent. Use .nanprod() for a single reduction, or con...
+.. [#fn-280] TypeError: Error interpreting argument to <function outer at 0x...> as an abstract array. The problematic value is of type <class 'ndonnx._array.Array'> and was passed to the function at path a. Th...
+.. [#fn-281] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'set'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
+.. [#fn-282] ValueError: found array with object dtype but it contains non-string elements
+.. [#fn-283] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'add'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
+.. [#fn-284] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'divide'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy()...
+.. [#fn-285] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'max'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
+.. [#fn-286] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'min'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy() to...
+.. [#fn-287] NotImplementedError: Quantity.at on dask backend does not support index type 'Array' for op 'multiply'. Use a boolean mask of the source shape, a slice, an int, or a 1D int array; or call .to_numpy...
+.. [#fn-288] TypeError: split() got an unexpected keyword argument 'axis'
+.. [#fn-289] AxisError: axis1: axis 0 is out of bounds for array of dimension 0
+.. [#fn-290] TypeError: 'NoneType' object is not iterable
+.. [#fn-291] TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
+.. [#fn-292] AttributeError: module 'ndonnx' has no attribute `swapaxes`
+.. [#fn-293] TypeError: Axis value must be an integer, got None
+.. [#fn-294] TypeError: tile(): argument 'dims' (position 2) must be tuple of ints, not int
+.. [#fn-295] TypeError: object of type 'int' has no len()
+.. [#fn-296] cupy backend not installed
+.. [#fn-297] TypeError: Value 'array(data: [1.0, 2.0, 3.0], dtype=float64)' with dtype object is not a valid JAX array type. Only arrays of numeric types are supported by JAX.
+.. [#fn-298] ValueError: unable to infer dtype from `[1. 2. 3.]`
+.. [#fn-299] ValueError: unable to infer dtype from `tensor([1., 2., 3.], dtype=torch.float64)`
+.. [#fn-300] ValueError: unable to infer dtype from `dask.array<array, shape=(3,), dtype=float64, chunksize=(3,), chunktype=numpy.ndarray>`
+.. [#fn-301] TypeError: len() of unsized object
+.. [#fn-302] ValueError: ONNX provides no control over the used device
+.. [#fn-303] BackendError (expected): Quantity.tolist() would materialize a dask-backed Quantity. Call `q.mantissa.compute()` first.
+.. [#fn-304] AttributeError: 'Array' object has no attribute 'tolist'
+.. [#fn-305] TypeError: trace() got an unexpected keyword argument 'offset'
+.. [#fn-306] AttributeError: module 'ndonnx' has no attribute `trace`
+.. [#fn-307] AttributeError: module 'ndonnx' has no attribute `transpose`
+.. [#fn-308] TypeError: view() received an invalid combination of arguments - got (type), but expected one of: \* (torch.dtype dtype) didn't match because some of the arguments have invalid types: (!type!) \* (tu...
+.. [#fn-309] AttributeError: 'Array' object has no attribute 'view'

--- a/saiunit/_backend.py
+++ b/saiunit/_backend.py
@@ -300,6 +300,28 @@ def _numpy_to_torch_dtype(np_dtype, torch_mod):
     return getattr(torch_mod, torch_name)
 
 
+def _translate_dtype(dtype, xp):
+    """Translate ``dtype`` (often a numpy dtype) to the equivalent on ``xp``.
+
+    torch and ndonnx reject numpy dtype objects: torch's ``Tensor.to`` raises
+    ``TypeError: received an invalid combination of arguments`` and ndonnx
+    raises ``AttributeError: type object 'numpy.float32' has no attribute
+    '__ndx_cast_from__'``. Both expose array-API dtype attributes
+    (``xp.float32``, ``xp.int64``, …) that match numpy's dtype names, so the
+    safest cross-backend bridge is ``getattr(xp, np.dtype(dtype).name)``.
+
+    Returns ``dtype`` unchanged if it isn't a numpy dtype-like value or if
+    ``xp`` doesn't expose the named attribute.
+    """
+    if dtype is None:
+        return None
+    try:
+        name = np.dtype(dtype).name
+    except (TypeError, ValueError):
+        return dtype
+    return getattr(xp, name, dtype)
+
+
 def to_backend(x, name: BackendName, **kwargs):
     """Convert ``x`` to the given backend; no-op if already there.
 

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -2414,7 +2414,9 @@ class Quantity:
         if dtype is None:
             return Quantity(self.mantissa, unit=self.unit)
         else:
-            return Quantity(get_backend(self).astype(self.mantissa, dtype), unit=self.unit)
+            from saiunit._backend import _translate_dtype
+            xp = get_backend(self)
+            return Quantity(xp.astype(self.mantissa, _translate_dtype(dtype, xp)), unit=self.unit)
 
     def clip(
         self,

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -21,7 +21,7 @@ from saiunit._jax_compat import jax, jnp, tree as _tree
 from saiunit._typing import Array, ArrayLike, DTypeLike
 import numpy as np
 
-from saiunit._backend import get_backend, get_default_backend, _xp_for
+from saiunit._backend import get_backend, get_default_backend, _xp_for, _translate_dtype
 from saiunit._base_dimension import UnitMismatchError
 from saiunit._base_unit import UNITLESS, Unit
 from saiunit._base_getters import fail_for_unit_mismatch, get_unit, unit_scale_align_to_first
@@ -1008,9 +1008,19 @@ def arange(
     start = start.in_unit(unit).mantissa if isinstance(start, Quantity) else start
     stop = stop.in_unit(unit).mantissa if isinstance(stop, Quantity) else stop
     step = step.in_unit(unit).mantissa if isinstance(step, Quantity) else step
-    # compute
+    # Build positional args without leading/trailing ``None``s. torch / dask /
+    # ndonnx reject a ``None`` ``step`` positional that numpy and jax silently
+    # treat as the default 1, and ndonnx additionally requires a non-``None``
+    # ``stop``. Normalize the single-arg form ``arange(stop)`` to ``(0, stop)``
+    # the way numpy does, then drop ``step`` when not given.
+    if stop is None:
+        stop = start
+        start = 0
+    pos = (start, stop) if step is None else (start, stop, step)
+    xp = _default_xp()
+    kwargs = {} if dtype is None else {"dtype": _translate_dtype(dtype, xp)}
     with jax.ensure_compile_time_eval():
-        r = _default_xp().arange(start, stop, step, dtype=dtype)
+        r = xp.arange(*pos, **kwargs)
     return r if unit.is_unitless else Quantity(r, unit=unit)
 
 
@@ -1379,10 +1389,16 @@ def vander(
 
 def tril_indices(n, k=0, m=None):
     xp = _default_xp()
+    name = getattr(xp, '__name__', '')
     # torch's binding spells the signature ``tril_indices(row, col, offset)``;
     # array-API / numpy / jax / dask spell it ``(n, k=0, m=None)``.
-    if 'torch' in getattr(xp, '__name__', ''):
+    if 'torch' in name:
         return xp.tril_indices(n, n if m is None else m, offset=k)
+    # ndonnx has no ``tril_indices``; compute the static index pair on numpy
+    # and wrap with ``xp.asarray`` so the caller receives backend-native arrays.
+    if 'ndonnx' in name:
+        rows, cols = np.tril_indices(n, k=k, m=m)
+        return (xp.asarray(rows), xp.asarray(cols))
     return _safe_call_xp(xp.tril_indices, (n,), {'k': k, 'm': m})
 
 
@@ -1424,8 +1440,12 @@ def tril_indices_from(
 
 def triu_indices(n, k=0, m=None):
     xp = _default_xp()
-    if 'torch' in getattr(xp, '__name__', ''):
+    name = getattr(xp, '__name__', '')
+    if 'torch' in name:
         return xp.triu_indices(n, n if m is None else m, offset=k)
+    if 'ndonnx' in name:
+        rows, cols = np.triu_indices(n, k=k, m=m)
+        return (xp.asarray(rows), xp.asarray(cols))
     return _safe_call_xp(xp.triu_indices, (n,), {'k': k, 'm': m})
 
 

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -1014,9 +1014,10 @@ def arange(
     # ``stop``. Normalize the single-arg form ``arange(stop)`` to ``(0, stop)``
     # the way numpy does, then drop ``step`` when not given.
     if stop is None:
-        stop = start
-        start = 0
-    pos = (start, stop) if step is None else (start, stop, step)
+        head: Tuple[Any, ...] = (0, start)
+    else:
+        head = (start, stop)
+    pos = head if step is None else (*head, step)
     xp = _default_xp()
     kwargs = {} if dtype is None else {"dtype": _translate_dtype(dtype, xp)}
     with jax.ensure_compile_time_eval():

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -24,7 +24,7 @@ from saiunit._jax_compat import jax, jnp, tree
 from saiunit._typing import Array, ArrayLike, DTypeLike
 import numpy as np
 
-from saiunit._backend import get_backend
+from saiunit._backend import get_backend, _translate_dtype
 
 
 def _promote_dtypes(*arrays):
@@ -1980,6 +1980,11 @@ def astype(
       >>> a = [1, 2, 3] * u.second
       >>> u.math.astype(a, jnp.float32)
     """
+    # torch and ndonnx reject numpy dtype objects; translate to the
+    # backend's own dtype attribute (``xp.float32`` etc.) before dispatch.
+    x = maybe_custom_array(x)
+    inner = x.mantissa if isinstance(x, Quantity) else x
+    dtype = _translate_dtype(dtype, get_backend(inner))
     return _fun_keep_unit_unary('astype', x, dtype)
 
 


### PR DESCRIPTION
## Summary

The four functions called out in `docs/backends/feature_support_matrix.rst`
were failing on at least one tested backend. After this change each cell is
`✓` on numpy, jax, torch, dask, and ndonnx (cupy stays `?` — no CUDA in the
sweep environment).

- New `_translate_dtype(dtype, xp)` in `saiunit/_backend.py` maps numpy
  dtypes to the backend's native dtype attribute. Torch's `Tensor.to`
  refused numpy dtype objects (`invalid combination of arguments`) and
  ndonnx raised `AttributeError: type object 'numpy.float32' has no
  attribute '__ndx_cast_from__'`.
- `arange` drops the `step=None` positional that torch / dask / ndonnx all
  reject, normalizes the one-arg `arange(stop)` form, and translates
  `dtype` through the new helper.
- `tril_indices` / `triu_indices` gain an ndonnx fallback that computes
  the index pair on numpy and wraps with `xp.asarray` (ndonnx exposes no
  `tril_indices` / `triu_indices`).
- `astype` (`saiunit.math.astype` and `Quantity.astype`) translates the
  requested dtype before dispatch.
- `dev/backend_support_data.json` and `docs/backends/feature_support_matrix.rst`
  are regenerated from the new sweep.

## Test plan

- [x] `PYTHONPATH=. python dev/backend_support_sweep.py` — sweep completes.
- [x] `PYTHONPATH=. python dev/backend_support_render.py` — rst regenerates.
- [x] Spot-check the four functions on every backend (numpy/jax/torch/dask/ndonnx)
      returns the expected backend-native array.
- [x] Confirm no other cells regressed in `dev/backend_support_data.json`.