### PR TITLE
docs: drop Backends section from brainunit index build

### DIFF
--- a/docs/make_brainunit_doc.py
+++ b/docs/make_brainunit_doc.py
@@ -17,6 +17,23 @@
 
 import glob
 import os
+import re
+
+# The brainunit docs don't ship the multi-backend section, so drop its toctree
+# block from the index when generating the brainunit version of the docs.
+_BACKENDS_TOCTREE = re.compile(
+    r'^\.\. toctree::\n'            # the toctree directive
+    r'(?:[ \t]+:[^\n]*\n)*?'       # option lines (:hidden:, :maxdepth:, ...)
+    r'[ \t]+:caption: Backends\n'  # ...specifically the Backends section
+    r'(?:[^\n]*\n)*?'              # blank lines + entry lines
+    r'(?=\.\. toctree::)',         # stop before the next toctree
+    re.MULTILINE,
+)
+
+
+def _remove_backends_section(content):
+    """Remove the 'Backends' toctree block from index content (brainunit only)."""
+    return _BACKENDS_TOCTREE.sub('', content)
 
 
 def make(root_dir):
@@ -47,6 +64,10 @@ def make(root_dir):
 
             # Replace occurrences of 'saiunit' with 'brainunit'
             modified_content = content.replace('saiunit', 'brainunit')
+
+            # The brainunit docs have no Backends section; strip it from the index.
+            if os.path.basename(file_path) == 'index.rst':
+                modified_content = _remove_backends_section(modified_content)
 
             # Define the destination file path
             relative_path = os.path.relpath(file_path, source_dir)


### PR DESCRIPTION
## Summary

For the **brainunit** documentation build only, strip the `Backends` toctree block from `index.rst`.

The Backends section is saiunit-specific. The brainunit docs are generated by `make_brainunit_doc.make()` (invoked from `conf.py` when `TARGET=brainunit`), which rewrites the shared docs `saiunit`→`brainunit`. This change removes the Backends `toctree` from `index.rst` during that transform, so the saiunit `index.rst` is left untouched and still shows Backends.

## Changes

- `docs/make_brainunit_doc.py`: add `_remove_backends_section()` (regex anchored on the `:caption: Backends` toctree) and apply it to `index.rst` after the `saiunit`→`brainunit` replacement.

## Verification

Ran the transform against the real `index.rst`:
- Backends caption and all 8 `backends/*` entries removed.
- The other 5 sections preserved in order (Getting Started, Physical Units, Unit-aware Operations, Advanced Tutorials, API Documentation).
- Clean seam between Getting Started and Physical Units (no stray blank lines / dangling directives).
- saiunit `index.rst` on disk unchanged.

## Note

The `docs/backends/*.ipynb` notebooks still exist, so the brainunit build will emit non-fatal "not in any toctree" warnings and still execute them. Excluding them via `exclude_patterns` in `conf.py` can be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update the brainunit doc generation script to strip the Backends toctree block from index.rst so that Backends appears only in the saiunit docs.