### PR TITLE
fix: avoid deprecated jax.core.concrete_or_error import

### DIFF
--- a/saiunit/_compatible_import.py
+++ b/saiunit/_compatible_import.py
@@ -48,24 +48,30 @@ if HAS_JAX:
     else:
         from jax.extend.core import Primitive
 
-    # concrete_or_error: still lives in jax.core for now; provide a shim if removed.
+    # ``concrete_or_error`` moved from ``jax.core`` to ``jax.extend.core`` in
+    # JAX 0.10; the ``jax.core`` alias is deprecated there and emits a
+    # DeprecationWarning on import. Prefer the new ``jax.extend.core`` location,
+    # fall back to ``jax.core`` for pre-0.10 JAX, and finally to a minimal shim.
     try:
-        from jax.core import concrete_or_error
+        from jax.extend.core import concrete_or_error
     except ImportError:
-        def concrete_or_error(typ, val, context=""):
-            """Minimal shim used when jax.core.concrete_or_error is unavailable.
+        try:
+            from jax.core import concrete_or_error
+        except ImportError:
+            def concrete_or_error(typ, val, context=""):
+                """Minimal shim used when concrete_or_error is unavailable.
 
-            Raises TypeError for traced/abstract values so callers don't silently
-            receive a tracer where they expected a static Python value.
-            """
-            from jax.core import Tracer
-            if isinstance(val, Tracer):
-                raise TypeError(
-                    f"Expected a concrete value but got a JAX tracer ({val!r}). {context}"
-                )
-            if typ is None:
-                return val
-            return typ(val)
+                Raises TypeError for traced/abstract values so callers don't silently
+                receive a tracer where they expected a static Python value.
+                """
+                from jax.core import Tracer
+                if isinstance(val, Tracer):
+                    raise TypeError(
+                        f"Expected a concrete value but got a JAX tracer ({val!r}). {context}"
+                    )
+                if typ is None:
+                    return val
+                return typ(val)
 
 
     def wrap_init(fun: Callable, args: tuple, kwargs: dict, name: str):


### PR DESCRIPTION
## Summary

On jax>=0.10, `jax.core.concrete_or_error` is **deprecated** (it moved to `jax.extend.core`) but still importable, so the previous

```python
try:
    from jax.core import concrete_or_error
except ImportError:
    ...shim...
```

succeeded **with a `DeprecationWarning`** — the `except ImportError` shim never fired.

This changes the import to a version-robust cascade:

1. `jax.extend.core.concrete_or_error` (jax>=0.10, the new home) — no warning
2. fall back to `jax.core.concrete_or_error` (pre-0.10 jax)
3. fall back to the existing minimal shim

## Verification

Importing `saiunit._compatible_import` on jax 0.10.1 emits **no** `concrete_or_error` DeprecationWarning; `concrete_or_error(int, 3)` still returns `3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent DeprecationWarning by preferring concrete_or_error from jax.extend.core and only falling back to jax.core or a local shim when necessary.