### PR TITLE
fix: scatter power with repeated indices on numpy/cupy applied power only once

### DIFF
--- a/saiunit/_scatter.py
+++ b/saiunit/_scatter.py
@@ -283,22 +283,31 @@ def _scatter_npy_like(xp, mantissa, index, value, op: str, *, mode, fill_value):
             out[sub_safe] = value(out[sub_safe])
         return out
 
-    # power: gather + pow + scatter (np.power.at doesn't exist)
+    # power: raise the indexed elements via the ``power`` ufunc's ``.at`` so
+    # repeated indices accumulate (JAX applies the power once per occurrence,
+    # e.g. ``.at[[0,0]].power(2)`` yields ``(x**2)**2``). Plain
+    # ``out[idx] = out[idx] ** value`` would be last-write-wins for repeated
+    # indices — applying the power only once. ``power`` is a ufunc on both numpy
+    # and cupy, so ``xp.power.at`` exists, mirroring the add/multiply paths below.
     if op == "power":
         if not isinstance(value, (int, np.integer)):
             raise TypeError(f"power exponent must be an integer, but got {type(value).__name__}")
         out = mantissa.copy()
         if not _is_simple_int_index(index) or mode == "clip":
-            out[index] = out[index] ** value
+            if mode == "clip" and _is_simple_int_index(index):
+                safe, _ = _normalize_simple_int(index, mantissa.shape[0], "clip")
+                xp.power.at(out, safe, value)
+            else:
+                xp.power.at(out, index, value)
             return out
         safe, valid = _normalize_simple_int(index, mantissa.shape[0], mode)
         if valid is None or (isinstance(valid, np.bool_) and bool(valid)):
-            out[safe] = out[safe] ** value
+            xp.power.at(out, safe, value)
         elif isinstance(valid, np.bool_):
             pass
         else:
             sub_safe = safe[valid]
-            out[sub_safe] = out[sub_safe] ** value
+            xp.power.at(out, sub_safe, value)
         return out
 
     out = mantissa.copy()

--- a/saiunit/_scatter_test.py
+++ b/saiunit/_scatter_test.py
@@ -216,6 +216,20 @@ def test_power_integer(backend):
     assert r.unit == meter ** 2
 
 
+def test_power_repeated_indices_accumulates(backend):
+    # JAX applies the power once per index occurrence, so a repeated index
+    # raises that element multiple times: ((x**2)**2) at idx 0. numpy/cupy must
+    # match. (torch/dask are documented last-write-wins / mask-based.)
+    if backend in ("ndonnx", "torch", "dask"):
+        pytest.skip("repeated-index power accumulation is a documented limitation here")
+    q = _make_quantity([2.0, 3.0, 4.0, 5.0], meter, backend)
+    idx = np.asarray([0, 0])
+    r = q.at[idx].power(2)
+    # (2**2)**2 == 16 at idx 0; others unchanged.
+    np.testing.assert_allclose(_to_numpy(r), [16.0, 3.0, 4.0, 5.0])
+    assert r.unit == meter ** 2
+
+
 def test_power_non_integer_raises(backend):
     if backend == "ndonnx":
         pytest.skip()


### PR DESCRIPTION
Quantity.at[idx].power(n) on a numpy- or cupy-backed Quantity computed the
power via gather + pow + scatter (out[idx] = out[idx] ** n). For repeated
indices this is last-write-wins: the power is applied a single time instead
of once per occurrence. JAX applies it per occurrence, so .at[[0,0]].power(2)
must yield (x**2)**2 == x**4 at index 0, but numpy returned x**2.

This contradicted both JAX's documented semantics (which this module targets)
and the module's own backend matrix, which marks numpy/cupy power as 'ok'
(no caveat). The add/multiply/divide/min/max paths already use ufunc.at,
which accumulates correctly; power was the lone op special-cased on the false
premise that 'np.power.at doesn't exist'. numpy and cupy both expose power as
a ufunc, so power.at exists and accumulates exactly like JAX.

Route power through xp.power.at, mirroring the arithmetic-op structure. This
also fixes repeated positions in multidimensional/tuple fancy indices for free.
Add test_power_repeated_indices_accumulates (failed on numpy: returned x**2).

## Summary by Sourcery

Ensure scatter power operations on numpy/cupy-backed quantities accumulate exponentiation for repeated indices, matching JAX semantics.

Bug Fixes:
- Fix scatter power with repeated indices on numpy/cupy so the exponent is applied once per index occurrence instead of last-write-wins.

Tests:
- Add a backend-parameterized test verifying that repeated-index power operations accumulate correctly on supported backends and documenting skips where accumulation is not supported.