### PR TITLE
fix: lax.eig added a spurious axis to eigenvalues when no eigenvectors requested

### DIFF
--- a/saiunit/lax/_lax_linalg.py
+++ b/saiunit/lax/_lax_linalg.py
@@ -169,8 +169,8 @@ def eig(
                                   compute_right_eigenvectors=compute_right_eigenvectors)
     else:
         if isinstance(x, Quantity):
-            w = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,  # type: ignore[assignment]
-                               compute_right_eigenvectors=compute_right_eigenvectors)
+            (w,) = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+                                  compute_right_eigenvectors=compute_right_eigenvectors)
             return (maybe_decimal(Quantity(w, unit=x.unit)),)
         else:
             return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,

--- a/saiunit/lax/_lax_linalg_test.py
+++ b/saiunit/lax/_lax_linalg_test.py
@@ -80,6 +80,20 @@ class TestLaxLinalg(parameterized.TestCase):
         assert_quantity(vl, vl_e)
         assert_quantity(vr, vr_e)
 
+    def test_eig_no_eigenvectors(self):
+        # With both eigenvector flags off, jax.lax.linalg.eig returns a
+        # one-element sequence holding the eigenvalues with shape (n,). The
+        # Quantity path must preserve that shape, not wrap the sequence and
+        # add a spurious leading axis.
+        x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        (w_e,) = lax.linalg.eig(x, compute_left_eigenvectors=False,
+                                compute_right_eigenvectors=False)
+
+        (w,) = ulax.eig(x * u.second, compute_left_eigenvectors=False,
+                        compute_right_eigenvectors=False)
+        self.assertEqual(w.mantissa.shape, w_e.shape)
+        assert_quantity(w, w_e, u.second)
+
     def test_cholesky(self):
         x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
 


### PR DESCRIPTION
When called with compute_left_eigenvectors=False and
compute_right_eigenvectors=False on a Quantity, sulax.eig assigned the
whole one-element sequence returned by jax.lax.linalg.eig to w and then
wrapped that sequence in a Quantity. jnp.asarray of a one-element list
adds a leading axis, so the eigenvalues came back with shape (1, n)
instead of (n,). Existing comparisons passed only because assert_quantity
broadcasts (1, n) against (n, n) element-wise, masking the shape error.

Unpack the one-element result ((w,) = ...) so the eigenvalues keep their
(n,) shape, and add test_eig_no_eigenvectors which asserts the shape
explicitly against jax.lax.linalg.eig.
