### PR TITLE
fix: lax.rem ignored unit scale/dimension between two Quantities

### DIFF
--- a/saiunit/lax/_lax_change_unit.py
+++ b/saiunit/lax/_lax_change_unit.py
@@ -456,6 +456,7 @@ def rem(
     x = maybe_custom_array(x)
     y = maybe_custom_array(y)
     if isinstance(x, Quantity) and isinstance(y, Quantity):
+        y = y.in_unit(x.unit)
         return maybe_decimal(Quantity(lax.rem(x.mantissa, y.mantissa, **kwargs), unit=x.unit))
     elif isinstance(x, Quantity):
         return maybe_decimal(Quantity(lax.rem(x.mantissa, y, **kwargs), unit=x.unit))  # type: ignore[arg-type]

--- a/saiunit/lax/_lax_change_unit_test.py
+++ b/saiunit/lax/_lax_change_unit_test.py
@@ -277,10 +277,9 @@ class TestLaxChangeUnit(parameterized.TestCase):
     @parameterized.product(
         value=[((1.0, 2.0), (1.23, 2.34)),
                ((1.0, 2.0), (3.0, 4.0))],
-        unit1=[meter, second],
-        unit2=[volt, second]
+        unit=[meter, second]
     )
-    def test_lax_change_unit_rem(self, value, unit1, unit2):
+    def test_lax_change_unit_rem(self, value, unit):
         bulax_fun_list = [getattr(bulax, fun) for fun in lax_change_unit_rem]
         lax_fun_list = [getattr(lax, fun) for fun in lax_change_unit_rem]
 
@@ -292,11 +291,22 @@ class TestLaxChangeUnit(parameterized.TestCase):
             expected = lax_fun(jnp.array(value1), jnp.array(value2))
             assert_quantity(result, expected)
 
-            q1 = value1 * unit1
-            q2 = value2 * unit2
+            # Remainder requires matching dimensions; the result keeps x's unit.
+            q1 = value1 * unit
+            q2 = value2 * unit
             result = bulax_fun(q1, q2)
             expected = lax_fun(jnp.array(value1), jnp.array(value2))
-            assert_quantity(result, expected, unit=u.get_unit(unit1))
+            assert_quantity(result, expected, unit=u.get_unit(unit))
+
+    def test_lax_change_unit_rem_alignment(self):
+        # ``y`` must be rescaled to ``x``'s unit before the remainder is taken:
+        # 200 cm == 2 m, so 7 m % 200 cm == 7 m % 2 m == 1 m (not 7 m).
+        result = bulax.rem(jnp.array(7.0) * u.meter, jnp.array(200.0) * u.cm)
+        assert_quantity(result, jnp.array(1.0), unit=u.meter)
+
+        # Mismatched dimensions cannot be reduced and must raise.
+        with self.assertRaises(u.UnitMismatchError):
+            bulax.rem(jnp.array(7.0) * u.meter, jnp.array(2.0) * u.second)
 
     @parameterized.product(
         value=[(1.0, 2.0), (1.23, 2.34, 3.45)],


### PR DESCRIPTION
sulax.rem(x, y) with two Quantities computed lax.rem(x.mantissa,
y.mantissa) directly, without rescaling y to x's unit or checking that
their dimensions match. This made physically identical inputs return
different results: rem(7*meter, 200*cm) gave 7*meter while
rem(7*meter, 2*meter) gave 1*meter, even though 200 cm == 2 m. It also
silently accepted dimensionally incoherent operands such as
rem(7*meter, 2*second).

The canonical remainder/mod/fmod in saiunit.math (all keep-unit binary
ops) already align the divisor to the dividend's unit via in_unit and
raise UnitMismatchError on a dimension mismatch. Mirror that here by
aligning y to x's unit before calling lax.rem; in_unit rescales on a
scale difference and raises on a dimension difference, fixing both the
wrong numeric result and the missing dimension check in one line.

The existing test_lax_change_unit_rem encoded the buggy behavior by
asserting rem across mismatched units (meter vs volt) equals the raw
mantissa remainder; it is updated to use a single shared unit, and a
new test_lax_change_unit_rem_alignment proves the cross-scale result
and the dimension-mismatch error.
