### PR TITLE
fix base unit scaled unit factor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ docs/_static/js/brainx-header.js
 /CLAUDE.md
 /docs/_static/js/brainx-footer.js
 /docs/_static/css/brainx-footer.css
+/dev/audit_progress.md

--- a/saiunit/_base_unit.py
+++ b/saiunit/_base_unit.py
@@ -1426,6 +1426,7 @@ class Unit:
             dispname=dispname,
             scale=scale,
             base=baseunit.base,
+            factor=baseunit.factor,
             is_fullname=True,
         )
         add_standard_unit(u)

--- a/saiunit/_base_unit_test.py
+++ b/saiunit/_base_unit_test.py
@@ -215,6 +215,17 @@ class TestUnitCreate:
         assert scaled.dispname == "mtlm"
         assert scaled.scale == -3
 
+    def test_create_scaled_unit_preserves_factor(self):
+        # Scaling a unit with a non-unit conversion factor (e.g. calorie =
+        # 4.184 J) must keep the factor; otherwise the scaled unit's
+        # magnitude is wrong (kcal would convert as 1000, not 4184).
+        energy = get_or_create_dimension([2, 1, -2, 0, 0, 0, 0])
+        cal = Unit.create(energy, name="testcalorie", dispname="tcal", factor=4.184)
+        kcal = Unit.create_scaled_unit(cal, "k")
+        assert kcal.factor == 4.184
+        assert kcal.scale == 3
+        assert kcal.magnitude == 4.184 * 1e3
+
     def test_create_scaled_unit_invalid_prefix(self):
         base = Unit(DIMENSIONLESS, name="x", dispname="x")
         with pytest.raises(ValueError, match="Unknown SI prefix"):


### PR DESCRIPTION
- **fix: add audit_progress.md to .gitignore**
- **fix: preserve the base unit's factor in Unit.create_scaled_unit**

## Summary by Sourcery

Preserve non-unit conversion factors when creating scaled units and add regression coverage for the behavior.

Bug Fixes:
- Ensure Unit.create_scaled_unit preserves the base unit's factor so scaled units keep the correct magnitude.

Tests:
- Add a regression test verifying that scaled units derived from units with non-unit conversion factors retain the original factor and correct magnitude.

Chores:
- Ignore audit_progress.md in version control.