### PR TITLE
fix type check array api compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ docs/_static/js/brainx-header.js
 /CLAUDE.md
 /docs/_static/js/brainx-footer.js
 /docs/_static/css/brainx-footer.css
+/dev/audit_progress.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ all = ["saiunit[jax,cupy,torch,dask,ndonnx]"]
 # core requirements (numpy + jax) installed.
 [[tool.mypy.overrides]]
 module = [
+    "array_api_compat",
+    "array_api_compat.*",
     "brainstate",
     "brainstate.*",
     "cupy",


### PR DESCRIPTION
- **fix: add audit_progress.md to .gitignore**
- **fix: silence mypy import-untyped errors for array_api_compat**

## Summary by Sourcery

Adjust type checking configuration and ignore a generated audit file.

Bug Fixes:
- Disable mypy import-untyped checks for the array_api_compat package to avoid spurious type errors.

Chores:
- Add audit_progress.md to .gitignore so the generated audit progress file is not tracked.