### PR TITLE
fix: preserve fractional exponents in get_or_create_dimension keyword form

### DIFF
--- a/saiunit/_base_dimension.py
+++ b/saiunit/_base_dimension.py
@@ -759,7 +759,9 @@ def get_or_create_dimension(*args, **kwds) -> Dimension:
             raise TypeError("Need a sequence of exactly 7 items")
     else:
         # initialisation by keywords
-        dims = np.asarray([0, 0, 0, 0, 0, 0, 0])
+        # Use a plain list (not an int array) so fractional exponents such
+        # as metre=0.5 are preserved; np.asarray below picks the dtype.
+        dims = [0, 0, 0, 0, 0, 0, 0]
         for k in kwds:
             # _dim2index stores the index of the dimension with name 'k'
             dims[_dim2index[k]] = kwds[k]

--- a/saiunit/_base_dimension_test.py
+++ b/saiunit/_base_dimension_test.py
@@ -280,6 +280,14 @@ class TestGetOrCreateDimension:
         assert d.get_dimension("kg") == 1
         assert d.get_dimension("s") == -2
 
+    def test_fractional_exponent_by_keyword(self):
+        # Fractional exponents passed by keyword must be preserved, not
+        # truncated to int. The list-form and ** paths already do this.
+        d = get_or_create_dimension(metre=0.5)
+        assert not d.is_dimensionless
+        assert d.get_dimension("m") == 0.5
+        assert d == get_or_create_dimension([0.5, 0, 0, 0, 0, 0, 0])
+
     def test_singleton_by_list(self):
         d1 = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])
         d2 = get_or_create_dimension([1, 0, 0, 0, 0, 0, 0])


### PR DESCRIPTION
The keyword-construction path built the exponent vector as an int64 numpy
array (np.asarray([0, 0, 0, 0, 0, 0, 0])), so assigning a fractional value
such as metre=0.5 was silently truncated to 0. As a result
get_or_create_dimension(metre=0.5) returned DIMENSIONLESS instead of m^0.5,
inconsistent with the list form ([0.5, 0, ...]) and the ** operator, both of
which preserve fractional powers.

Build the exponents as a plain Python list so the subsequent np.asarray picks
a float dtype when needed. Adds a regression test.

## Summary by Sourcery

Preserve fractional exponents when constructing dimensions via keyword arguments and add a regression test to cover this behavior.

Bug Fixes:
- Fix keyword-based dimension construction truncating fractional exponents by ensuring exponents are stored with a floating-point-capable container.

Tests:
- Add a regression test verifying that fractional exponents passed via keywords produce the correct non-dimensionless dimension and match the list-based constructor.