### PR TITLE
fix: lax.tridiagonal returned the input matrix instead of the reduced form

### DIFF
--- a/saiunit/lax/_lax_linalg.py
+++ b/saiunit/lax/_lax_linalg.py
@@ -725,7 +725,7 @@ def tridiagonal(
     a = maybe_custom_array(a)
     if isinstance(a, Quantity):
         arr, d, e, taus = lax.linalg.tridiagonal(a.mantissa, lower=lower)
-        return maybe_decimal(Quantity(a, unit=a.unit)), maybe_decimal(Quantity(d, unit=a.unit)), \
+        return maybe_decimal(Quantity(arr, unit=a.unit)), maybe_decimal(Quantity(d, unit=a.unit)), \
             maybe_decimal(Quantity(e, unit=a.unit)), taus
     else:
         return lax.linalg.tridiagonal(a, lower=lower)

--- a/saiunit/lax/_lax_linalg_test.py
+++ b/saiunit/lax/_lax_linalg_test.py
@@ -212,6 +212,19 @@ class TestLaxLinalg(parameterized.TestCase):
         assert_quantity(e, e_e, u.second)
         assert_quantity(taus, taus_e)
 
+    def test_tridiagonal_matches_jax(self):
+        # Use a 3x3 (a 2x2 is already tridiagonal, so the reduced matrix would
+        # coincide with the input and hide the bug). The first output is the
+        # reduced matrix, NOT the original input.
+        x = jnp.array([[2.0, 1.0, 0.5], [1.0, 3.0, 0.7], [0.5, 0.7, 4.0]])
+        arr_ref, d_ref, e_ref, taus_ref = lax.linalg.tridiagonal(x, lower=True)
+
+        arr, d, e, taus = ulax.tridiagonal(x * u.second, lower=True)
+        assert_quantity(arr, arr_ref, u.second)
+        assert_quantity(d, d_ref, u.second)
+        assert_quantity(e, e_ref, u.second)
+        assert_quantity(taus, taus_ref)
+
     def test_householder_product(self):
         a = jnp.array([[1.0, 2.0], [3.0, 4.0]])
         taus = jnp.array([1.0])


### PR DESCRIPTION
sulax.tridiagonal(a) unpacked the reduced matrix into a local named
'arr' but then returned Quantity(a, ...) — the original input matrix —
as the first output, discarding 'arr' entirely. The d/e diagonals were
returned correctly; only the reduced matrix (a_out) was wrong.

The existing test only compared tridiagonal(x) against a second call of
tridiagonal(x) (the buggy output against itself) on a 2x2 matrix, which
is already tridiagonal so the reduced form coincides with the input.
That hid the bug on both counts.

Return Quantity(arr, ...) so the first output is the reduced matrix, and
add a regression test on a 3x3 matrix comparing all four outputs against
jax.lax.linalg.tridiagonal.
