### PR TITLE
fix: validate_units(strict=True) must check dimension, not just magnitude

### DIFF
--- a/saiunit/typing.py
+++ b/saiunit/typing.py
@@ -595,7 +595,11 @@ def validate_units(func=None, *, strict: bool = False):
                 )
 
             if check_kind == "unit" and strict:
-                if not value.unit.has_same_magnitude(ref):
+                # Exact unit match: same dimension AND same scale/base/factor.
+                # has_same_magnitude alone ignores dimension, so without the
+                # dimension guard every coherent SI unit (scale 0) would be
+                # accepted regardless of dimension.
+                if not (value.unit.has_same_dim(ref) and value.unit.has_same_magnitude(ref)):
                     raise UnitMismatchError(
                         f"Argument {param_name!r} of {func.__name__!r} "
                         f"expected unit {ref}, got {value.unit}."

--- a/saiunit/typing_test.py
+++ b/saiunit/typing_test.py
@@ -368,6 +368,22 @@ class TestValidateUnits:
         result = f(1.0 * u.meter)
         assert result.mantissa == 1.0
 
+    def test_strict_mode_rejects_wrong_dimension(self):
+        # Strict mode must still reject a dimension mismatch even when the
+        # offending unit shares scale/base/factor with the target — every
+        # coherent SI unit has scale 0, base 10, factor 1, so a pure
+        # magnitude comparison would wrongly accept metre/ohm for a volt.
+        @validate_units(strict=True)
+        def f(V: u.Quantity[u.volt]):
+            return V
+
+        with pytest.raises(Exception):
+            f(5.0 * u.meter)
+        with pytest.raises(Exception):
+            f(5.0 * u.ohm)
+        # the correct unit still passes
+        assert f(5.0 * u.volt).mantissa == 5.0
+
     def test_physical_type_annotation(self):
         @validate_units
         def f(x: u.Quantity["length"]):  # type: ignore[name-defined]


### PR DESCRIPTION
In strict mode, argument validation compared only Unit.has_same_magnitude
(scale/base/factor), which ignores dimension. Because every coherent SI
unit has scale 0, base 10, factor 1, a strict 'Quantity[volt]' annotation
silently accepted metre, ohm, second, etc. — strict mode failed to catch
the very dimension mismatches non-strict mode catches.

Require both has_same_dim and has_same_magnitude for an exact unit match.
Adds a regression test (strict volt annotation rejects metre/ohm, accepts
volt). Existing strict tests (rejects different scale, accepts same unit)
still pass.

## Summary by Sourcery

Ensure strict unit-annotated argument validation enforces exact unit matches rather than only magnitude equivalence.

Bug Fixes:
- Fix strict validate_units unit checks so they reject arguments with the wrong physical dimension even if they share the same magnitude parameters.

Tests:
- Add regression tests confirming strict volt-annotated parameters reject metre/ohm and accept volt.