### PR TITLE
fix: CustomArray.sort() corrupts numpy-backed data to None

### DIFF
--- a/saiunit/custom_array.py
+++ b/saiunit/custom_array.py
@@ -613,7 +613,11 @@ class CustomArray:
             When ``a`` is an array with fields defined, this argument specifies
             which fields to compare first, second, etc.
         """
-        self.data = self.data.sort(axis=axis, stable=stable, order=order)
+        # Use the backend-agnostic ``math.sort`` (returns a new sorted array on
+        # every backend). numpy's ``ndarray.sort`` sorts in place and returns
+        # None, so assigning ``self.data = self.data.sort(...)`` would corrupt
+        # a numpy-backed array to None.
+        self.data = math.sort(self.data, axis=axis, stable=stable, order=order)
 
     def squeeze(self, axis=None):
         """Remove axes of length one from ``a``."""

--- a/saiunit/custom_array_test.py
+++ b/saiunit/custom_array_test.py
@@ -522,6 +522,23 @@ class TestArrayWithCustomArrayIntegration:
         arr_squeezable = SimpleArray(np.array([[[1, 2, 3]]]))
         np.testing.assert_array_equal(arr_squeezable.squeeze(), np.array([1, 2, 3]))
 
+    def test_array_sort(self):
+        # sort() must leave ``data`` sorted in place for every backend.
+        # numpy's ndarray.sort() sorts in place and returns None, so a naive
+        # ``self.data = self.data.sort()`` corrupts the wrapped array to None.
+        arr = SimpleArray(np.array([3, 1, 2]))
+        arr.sort()
+        np.testing.assert_array_equal(arr.data, np.array([1, 2, 3]))
+
+        jarr = SimpleArray(jnp.array([3.0, 1.0, 2.0]))
+        jarr.sort()
+        np.testing.assert_array_equal(jarr.data, jnp.array([1.0, 2.0, 3.0]))
+
+        # 2-D along an explicit axis
+        arr2d = SimpleArray(np.array([[3, 1], [2, 4]]))
+        arr2d.sort(axis=0)
+        np.testing.assert_array_equal(arr2d.data, np.array([[2, 1], [3, 4]]))
+
     def test_array_indexing_and_slicing(self):
         arr = SimpleArray(np.array([10, 20, 30, 40, 50]))
 


### PR DESCRIPTION
numpy's ndarray.sort() sorts in place and returns None, so
'self.data = self.data.sort(...)' set the wrapped array to None for any
numpy-backed CustomArray (it happened to work on JAX, whose immutable
.sort() returns a new array). Route through the backend-agnostic
math.sort, which returns a new sorted array on every backend.

Adds a regression test covering numpy, JAX, and a 2-D axis sort.

## Summary by Sourcery

Fix CustomArray.sort() to use a backend-agnostic sort implementation and add coverage to ensure consistent behavior across numpy and JAX backends, including multi-dimensional axis sorting.

Bug Fixes:
- Prevent CustomArray.sort() from corrupting numpy-backed arrays by replacing the in-place ndarray.sort() usage with a backend-agnostic sort that returns a new array.

Tests:
- Add regression tests verifying CustomArray.sort() correctly sorts data in place for numpy and JAX backends, including 2-D sorting along an explicit axis.