### PR TITLE
fix: support one-sided Quantity.clip (min-only or max-only)

### DIFF
--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -2457,9 +2457,14 @@ class Quantity:
             >>> q.clip(min=u.Quantity(1.5, unit=u.mV), max=u.Quantity(2.5, unit=u.mV))
             Quantity([1.5 2.  2.5], "mV")
         """
-        _, min = unit_scale_align_to_first(self, min)
-        _, max = unit_scale_align_to_first(self, max)
-        return Quantity(get_backend(self, min, max).clip(self.mantissa, min.mantissa, max.mantissa), unit=self.unit)  # type: ignore[union-attr]
+        if min is None and max is None:
+            raise ValueError("clip requires at least one of `min` or `max` to be specified.")
+        # Align only the bounds that are given; a missing bound stays ``None``
+        # and is passed straight to the backend ``clip`` (numpy/jax accept
+        # ``None`` for an unbounded side). Aligning ``None`` previously crashed.
+        min_val = None if min is None else unit_scale_align_to_first(self, min)[1].mantissa
+        max_val = None if max is None else unit_scale_align_to_first(self, max)[1].mantissa
+        return Quantity(get_backend(self).clip(self.mantissa, min_val, max_val), unit=self.unit)
 
     def conj(self) -> 'Quantity':
         """

--- a/saiunit/_base_quantity_test.py
+++ b/saiunit/_base_quantity_test.py
@@ -577,6 +577,13 @@ class TestQuantityIntegration:
         b = Quantity([1, 2.])
         assert u.math.allclose(b.clip(1.5, 2.5), u.math.asarray([1.5, 2.]))
 
+    def test_clip_one_sided(self):
+        # The docstring states at least one of min/max suffices (numpy/jax
+        # allow one-sided clipping). Passing only one bound must not crash.
+        a = [1., 2., 3.] * u.ms
+        assert u.math.allclose(a.clip(min=1.5 * u.ms), [1.5, 2., 3.] * u.ms)
+        assert u.math.allclose(a.clip(max=2.5 * u.ms), [1., 2., 2.5] * u.ms)
+
     def test_round(self):
         for unit in [u.ms, u.joule, u.mV]:
             a = [1.1, 2.2] * unit


### PR DESCRIPTION
Quantity.clip documents that "at least one of min or max must be given",
but passing only one bound crashed: the unset bound defaulted to None and
unit_scale_align_to_first(self, None) raised
AttributeError: 'NoneType' object has no attribute 'in_unit'.

Align only the bounds that are actually provided and pass None through to the
backend clip (numpy/jax accept None for an unbounded side). Raise a clear
ValueError when both bounds are None. Adds a regression test.

## Summary by Sourcery

Ensure Quantity.clip supports one-sided clipping bounds without crashing and add coverage for this behavior.

Bug Fixes:
- Prevent Quantity.clip from raising an AttributeError when only min or only max is provided by correctly handling missing bounds.

Tests:
- Add regression tests verifying that Quantity.clip works correctly with only a minimum or only a maximum bound specified.