### PR TITLE
fix: exprel second derivative is NaN at exactly x=0 (reverse-over-reverse)

### DIFF
--- a/saiunit/math/_exprel.py
+++ b/saiunit/math/_exprel.py
@@ -311,11 +311,21 @@ def _exprel_deriv(x, order: Optional[int] = None):
     dtype = x.dtype
     threshold = _get_threshold(dtype)
     abs_x = jnp.abs(x)
+    is_small = abs_x <= threshold
+
+    # Guard the direct branch against ``x == 0``. ``_exprel_deriv_direct`` is
+    # ``((x-1)*exp(x)+1)/x**2`` — a removable ``0/0`` at ``x = 0``. ``where``
+    # masks the *value*, but under differentiation (e.g. ``grad(grad(exprel))``)
+    # the unselected branch's gradient is still evaluated, and ``d/dx`` of the
+    # direct form is NaN at 0, poisoning the result via ``0 * NaN``. Feeding the
+    # direct branch a safe non-zero ``x`` wherever the Taylor branch is selected
+    # keeps that gradient finite; the outer ``where`` discards the value anyway.
+    safe_x = jnp.where(is_small, jnp.ones_like(x), x)
 
     return jnp.where(
-        abs_x <= threshold,
+        is_small,
         _exprel_deriv_taylor(x, order),
-        _exprel_deriv_direct(x)
+        _exprel_deriv_direct(safe_x)
     )
 
 

--- a/saiunit/math/_exprel_test.py
+++ b/saiunit/math/_exprel_test.py
@@ -407,6 +407,21 @@ class TestExprelSecondOrder:
         assert not jnp.any(jnp.isnan(hessian)), "Hessian contains NaN"
         assert not jnp.any(jnp.isinf(hessian)), "Hessian contains Inf"
 
+    def test_grad_of_grad_at_zero(self):
+        """Reverse-over-reverse second derivative at exactly 0 must be finite.
+
+        ``jax.grad(jax.grad(exprel))`` differentiates ``_exprel_deriv``, which
+        selects between a Taylor branch and the direct branch
+        ``((x-1)*exp(x)+1)/x**2`` — the latter is ``0/0`` at ``x=0``. The
+        ``where`` masks the value, but the unselected direct branch's gradient
+        is NaN and poisons the result via ``0 * NaN``. (The forward-over-reverse
+        ``jax.hessian`` path above happens to avoid it; reverse-over-reverse
+        does not.) The limit is ``f''(0) = 1/3``.
+        """
+        d2 = jax.grad(jax.grad(exprel))(jnp.asarray(0.0))
+        assert not jnp.isnan(d2), f"second derivative at 0 is NaN: {d2}"
+        assert jnp.allclose(d2, 1.0 / 3.0, rtol=1e-4), f"expected 1/3, got {d2}"
+
 
 class TestExprelBatching:
     """Tests for vmap batching."""


### PR DESCRIPTION
jax.grad(jax.grad(exprel))(0.0) returned NaN instead of the limit f''(0)=1/3.
_exprel_deriv selects via jnp.where between a Taylor branch and the direct
branch ((x-1)*exp(x)+1)/x**2, which is 0/0 at x=0. The where masks the value,
but under reverse-over-reverse differentiation the unselected direct branch's
gradient is still evaluated and is NaN at 0, poisoning the result through the
0*NaN term — the classic 'NaN gradient through where' trap.

The existing Hessian tests only exercised the forward-over-reverse path
(jax.hessian = jacfwd(jacrev)), which happens to dodge the NaN, so the bug in
the very common grad(grad) idiom went uncaught. NaN silently poisons any Hessian
involving exprel evaluated at zero (e.g. zero potential difference in GHK-type
equations).

Feed the direct branch a safe non-zero x wherever the Taylor branch is selected
(safe_x = where(is_small, 1, x)); its gradient stays finite and the outer where
discards that value anyway. Values and the first derivative are unchanged; all
four second-order AD compositions now give 1/3 at exactly 0.

Add test_grad_of_grad_at_zero (failed: NaN before the fix).

## Summary by Sourcery

Ensure exprel has a finite and correct second derivative at x=0 under reverse-over-reverse autodiff and prevent NaNs from propagating in this case.

Bug Fixes:
- Prevent NaNs in the reverse-over-reverse second derivative of exprel at x=0 by guarding the direct branch evaluation used in autodiff.

Tests:
- Add a regression test verifying that jax.grad(jax.grad(exprel))(0.0) is finite and equals 1/3.