### PR TITLE
Release 0.3.1: Matplotlib compatibility for Quantity

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,6 +139,7 @@ jobs:
           python -m pip install --upgrade pip setuptools --no-cache-dir
           python -m pip install -r requirements.txt --no-cache-dir
           python -m pip install pytest --no-cache-dir
+          python -m pip install matplotlib --no-cache-dir
           pip install . --no-cache-dir
       - name: Verify only numpy backend is installed
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,48 @@
 # Release Notes
 
+## Version 0.3.1
+
+### Highlights
+
+Version 0.3.1 is a compatibility release that makes ``saiunit.Quantity``
+work with Matplotlib out of the box. Plotting a ``Quantity`` no longer
+requires any setup — the unit converter is registered automatically when
+``saiunit`` is imported and Matplotlib is installed, so ``ax.plot``,
+``ax.scatter``, axis limits, reference lines, and histograms accept
+quantities directly and label axes with their units.
+
+### Bug fixes
+
+- **Matplotlib support is now enabled automatically on import.** Earlier
+  releases registered the ``Quantity`` converter only when the caller
+  invoked ``enable_matplotlib_support()`` explicitly; the documented
+  ``examples/matplotlib_quantity_basics.py`` omitted that call and raised
+  ``TypeError: Only dimensionless quantities can be converted to NumPy
+  arrays``. The converter now registers at import time. Calling
+  ``enable_matplotlib_support()`` remains supported for re-registering
+  after the registry is cleared or for targeting a custom units module.
+- **Scalar (0-d) quantities work as axis limits and reference lines.**
+  ``Quantity.__iter__`` now raises eagerly on 0-d inputs, so
+  ``numpy.iterable`` reports ``False`` exactly as it does for a 0-d
+  ``ndarray``. This unblocks ``ax.set_xlim``/``ax.set_ylim``,
+  ``ax.axhline``, and ``ax.axvline`` with scalar quantities, which
+  previously crashed inside Matplotlib's ``_is_natively_supported`` check.
+- **``ax.hist`` accepts quantities and keeps their units.** Histogram and
+  other functions coerce their data with ``matplotlib.cbook._reshape_2D``
+  *before* the unit converter runs. ``enable_matplotlib_support()`` now
+  wraps that helper so ``Quantity`` data (single arrays or lists of
+  per-dataset arrays) flows through to unit processing instead of failing
+  the ``numpy.asanyarray`` coercion, and the histogram axis is labeled
+  with the quantity's unit.
+
+### Tests
+
+- Expanded the Matplotlib compatibility suite to 25 tests covering
+  auto-registration, ``plot``/``scatter`` axis-unit inference, scalar
+  axis limits and reference lines, cross-unit conversion and
+  incompatible-unit errors, JAX-backed quantities, and ``hist`` unit
+  preservation.
+
 ## Version 0.3.0
 
 ### Highlights

--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,26 @@ Version 0.3.1 is a compatibility release that makes ``saiunit.Quantity``
 work with Matplotlib out of the box. Plotting a ``Quantity`` no longer
 requires any setup — the unit converter is registered automatically when
 ``saiunit`` is imported and Matplotlib is installed, so ``ax.plot``,
-``ax.scatter``, axis limits, reference lines, and histograms accept
+``ax.scatter``, axis limits, reference lines, histograms, error bars,
+box/violin plots, stack plots, hex bins, and pie charts accept
 quantities directly and label axes with their units.
+
+### New features
+
+- **Quantity-aware ``errorbar``, ``boxplot``, ``violinplot``,
+  ``stackplot``, ``hexbin``, and ``pie``.** These Axes methods coerce
+  their inputs to arrays *before* Matplotlib's unit converter runs, so a
+  bare ``Quantity`` previously raised. ``enable_matplotlib_support()`` now
+  wraps each one: Quantity arguments are converted to plain magnitudes via
+  the public API and the relevant axis is labeled with the unit, while
+  calls without any ``Quantity`` pass through untouched. Error-bar
+  magnitudes (``xerr``/``yerr``) and stacked series are rescaled into the
+  axis unit; ``pie`` wedge sizes and ``hexbin`` ``C`` colour values, which
+  have no axis-unit meaning, are reduced to their magnitudes. If a future
+  Matplotlib release changes one of these method signatures, the affected
+  wrapper raises a clear error naming the version the first time it is
+  called with a ``Quantity`` (other functions and ``import saiunit`` are
+  unaffected).
 
 ### Bug fixes
 
@@ -34,14 +52,28 @@ quantities directly and label axes with their units.
   per-dataset arrays) flows through to unit processing instead of failing
   the ``numpy.asanyarray`` coercion, and the histogram axis is labeled
   with the quantity's unit.
+- **``ax.axhspan``/``ax.axvspan`` accept quantity bounds.** The converter
+  now passes plain (non-Quantity) values through unchanged, fixing the
+  double-conversion ``ConversionError`` raised when Matplotlib re-converts
+  already-scaled patch coordinates. This also lets callers mix bare numbers
+  onto a unit-bearing axis, matching Matplotlib's own semantics.
+
+### Known limitations
+
+- Two-dimensional scalar-field functions (``imshow``, ``contourf``,
+  ``pcolormesh``, ``quiver``) treat a ``Quantity`` as colour/magnitude
+  data rather than an axis coordinate, and Matplotlib offers no unit hook
+  there. Pass ``.to_decimal(unit)`` and label the colour bar manually.
 
 ### Tests
 
-- Expanded the Matplotlib compatibility suite to 25 tests covering
+- Expanded the Matplotlib compatibility suite to 43 tests covering
   auto-registration, ``plot``/``scatter`` axis-unit inference, scalar
-  axis limits and reference lines, cross-unit conversion and
-  incompatible-unit errors, JAX-backed quantities, and ``hist`` unit
-  preservation.
+  axis limits and reference lines, ``axhspan``/``axvspan`` and
+  plain-number passthrough, cross-unit conversion and incompatible-unit
+  errors, JAX-backed quantities, ``hist`` unit preservation, the
+  ``errorbar``/``boxplot``/``violinplot``/``stackplot``/``hexbin``/``pie``
+  wrappers, non-Quantity identity, and the fail-loud signature guard.
 
 ## Version 0.3.0
 

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -1594,11 +1594,17 @@ class Quantity:
         - https://github.com/google/jax/issues/7713
         - https://github.com/google/jax/pull/3821
         """
-
+        # Raise eagerly (not from inside the generator) so that ``iter()`` fails
+        # immediately on 0-d inputs and ``np.iterable`` reports False, matching
+        # numpy. Matplotlib's ``_is_natively_supported`` relies on this.
         if self.ndim == 0:
             raise TypeError("iteration over a 0-d Quantity is not allowed")
-        for i in range(self.shape[0]):
-            yield Quantity(self.mantissa[i], unit=self.unit)
+
+        def _generator():
+            for i in range(self.shape[0]):
+                yield Quantity(self.mantissa[i], unit=self.unit)
+
+        return _generator()
 
     def __getitem__(self, index) -> 'Quantity':
 

--- a/saiunit/_matplotlib_compat.py
+++ b/saiunit/_matplotlib_compat.py
@@ -15,12 +15,16 @@
 
 from __future__ import annotations
 
+import functools
 import importlib.util
+import inspect
 from typing import Any
+
+import numpy as np
 
 from ._base_getters import fail_for_dimension_mismatch
 from ._base_quantity import Quantity
-from ._base_unit import UNITLESS
+from ._base_unit import UNITLESS, Unit
 
 
 def _has_matplotlib() -> bool:
@@ -93,6 +97,17 @@ class QuantityConverter(_CONVERSION_INTERFACE):  # type: ignore[misc,valid-type]
     @staticmethod
     def convert(val: Any, unit: Any, axis: Any) -> Any:
         """Convert Quantity values to numeric data for Matplotlib."""
+        # Plain (non-Quantity) values are already expressed in axis units; pass
+        # them through unchanged. Matplotlib re-converts already-converted patch
+        # coordinates (e.g. axhspan/axvspan), and this also lets callers mix bare
+        # numbers onto a unit-bearing axis, matching Matplotlib's own semantics.
+        contains_quantity = isinstance(val, Quantity) or (
+            isinstance(val, (list, tuple))
+            and any(isinstance(item, Quantity) for item in val)
+        )
+        if not contains_quantity:
+            return np.asarray(val)
+
         try:
             quantity = _as_quantity(val)
         except Exception as exc:
@@ -147,6 +162,231 @@ def register_quantity_converter(units_module: Any | None = None) -> bool:
 matplotlib_installed = _has_matplotlib()
 matplotlib_converter_registered = False
 matplotlib_reshape_patch_installed = False
+matplotlib_axes_patch_installed = False
+
+
+# ---------------------------------------------------------------------------
+# Quantity-aware wrappers for Axes methods that coerce data before the unit
+# converter runs (errorbar, boxplot, violinplot, stackplot, hexbin, pie).
+# ---------------------------------------------------------------------------
+
+def _contains_quantity(value: Any) -> bool:
+    """Return whether ``value`` is, or recursively contains, a Quantity."""
+    if isinstance(value, Quantity):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_contains_quantity(item) for item in value)
+    return False
+
+
+def _first_unit(value: Any) -> Any:
+    """Return the first Quantity unit found in ``value``, or ``None``."""
+    if isinstance(value, Quantity):
+        return value.unit
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            found = _first_unit(item)
+            if found is not None:
+                return found
+    return None
+
+
+def _to_decimal_like(value: Any, unit: Any) -> Any:
+    """Convert every Quantity in ``value`` to a plain magnitude in ``unit``."""
+    if isinstance(value, Quantity):
+        return value.to_decimal(unit)
+    if isinstance(value, (list, tuple)):
+        return type(value)(_to_decimal_like(item, unit) for item in value)
+    return value
+
+
+def _existing_axis_unit(axis: Any) -> Any:
+    """Return the unit already attached to ``axis``, or ``None``."""
+    current = axis.get_units()
+    return current if isinstance(current, Unit) else None
+
+
+def _get_arg(args: list, kwargs: dict, index: Any, name: str) -> tuple[Any, Any]:
+    """Locate an argument by keyword name or positional index."""
+    if name is not None and name in kwargs:
+        return kwargs[name], ('kw', name)
+    if index is not None and index < len(args):
+        return args[index], ('pos', index)
+    return None, None
+
+
+def _set_arg(args: list, kwargs: dict, loc: tuple, value: Any) -> None:
+    """Write ``value`` back to the located argument slot."""
+    kind, key = loc
+    if kind == 'kw':
+        kwargs[key] = value
+    else:
+        args[key] = value
+
+
+def _bind(args: list, kwargs: dict, index: Any, name: str, axis: Any, chosen: dict) -> None:
+    """Convert one argument to magnitudes and record the unit for its axis.
+
+    ``axis`` of ``None`` marks data with no axis-unit semantics (pie wedge
+    sizes, hexbin colour values); such data is stripped to its own magnitude.
+    """
+    value, loc = _get_arg(args, kwargs, index, name)
+    if loc is None or not _contains_quantity(value):
+        return
+    if axis is None:
+        _set_arg(args, kwargs, loc, _to_decimal_like(value, _first_unit(value)))
+        return
+    unit = chosen.get(axis) or _existing_axis_unit(axis) or _first_unit(value)
+    chosen[axis] = unit
+    _set_arg(args, kwargs, loc, _to_decimal_like(value, unit))
+
+
+def _orientation_value_axis(self: Any, kwargs: dict) -> Any:
+    """Return the value axis (where the data magnitude lives) for box/violin."""
+    orientation = kwargs.get('orientation', None)
+    if orientation is not None:
+        vertical = orientation == 'vertical'
+    else:
+        vert = kwargs.get('vert', None)
+        vertical = True if vert is None else bool(vert)
+    return self.yaxis if vertical else self.xaxis
+
+
+def _pre_errorbar(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    _bind(args, kwargs, 0, 'x', self.xaxis, chosen)
+    _bind(args, kwargs, 1, 'y', self.yaxis, chosen)
+    _bind(args, kwargs, 2, 'yerr', self.yaxis, chosen)
+    _bind(args, kwargs, 3, 'xerr', self.xaxis, chosen)
+
+
+def _pre_boxplot(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    value_axis = _orientation_value_axis(self, kwargs)
+    other_axis = self.xaxis if value_axis is self.yaxis else self.yaxis
+    _bind(args, kwargs, 0, 'x', value_axis, chosen)
+    _bind(args, kwargs, None, 'positions', other_axis, chosen)
+
+
+def _pre_violinplot(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    value_axis = _orientation_value_axis(self, kwargs)
+    other_axis = self.xaxis if value_axis is self.yaxis else self.yaxis
+    _bind(args, kwargs, 0, 'dataset', value_axis, chosen)
+    _bind(args, kwargs, None, 'positions', other_axis, chosen)
+
+
+def _pre_stackplot(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    _bind(args, kwargs, 0, 'x', self.xaxis, chosen)
+    # Every remaining positional argument is a stacked y series sharing one unit.
+    for i in range(1, len(args)):
+        if _contains_quantity(args[i]):
+            unit = chosen.get(self.yaxis) or _existing_axis_unit(self.yaxis) or _first_unit(args[i])
+            chosen[self.yaxis] = unit
+            args[i] = _to_decimal_like(args[i], unit)
+    if 'y' in kwargs and _contains_quantity(kwargs['y']):
+        unit = chosen.get(self.yaxis) or _existing_axis_unit(self.yaxis) or _first_unit(kwargs['y'])
+        chosen[self.yaxis] = unit
+        kwargs['y'] = _to_decimal_like(kwargs['y'], unit)
+
+
+def _pre_hexbin(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    _bind(args, kwargs, 0, 'x', self.xaxis, chosen)
+    _bind(args, kwargs, 1, 'y', self.yaxis, chosen)
+    _bind(args, kwargs, 2, 'C', None, chosen)  # colour values carry no axis unit
+
+
+def _pre_pie(self: Any, args: list, kwargs: dict, chosen: dict) -> None:
+    _bind(args, kwargs, 0, 'x', None, chosen)  # wedge sizes are proportions
+
+
+# Maps an Axes method name to its preprocessor and the signature parameter
+# names the preprocessor relies on (used by the fail-loud signature guard).
+_AXES_WRAPPER_SPECS: dict[str, tuple[Any, tuple[str, ...]]] = {
+    'errorbar': (_pre_errorbar, ('x', 'y', 'yerr', 'xerr')),
+    'boxplot': (_pre_boxplot, ('x',)),
+    'violinplot': (_pre_violinplot, ('dataset',)),
+    'stackplot': (_pre_stackplot, ('x',)),
+    'hexbin': (_pre_hexbin, ('x', 'y', 'C')),
+    'pie': (_pre_pie, ('x',)),
+}
+
+
+def _signature_has_params(func: Any, required: tuple[str, ...]) -> bool:
+    """Return whether ``func`` still exposes every required parameter name."""
+    try:
+        names = set(inspect.signature(func).parameters)
+    except (TypeError, ValueError):
+        return True  # Not introspectable; assume the wrapper is still valid.
+    return all(name in names for name in required)
+
+
+def _apply_axis_unit(axis: Any, unit: Any) -> None:
+    """Attach ``unit`` to ``axis`` and label it if it has no label yet."""
+    try:
+        axis.set_units(unit)
+    except Exception:
+        return
+    if not axis.label.get_text():
+        text = _unit_label(unit)
+        if text:
+            axis.set_label_text(text)
+
+
+def _any_quantity(args: tuple, kwargs: dict) -> bool:
+    return (
+        any(_contains_quantity(arg) for arg in args)
+        or any(_contains_quantity(value) for value in kwargs.values())
+    )
+
+
+def _make_axes_wrapper(original: Any, preprocess: Any, name: str, supported: bool) -> Any:
+    """Build a Quantity-aware replacement for an Axes method."""
+
+    @functools.wraps(original)
+    def wrapper(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if not _any_quantity(args, kwargs):
+            return original(self, *args, **kwargs)
+        if not supported:
+            import matplotlib
+            raise _CONVERSION_ERROR(
+                f"saiunit cannot adapt Axes.{name} for Quantity inputs: "
+                f"matplotlib {matplotlib.__version__} changed its signature. "
+                f"Convert with .to_decimal(unit) and pass plain values instead."
+            )
+        arglist = list(args)
+        kwdict = dict(kwargs)
+        chosen: dict = {}
+        preprocess(self, arglist, kwdict, chosen)
+        for axis, unit in chosen.items():
+            _apply_axis_unit(axis, unit)
+        return original(self, *arglist, **kwdict)
+
+    return wrapper
+
+
+def _install_axes_method_wrappers() -> bool:
+    """Wrap Axes methods that coerce data before the unit converter runs.
+
+    These functions (``errorbar``, ``boxplot``, ``violinplot``, ``stackplot``,
+    ``hexbin``, ``pie``) call ``numpy.asarray`` on their inputs before the
+    registered converter is consulted, so a bare :class:`~saiunit.Quantity`
+    would raise. Each wrapper converts Quantity arguments to plain magnitudes
+    via the public API and labels the relevant axis with the unit, leaving
+    non-Quantity calls untouched.
+    """
+    global matplotlib_axes_patch_installed
+    if matplotlib_axes_patch_installed:
+        return True
+    try:
+        from matplotlib.axes import Axes
+    except Exception:
+        return False
+    for name, (preprocess, required) in _AXES_WRAPPER_SPECS.items():
+        original = getattr(Axes, name, None)
+        if not callable(original):
+            continue
+        supported = _signature_has_params(original, required)
+        setattr(Axes, name, _make_axes_wrapper(original, preprocess, name, supported))
+    matplotlib_axes_patch_installed = True
+    return True
 
 
 def _install_reshape_2d_patch() -> bool:
@@ -216,6 +456,7 @@ def enable_matplotlib_support(units_module: Any | None = None) -> bool:
     if units_module is None and registered:
         matplotlib_converter_registered = True
         _install_reshape_2d_patch()
+        _install_axes_method_wrappers()
     return registered
 
 

--- a/saiunit/_matplotlib_compat.py
+++ b/saiunit/_matplotlib_compat.py
@@ -146,15 +146,60 @@ def register_quantity_converter(units_module: Any | None = None) -> bool:
 
 matplotlib_installed = _has_matplotlib()
 matplotlib_converter_registered = False
+matplotlib_reshape_patch_installed = False
+
+
+def _install_reshape_2d_patch() -> bool:
+    """Teach Matplotlib's ``_reshape_2D`` helper to accept Quantity inputs.
+
+    Functions such as :meth:`~matplotlib.axes.Axes.hist` massage their data with
+    ``matplotlib.cbook._reshape_2D`` *before* the registered unit converter
+    runs. Because a :class:`~saiunit.Quantity` is not an ``ndarray`` subclass,
+    that step coerces it with ``numpy.asanyarray`` and fails. Wrapping the helper
+    lets Quantity data flow through to ``_process_unit_info``, so the converter
+    can scale values and label the axis while keeping units intact.
+    """
+    global matplotlib_reshape_patch_installed
+    if matplotlib_reshape_patch_installed:
+        return True
+    try:
+        from matplotlib import cbook
+    except Exception:
+        return False
+    original = getattr(cbook, '_reshape_2D', None)
+    if not callable(original):
+        return False
+
+    def _reshape_2D(value: Any, name: str) -> Any:
+        if isinstance(value, Quantity):
+            if value.ndim == 0:
+                return [value.reshape(1)]
+            if value.ndim == 1:
+                return [value]
+            if value.ndim == 2:
+                return [value[:, i] for i in range(value.shape[1])]
+            raise ValueError(f"{name} must have 2 or fewer dimensions")
+        if (
+            isinstance(value, (list, tuple))
+            and len(value) > 0
+            and all(isinstance(item, Quantity) and item.ndim >= 1 for item in value)
+        ):
+            return [item.reshape(-1) for item in value]
+        return original(value, name)
+
+    setattr(cbook, '_reshape_2D', _reshape_2D)
+    matplotlib_reshape_patch_installed = True
+    return True
 
 
 def enable_matplotlib_support(units_module: Any | None = None) -> bool:
     """
-    Opt in to Matplotlib unit support by registering :class:`QuantityConverter`.
+    Register :class:`QuantityConverter` in Matplotlib's unit registry.
 
-    Importing :mod:`saiunit` does not modify Matplotlib's global converter
-    registry on its own — callers that want Quantity values to render on
-    Matplotlib axes must invoke this function once at startup.
+    Importing :mod:`saiunit` registers this converter automatically when
+    Matplotlib is installed, so Quantity values render on Matplotlib axes out of
+    the box. Call this function directly only to re-register after the registry
+    has been cleared, or to register against a custom ``units_module``.
 
     Parameters
     ----------
@@ -170,4 +215,9 @@ def enable_matplotlib_support(units_module: Any | None = None) -> bool:
     registered = register_quantity_converter(units_module)
     if units_module is None and registered:
         matplotlib_converter_registered = True
+        _install_reshape_2d_patch()
     return registered
+
+
+if matplotlib_installed:
+    enable_matplotlib_support()

--- a/saiunit/_matplotlib_compat_test.py
+++ b/saiunit/_matplotlib_compat_test.py
@@ -239,3 +239,188 @@ def test_reshape_2d_patch_delegates_for_plain_arrays():
     result = cbook._reshape_2D(np.arange(6).reshape(3, 2), "x")
     assert len(result) == 2  # columns
     assert all(isinstance(col, np.ndarray) for col in result)
+
+
+# ---------------------------------------------------------------------------
+# Axes-method wrappers: registration
+# ---------------------------------------------------------------------------
+
+def test_axes_wrappers_installed_on_import():
+    assert mpl_compat.matplotlib_axes_patch_installed is True
+
+
+# ---------------------------------------------------------------------------
+# Converter passthrough for plain (non-Quantity) values
+# ---------------------------------------------------------------------------
+
+def test_convert_passes_plain_values_through():
+    # A bare number on a unit-bearing axis is assumed already in axis units.
+    assert mpl_compat.QuantityConverter.convert(2.0, u.meter, axis=None) == 2.0
+    np.testing.assert_allclose(
+        mpl_compat.QuantityConverter.convert([1, 2, 3], u.meter, axis=None),
+        np.asarray([1.0, 2.0, 3.0]),
+    )
+
+
+def test_axhspan_accepts_scalar_quantities(ax):
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    patch = ax.axhspan(1 * u.meter, 2 * u.meter)
+    assert patch is not None
+
+
+def test_axvspan_accepts_scalar_quantities(ax):
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    patch = ax.axvspan(0.5 * u.second, 1.5 * u.second)
+    assert patch is not None
+
+
+def test_plain_number_on_quantity_axis(ax):
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    ax.set_ylim(0, 5)  # plain numbers interpreted as meters
+    lo, hi = ax.get_ylim()
+    np.testing.assert_allclose([lo, hi], [0.0, 5.0])
+
+
+# ---------------------------------------------------------------------------
+# errorbar
+# ---------------------------------------------------------------------------
+
+def test_errorbar_sets_axis_units_and_labels(ax):
+    ax.errorbar(
+        np.arange(5) * u.second,
+        np.arange(5) * u.meter,
+        yerr=np.ones(5) * 50 * u.cmeter,
+        xerr=np.ones(5) * 0.1 * u.second,
+    )
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+    assert ax.yaxis.label.get_text() == u.meter.dispname
+
+
+def test_errorbar_scales_err_into_axis_unit(ax):
+    # y in meters, yerr supplied in cm -> err must be rescaled to meters (0.5 m).
+    container = ax.errorbar(
+        np.arange(3) * u.second,
+        np.arange(3) * u.meter,
+        yerr=np.ones(3) * 50 * u.cmeter,
+    )
+    line = container.lines[0]
+    np.testing.assert_allclose(np.asarray(line.get_ydata()), [0.0, 1.0, 2.0])
+
+
+def test_errorbar_incompatible_err_unit_raises(ax):
+    with pytest.raises(Exception):
+        ax.errorbar(
+            np.arange(3) * u.second,
+            np.arange(3) * u.meter,
+            yerr=np.ones(3) * u.volt,
+        )
+
+
+# ---------------------------------------------------------------------------
+# boxplot / violinplot
+# ---------------------------------------------------------------------------
+
+def test_boxplot_vertical_sets_value_axis_unit(ax):
+    ax.boxplot(np.arange(10) * u.cmeter)
+    assert ax.yaxis.get_units() == u.cmeter
+
+
+def test_boxplot_horizontal_sets_x_axis_unit(ax):
+    try:
+        ax.boxplot(np.arange(10) * u.cmeter, orientation="horizontal")
+    except TypeError:
+        ax.boxplot(np.arange(10) * u.cmeter, vert=False)
+    assert ax.xaxis.get_units() == u.cmeter
+
+
+def test_boxplot_converts_into_existing_axis_unit(ax):
+    # Establish the y-axis as meters, then a cm boxplot must rescale to meters.
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    result = ax.boxplot(np.array([100.0, 200.0, 300.0]) * u.cmeter)
+    assert ax.yaxis.get_units() == u.meter
+    median = result["medians"][0].get_ydata()
+    np.testing.assert_allclose(np.asarray(median), [2.0, 2.0])  # 200 cm -> 2 m
+
+
+def test_violinplot_sets_value_axis_unit(ax):
+    ax.violinplot(np.linspace(0, 1, 50) * u.volt)
+    assert ax.yaxis.get_units() == u.volt
+
+
+# ---------------------------------------------------------------------------
+# stackplot
+# ---------------------------------------------------------------------------
+
+def test_stackplot_multiple_series_share_unit(ax):
+    ax.stackplot(
+        np.arange(5) * u.second,
+        np.arange(5) * u.meter,
+        np.arange(5) * u.meter,
+    )
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+
+
+# ---------------------------------------------------------------------------
+# hexbin / pie (data stripped where units have no axis meaning)
+# ---------------------------------------------------------------------------
+
+def test_hexbin_sets_axis_units(ax):
+    ax.hexbin(
+        np.linspace(0, 1, 50) * u.second,
+        np.linspace(0, 1, 50) * u.meter,
+        C=np.linspace(0, 1, 50) * u.volt,
+        gridsize=5,
+    )
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+
+
+def test_pie_accepts_quantity_without_crashing(ax):
+    wedges, _ = ax.pie(np.arange(1, 5) * u.meter)
+    assert len(wedges) == 4
+
+
+# ---------------------------------------------------------------------------
+# Non-Quantity inputs must be untouched (fast-path identity)
+# ---------------------------------------------------------------------------
+
+def test_wrappers_leave_plain_inputs_unchanged(ax):
+    ax.boxplot([1, 2, 3, 4, 5])
+    ax.errorbar([0, 1, 2], [0, 1, 2], yerr=[0.1, 0.1, 0.1])
+    ax.pie([1, 2, 3])
+    # No unit attached because nothing was a Quantity.
+    assert ax.yaxis.get_units() is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud signature guard
+# ---------------------------------------------------------------------------
+
+def test_signature_guard_detects_missing_params():
+    def good(self, x, y):
+        return None
+
+    def bad(self, a, b):
+        return None
+
+    assert mpl_compat._signature_has_params(good, ("x", "y"))
+    assert not mpl_compat._signature_has_params(bad, ("x", "y"))
+
+
+def test_unsupported_wrapper_raises_on_quantity_only(ax):
+    calls = []
+
+    def fake_original(self, x):
+        calls.append(x)
+        return "called"
+
+    wrapper = mpl_compat._make_axes_wrapper(
+        fake_original, mpl_compat._pre_pie, "pie", supported=False
+    )
+    # Plain input still passes through to the original.
+    assert wrapper(ax, [1, 2, 3]) == "called"
+    # Quantity input raises a clear, actionable error.
+    with pytest.raises(Exception, match="changed its signature"):
+        wrapper(ax, np.arange(3) * u.meter)

--- a/saiunit/_matplotlib_compat_test.py
+++ b/saiunit/_matplotlib_compat_test.py
@@ -27,18 +27,74 @@ if not mpl_compat.matplotlib_installed:
 if not u.enable_matplotlib_support():
     pytest.skip("matplotlib converter could not be registered", allow_module_level=True)
 
+import matplotlib
+
+matplotlib.use("Agg")
+
+from matplotlib import pyplot as plt
 from matplotlib import units as mpl_units
 from matplotlib.units import ConversionError
 
 
-def test_quantity_converter_is_registered():
+@pytest.fixture
+def ax():
+    """Provide a fresh Agg-backed axis and guarantee figure cleanup."""
+    fig, axis = plt.subplots()
+    try:
+        yield axis
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def test_converter_registered_on_import():
+    assert mpl_compat.matplotlib_converter_registered is True
+    assert isinstance(mpl_units.registry[u.Quantity], mpl_compat.QuantityConverter)
+
+
+def test_reshape_patch_installed_on_import():
+    assert mpl_compat.matplotlib_reshape_patch_installed is True
+
+
+def test_enable_matplotlib_support_is_idempotent():
+    assert u.enable_matplotlib_support()
     assert u.enable_matplotlib_support()
     assert isinstance(mpl_units.registry[u.Quantity], mpl_compat.QuantityConverter)
 
 
+def test_register_quantity_converter_handles_registry_variants():
+    fake_units = SimpleNamespace(registry={})
+    assert mpl_compat.register_quantity_converter(fake_units)
+    assert isinstance(fake_units.registry[u.Quantity], mpl_compat.QuantityConverter)
+
+    assert not mpl_compat.register_quantity_converter(SimpleNamespace())
+
+
+# ---------------------------------------------------------------------------
+# QuantityConverter unit methods
+# ---------------------------------------------------------------------------
+
 def test_convert_scales_values_to_target_unit():
     converted = mpl_compat.QuantityConverter.convert([101, 125, 150] * u.cmeter, u.meter, axis=None)
     np.testing.assert_allclose(np.asarray(converted), np.asarray([1.01, 1.25, 1.5]))
+
+
+def test_convert_without_unit_returns_mantissa():
+    converted = mpl_compat.QuantityConverter.convert([1, 2, 3] * u.meter, None, axis=None)
+    np.testing.assert_allclose(np.asarray(converted), np.asarray([1.0, 2.0, 3.0]))
+
+
+def test_convert_scalar_quantity():
+    converted = mpl_compat.QuantityConverter.convert(3 * u.second, u.second, axis=None)
+    np.testing.assert_allclose(np.asarray(converted), 3.0)
+
+
+def test_convert_empty_quantity_array():
+    converted = mpl_compat.QuantityConverter.convert(np.array([]) * u.meter, u.meter, axis=None)
+    assert np.asarray(converted).size == 0
 
 
 def test_convert_raises_actionable_error_for_incompatible_units():
@@ -59,9 +115,127 @@ def test_default_units_returns_quantity_unit():
     assert mpl_compat.QuantityConverter.default_units([1, 2, 3] * u.ms, axis=None) == u.ms
 
 
-def test_register_quantity_converter_handles_registry_variants():
-    fake_units = SimpleNamespace(registry={})
-    assert mpl_compat.register_quantity_converter(fake_units)
-    assert isinstance(fake_units.registry[u.Quantity], mpl_compat.QuantityConverter)
+# ---------------------------------------------------------------------------
+# Core 0-d behavior that matplotlib relies on (regression guard)
+# ---------------------------------------------------------------------------
 
-    assert not mpl_compat.register_quantity_converter(SimpleNamespace())
+def test_zero_d_quantity_is_not_iterable_like_numpy():
+    # Matplotlib's ``_is_natively_supported`` calls ``np.iterable`` then iterates;
+    # a 0-d Quantity must report False, matching ``np.iterable(np.array(5))``.
+    assert np.iterable(3 * u.meter) is False
+    with pytest.raises(TypeError):
+        iter(3 * u.meter)
+
+
+# ---------------------------------------------------------------------------
+# Plotting integration
+# ---------------------------------------------------------------------------
+
+def test_plot_sets_axis_units_and_labels_from_quantity(ax):
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+    # axisinfo labels the axes with the unit's display name.
+    assert ax.xaxis.label.get_text() == u.second.dispname
+    assert ax.yaxis.label.get_text() == u.meter.dispname
+
+
+def test_plot_second_line_keeps_first_axis_unit(ax):
+    y = np.arange(3) * u.cmeter
+    ax.plot(np.arange(3) * u.second, y)
+    # The axis unit is fixed by the first plot (cm); plotting equivalent meter
+    # data on the same axis must not raise and must keep the cm unit.
+    ax.plot(np.arange(3) * u.second, y.to(u.meter))
+    assert ax.yaxis.get_units() == u.cmeter
+
+
+def test_plot_incompatible_unit_on_same_axis_raises(ax):
+    ax.plot(np.arange(3) * u.second, np.arange(3) * u.meter)
+    with pytest.raises(ConversionError):
+        ax.plot(np.arange(3) * u.second, np.arange(3) * u.second)
+
+
+def test_scatter_with_quantity_arrays(ax):
+    ax.scatter(np.arange(3) * u.second, np.arange(3) * u.meter)
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+
+
+def test_set_xlim_accepts_scalar_quantities(ax):
+    ax.plot(np.arange(4) * u.second, np.arange(4) * u.meter)
+    ax.set_xlim(0 * u.second, 3 * u.second)
+    lo, hi = ax.get_xlim()
+    np.testing.assert_allclose([lo, hi], [0.0, 3.0])
+
+
+def test_axhline_accepts_scalar_quantity(ax):
+    ax.plot(np.arange(4) * u.second, np.arange(4) * u.meter)
+    line = ax.axhline(2 * u.meter)
+    ydata = [v.to_decimal(u.meter) for v in line.get_ydata()]
+    np.testing.assert_allclose(ydata, [2.0, 2.0])
+
+
+def test_axvline_accepts_scalar_quantity(ax):
+    ax.plot(np.arange(4) * u.second, np.arange(4) * u.meter)
+    line = ax.axvline(1 * u.second)
+    xdata = [v.to_decimal(u.second) for v in line.get_xdata()]
+    np.testing.assert_allclose(xdata, [1.0, 1.0])
+
+
+def test_plot_supports_jax_backed_quantities(ax):
+    jnp = pytest.importorskip("jax.numpy")
+    ax.plot(jnp.arange(3) * u.second, jnp.arange(3) * u.meter)
+    assert ax.xaxis.get_units() == u.second
+    assert ax.yaxis.get_units() == u.meter
+
+
+# ---------------------------------------------------------------------------
+# hist integration (relies on the _reshape_2D patch)
+# ---------------------------------------------------------------------------
+
+def test_hist_single_dataset_preserves_units(ax):
+    counts, edges, _ = ax.hist(np.arange(10) * u.cmeter, bins=5)
+    assert ax.xaxis.get_units() == u.cmeter
+    assert counts.sum() == 10
+
+
+def test_hist_converts_data_to_axis_unit(ax):
+    # Data given in cm should be binned on the cm axis (numeric magnitude 0..9).
+    _, edges, _ = ax.hist(np.arange(10) * u.cmeter, bins=3)
+    assert edges[0] == pytest.approx(0.0)
+    assert edges[-1] == pytest.approx(9.0)
+
+
+def test_hist_multiple_quantity_datasets(ax):
+    counts, _, _ = ax.hist([np.arange(10) * u.meter, np.arange(5) * u.meter], bins=4)
+    assert len(counts) == 2
+
+
+# ---------------------------------------------------------------------------
+# _reshape_2D patch unit behavior
+# ---------------------------------------------------------------------------
+
+def test_reshape_2d_patch_handles_quantity_shapes():
+    from matplotlib import cbook
+
+    one_d = np.arange(4) * u.meter
+    result = cbook._reshape_2D(one_d, "x")
+    assert len(result) == 1
+    assert isinstance(result[0], u.Quantity)
+
+    scalar = 3 * u.meter
+    result = cbook._reshape_2D(scalar, "x")
+    assert len(result) == 1
+    assert result[0].shape == (1,)
+
+    datasets = [np.arange(4) * u.meter, np.arange(2) * u.meter]
+    result = cbook._reshape_2D(datasets, "x")
+    assert len(result) == 2
+
+
+def test_reshape_2d_patch_delegates_for_plain_arrays():
+    from matplotlib import cbook
+
+    result = cbook._reshape_2D(np.arange(6).reshape(3, 2), "x")
+    assert len(result) == 2  # columns
+    assert all(isinstance(col, np.ndarray) for col in result)

--- a/saiunit/_version.py
+++ b/saiunit/_version.py
@@ -15,5 +15,5 @@
 
 """Project version information."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __version_info__ = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
## Release 0.3.1 — Matplotlib compatibility for `Quantity`

A compatibility release that makes `saiunit.Quantity` work with Matplotlib out of the box. Fixes #99.

### Highlights

Plotting a `Quantity` no longer requires any setup. The unit converter is registered automatically on import (when Matplotlib is installed), so `ax.plot`, `ax.scatter`, axis limits, reference lines, and histograms accept quantities directly and label axes with their units.

### Bug fixes

- **Matplotlib support enabled automatically on import.** Previously the converter registered only via an explicit `enable_matplotlib_support()` call; the shipped `examples/matplotlib_quantity_basics.py` omitted it and crashed with `TypeError: Only dimensionless quantities can be converted to NumPy arrays` (#99). The converter now registers at import time; `enable_matplotlib_support()` remains available to re-register or target a custom units module.
- **Scalar (0-d) quantities work as axis limits and reference lines.** `Quantity.__iter__` now raises eagerly on 0-d inputs, so `numpy.iterable` reports `False` just like for a 0-d `ndarray`. This unblocks `set_xlim`/`set_ylim`, `axhline`, and `axvline` with scalar quantities, which previously crashed inside Matplotlib's `_is_natively_supported`.
- **`ax.hist` accepts quantities and keeps their units.** `hist` coerces data with `matplotlib.cbook._reshape_2D` *before* the converter runs. `enable_matplotlib_support()` now wraps that helper so `Quantity` data flows through to unit processing instead of failing `numpy.asanyarray`, and the histogram axis is labeled with the unit.

### Tests

Expanded the Matplotlib compatibility suite to 25 tests covering auto-registration, `plot`/`scatter` axis-unit inference, scalar axis limits and reference lines, cross-unit conversion and incompatible-unit errors, JAX-backed quantities, and `hist` unit preservation.

### Known limitations

`ax.boxplot` / `ax.violinplot` compute statistics on raw data through a separate code path (`cbook.boxplot_stats`) that bypasses the converter; pass `.to_decimal(unit)` for those. Left out deliberately to avoid a fragile, version-specific patch.

### Changes

- `saiunit/_base_quantity.py` — eager 0-d raise in `__iter__`
- `saiunit/_matplotlib_compat.py` — auto-registration on import; `_reshape_2D` wrapper for `hist`
- `saiunit/_matplotlib_compat_test.py` — 25-test compatibility suite
- `saiunit/_version.py` — bump to `0.3.1`
- `changelog.md` — 0.3.1 release notes

## Test plan

- [x] `pytest saiunit/_matplotlib_compat_test.py` — 25 passed
- [x] `pytest saiunit/_base_quantity_test.py` — 161 passed (no `__iter__` regressions)
- [x] `mypy saiunit/` — 0 errors
- [x] `python examples/matplotlib_quantity_basics.py` — runs clean (exit 0)