### PR TITLE
Release 0.3.2: JAX import-warning fix and brainunit doc cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## Version 0.3.2
+
+### Highlights
+
+Version 0.3.2 is a maintenance release that restores clean compatibility
+with recent JAX releases and tidies the generated ``brainunit``
+documentation. There are no API changes; upgrading is a drop-in
+replacement for 0.3.1.
+
+### Bug fixes
+
+- **Stop emitting a JAX ``DeprecationWarning`` on import.** ``saiunit``
+  imports ``concrete_or_error`` from JAX, which moved to
+  ``jax.extend.core`` in JAX 0.10. The previous ``try: from jax.core
+  import concrete_or_error`` branch still succeeded on JAX ≥ 0.10 — the
+  old alias is deprecated, not removed — so it kept firing and surfaced a
+  ``DeprecationWarning`` to every downstream user while the intended
+  fallback shim never ran. The import now prefers
+  ``jax.extend.core.concrete_or_error`` (JAX ≥ 0.10), falls back to
+  ``jax.core`` for older JAX, and only then to the minimal internal shim
+  (#103).
+
+### Documentation
+
+- **Drop the saiunit-specific *Backends* section from the brainunit doc
+  build.** The ``Backends`` toctree applies to ``saiunit`` only;
+  ``make_brainunit_doc`` now strips it from ``index.rst`` when generating
+  the ``brainunit`` documentation, leaving the ``saiunit`` index
+  unchanged (#104).
+
 ## Version 0.3.1
 
 ### Highlights

--- a/saiunit/_version.py
+++ b/saiunit/_version.py
@@ -15,5 +15,5 @@
 
 """Project version information."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __version_info__ = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
Bump version to 0.3.2 and add a changelog entry covering:
- avoid the deprecated jax.core.concrete_or_error import that surfaced a
  DeprecationWarning on JAX >= 0.10 (#103)
- drop the saiunit-specific Backends section from the generated brainunit
  documentation (#104)

## Summary by Sourcery

Release version 0.3.2 with a JAX import compatibility fix and documentation cleanup for the generated brainunit docs.

Bug Fixes:
- Resolve a JAX DeprecationWarning on import by updating the concrete_or_error import path to prefer the newer JAX APIs while maintaining backward compatibility.

Documentation:
- Document the 0.3.2 maintenance release in the changelog, including the JAX import fix and documentation cleanup.
- Exclude the saiunit-specific Backends section from the generated brainunit documentation index to keep brainunit docs focused and accurate.