### PR TITLE
fix: math.gradient on 1-D Quantity with spacing returned a list of scalars

### DIFF
--- a/saiunit/math/_misc.py
+++ b/saiunit/math/_misc.py
@@ -712,10 +712,16 @@ def gradient(
             return xp.gradient(f)  # type: ignore[arg-type]
     elif len(varargs) == 1:
         unit = get_unit(f) / get_unit(varargs[0])
+        grad = xp.gradient(f_mantissa, varargs_mantissa[0], axis=axis)  # type: ignore[arg-type]
         if isinstance(unit, Unit) and unit.is_unitless:
-            return xp.gradient(f_mantissa, varargs_mantissa[0], axis=axis)  # type: ignore[arg-type]
-        else:
-            return [Quantity(r, unit=unit) for r in xp.gradient(f_mantissa, varargs_mantissa[0], axis=axis)]
+            return grad
+        # ``xp.gradient`` returns a single array when differentiating along one
+        # axis (1-D input, or a scalar ``axis``) and a list of arrays for
+        # multiple axes. Wrap accordingly: iterating a single array would
+        # erroneously wrap each scalar element as its own Quantity.
+        if isinstance(grad, list):
+            return [Quantity(r, unit=unit) for r in grad]
+        return Quantity(grad, unit=unit)
     else:
         unit_list = [get_unit(f) / get_unit(v) for v in varargs]
         result_list = xp.gradient(f_mantissa, *varargs_mantissa, axis=axis)  # type: ignore[arg-type]

--- a/saiunit/math/_misc_test.py
+++ b/saiunit/math/_misc_test.py
@@ -321,6 +321,17 @@ def test_gradient_quantity_no_spacing_returns_quantity():
     assert_quantity(g, jnp.gradient(f.mantissa), unit=meter)
 
 
+def test_gradient_1d_with_unit_spacing_returns_single_quantity():
+    # 1-D input with a single spacing: numpy returns ONE array, so the result
+    # must be a single Quantity of the same shape as f — not a list of scalar
+    # Quantities (which is what iterating the single array element-wise yields).
+    f = jnp.array([1.0, 2.0, 4.0], dtype=jnp.float32) * meter
+    dx = 1.0 * second
+    g = u.math.gradient(f, dx)
+    assert isinstance(g, u.Quantity), f"expected a single Quantity, got {type(g).__name__}"
+    assert_quantity(g, jnp.gradient(f.mantissa, dx.mantissa), unit=meter / second)
+
+
 def test_gradient_with_unit_spacing_and_multi_axis():
     f = jnp.arange(12.0, dtype=jnp.float64).reshape(3, 4) * meter
     dy = 0.5 * second


### PR DESCRIPTION
u.math.gradient(f, dx) on a 1-D Quantity f returned a Python list of scalar
Quantities ([1*mV/ms, 1.5*mV/ms, 2*mV/ms]) instead of a single Quantity array
([1, 1.5, 2]*mV/ms). numpy's gradient returns ONE array when differentiating
along a single axis (1-D input, or a scalar axis) and a list of arrays for
multiple axes. The single-spacing branch unconditionally did
[Quantity(r, ...) for r in xp.gradient(...)], which — for a single returned
array — iterates the array element-wise and wraps each scalar separately. The
no-spacing branch already wrapped the whole result correctly, so gradient(f)
worked but gradient(f, dx) did not.

This violated the documented contract ('a single ndarray if there is only one
dimension ... same shape as f') and broke any downstream use expecting an
array (.shape, indexing, arithmetic). Existing tests only covered no-spacing
1-D and multi-axis 2-D, missing the 1-D-with-spacing path.

Branch on whether xp.gradient returned a list vs a single array and wrap
accordingly. Multi-axis (list) behaviour and the unitless path are unchanged.

Add test_gradient_1d_with_unit_spacing_returns_single_quantity (failed:
returned list).
