### PR TITLE
fix: Quantity repr/format crashes and wrong format-spec semantics

### DIFF
--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import functools
 import numbers
 import operator
-import re
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from typing import Any
@@ -1159,9 +1158,12 @@ class Quantity:
             # Prefer ``jnp.asarray`` when JAX is installed so the precision
             # matches JAX's x32 default (test fixtures key off this); fall
             # back to NumPy when JAX is unavailable.
+            # OverflowError: Python ints that exceed the backend integer
+            # dtype (e.g. 2**40 under JAX's x32 default). Keep the raw
+            # value; the fallback below prints it via ``str``.
             try:
                 value = jnp.asarray(m) if HAS_JAX else np.asarray(m)
-            except TypeError:
+            except (TypeError, OverflowError):
                 value = m
         else:
             # cupy / torch / dask / ndonnx arrays: don't lift to JAX (that
@@ -1560,8 +1562,11 @@ class Quantity:
     def __format__(self, format_spec) -> str:
         if not format_spec:
             return str(self)
-        # Block '%' format on quantities with units — "50% mV" is meaningless
-        if '%' in format_spec and not self.unit.is_unitless:
+        # Block '%'-type format on quantities whose unit is displayed —
+        # "50% mV" (or "50% rad") is meaningless. The format type is always
+        # the last character of the spec, so a '%' used as a fill character
+        # (e.g. '%>10') is not rejected.
+        if format_spec.endswith('%') and self.unit.should_display_unit:
             raise ValueError(
                 f"'%' format is not supported for Quantity with unit {str(self.unit)!r}. "
                 f"Convert to a dimensionless value first."
@@ -1569,22 +1574,37 @@ class Quantity:
         unit_str = str(self.unit)
         show_unit = self.unit.should_display_unit
         if self.shape == ():
-            formatted_value = format(self.mantissa, format_spec)
+            try:
+                formatted_value = format(self.mantissa, format_spec)
+            except TypeError:
+                # Mantissas that don't implement format specs (JAX tracers,
+                # lazy/symbolic backends): degrade to the plain display.
+                return str(self)
             if not show_unit:
                 return formatted_value
             return f"{formatted_value} {unit_str}"
         else:
-            # Parse precision from standard format specs like .2f, .3e, .4g,
-            # 10.2f, +.2f, etc.  Use a regex to extract the precision field.
-            m = re.match(r'^[^.]*\.(\d+)[feEgGn%]?$', format_spec)
-            if m is not None:
-                precision = int(m.group(1))
-                value = np.asarray(self.mantissa)
-                s = np.array_str(np.round(value, precision), precision=precision)
-                if not show_unit:
-                    return s
-                return f"{s} {unit_str}"
-            return str(self)
+            # Apply the spec per element so 'e'/'g'/'%' types keep their
+            # Python semantics. Traced / lazy / symbolic mantissas cannot
+            # be converted to numpy without crashing or materializing —
+            # degrade to the plain display, exactly like ``repr`` does.
+            from saiunit._backend import is_dask_array, is_ndonnx_array
+            mantissa = self.mantissa
+            if _is_tracer(mantissa) or is_dask_array(mantissa) or is_ndonnx_array(mantissa):
+                return str(self)
+            try:
+                value = np.asarray(mantissa)
+            except (TypeError, ValueError, RuntimeError):
+                # e.g. torch tensors with requires_grad refuse __array__
+                return str(self)
+            try:
+                s = np.array2string(value, formatter={'all': lambda x: format(x, format_spec)})
+            except (TypeError, ValueError):
+                # Spec not applicable element-wise — fall back to str()
+                return str(self)
+            if not show_unit:
+                return s
+            return f"{s} {unit_str}"
 
     def __iter__(self):
         """Solve the issue of DeviceArray.__iter__.

--- a/saiunit/_base_quantity_format_test.py
+++ b/saiunit/_base_quantity_format_test.py
@@ -1,0 +1,197 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests from the Quantity string-formatting audit.
+
+Each test below pins one confirmed bug in ``__repr__`` / ``__str__`` /
+``__format__`` / ``_format_value`` (saiunit/_base_quantity.py). The docstrings
+record the wrong behavior observed before the fix.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import saiunit as u
+from saiunit import Quantity
+
+
+class TestReprLargePythonInt:
+    def test_repr_does_not_crash_on_large_python_int(self):
+        """``_format_value`` promotes Python scalars via ``jnp.asarray`` and
+        caught only TypeError. A Python int that does not fit int32 raises
+        OverflowError, so ``repr``/``str`` crashed for values as small as
+        2**40.
+
+        Before the fix: OverflowError: Python int 1099511627776 too large to
+        convert to int32.
+        """
+        q = Quantity(2 ** 40, unit=u.mV)
+        r = repr(q)
+        s = str(q)
+        assert "1099511627776" in r
+        assert "1099511627776" in s
+
+
+class TestPercentFormatGuard:
+    def test_percent_rejected_for_named_dimensionless_unit(self):
+        """The '%' guard in ``__format__`` checked ``unit.is_unitless`` while
+        display uses ``unit.should_display_unit``. Radian is unitless by
+        magnitude but displays 'rad', so the guard let through exactly the
+        nonsense it was written to block.
+
+        Before the fix: format(Quantity(0.5, unit=u.radian), '.1%')
+        == '50.0% rad'.
+        """
+        q = Quantity(0.5, unit=u.radian)
+        with pytest.raises(ValueError):
+            format(q, ".1%")
+
+    def test_percent_as_fill_character_is_not_rejected(self):
+        """The guard tested ``'%' in format_spec``, so '%' used as a
+        legitimate fill character (e.g. '%>10') was rejected even though the
+        format type is not '%'.
+
+        Before the fix: ValueError instead of '%%%%%%%0.5 mV'
+        (plain ``format(0.5, '%>10')`` gives '%%%%%%%0.5').
+        """
+        q = Quantity(0.5, unit=u.mV)
+        assert format(q, "%>10") == "%%%%%%%0.5 mV"
+
+    def test_percent_array_keeps_percent_semantics(self):
+        """For non-scalar unitless quantities, '.1%' fell into the
+        precision-regex path which treated '%' as a plain rounding spec: no
+        x100 scaling and no '%' sign — silently wrong values. Scalars gave
+        '50.0%'; arrays gave '[0.5 0.2]'.
+
+        Either honoring percent semantics per element or rejecting the spec
+        for arrays is acceptable; silently emitting wrong numbers is not.
+        """
+        q = Quantity(np.array([0.5, 0.25]))
+        try:
+            out = format(q, ".1%")
+        except ValueError:
+            return  # explicit rejection is an acceptable contract
+        assert "%" in out, f"percent semantics dropped: {out!r}"
+
+
+class TestFormatSpecArraySemantics:
+    def test_scientific_spec_array_uses_scientific_notation(self):
+        """The array path extracted only the precision digit from '.1e' and
+        applied decimal rounding (np.round(value, 1)), ignoring the 'e' type
+        entirely. Scalars honor it ('1.2e+03'); arrays did not.
+
+        Before the fix: format(Quantity([1234.5], mV), '.1e')
+        == '[1234.5] mV'.
+        """
+        q = Quantity(np.array([1234.5]), unit=u.mV)
+        out = format(q, ".1e")
+        value_part = out.replace("mV", "")
+        assert "e" in value_part, f"scientific notation dropped: {out!r}"
+
+
+class TestFormatSpecUnderJit:
+    def test_format_spec_scalar_under_jit_does_not_crash(self):
+        """``__format__`` had no tracer guard (unlike ``_format_value``).
+        For 0-d quantities it called ``format(self.mantissa, format_spec)``
+        which raises on tracers.
+
+        Before the fix: TypeError: unsupported format string passed to
+        DynamicJaxprTracer.__format__.
+        """
+        captured = []
+
+        @jax.jit
+        def f(x):
+            q = Quantity(x, unit=u.mV)
+            captured.append(f"{q:.2f}")
+            return x
+
+        f(jnp.asarray(1.0))
+        assert captured and isinstance(captured[0], str)
+
+    def test_format_spec_array_under_jit_does_not_crash(self):
+        """For non-scalar quantities ``__format__`` called
+        ``np.asarray(self.mantissa)`` which raises
+        TracerArrayConversionError on traced arrays.
+        """
+        captured = []
+
+        @jax.jit
+        def f(x):
+            q = Quantity(x, unit=u.mV)
+            captured.append(f"{q:.2f}")
+            return x
+
+        f(jnp.arange(3.0))
+        assert captured and isinstance(captured[0], str)
+
+
+class TestFormatSpecLazyBackends:
+    def test_format_spec_dask_does_not_materialize(self):
+        """``_format_value`` never materializes dask graphs and
+        ``np.asarray(Quantity)`` raises BackendError, but
+        ``__format__('.2f')`` called ``np.asarray(self.mantissa)`` directly,
+        silently computing the whole graph.
+
+        Either a lazy-safe fallback or BackendError is acceptable; silent
+        materialization is not.
+        """
+        da = pytest.importorskip("dask.array")
+        reads = []
+
+        def spy(block):
+            if block.size:  # ignore dask's zero-size meta-inference calls
+                reads.append(block.size)
+            return block
+
+        arr = da.from_array(np.array([1.0, 2.0]), chunks=1).map_blocks(spy)
+        q = Quantity(arr, unit=u.mV)
+        reads.clear()
+        try:
+            format(q, ".2f")
+        except u.BackendError:
+            pass  # explicit rejection is an acceptable contract
+        assert not reads, "format(q, '.2f') materialized the dask graph"
+
+    def test_format_spec_ndonnx_no_opaque_crash(self):
+        """``__format__('.2f')`` applied ``np.round`` to the ndonnx symbolic
+        array, raising an opaque ufunc TypeError. ``repr``/``str`` degrade
+        gracefully for the same quantity.
+
+        Before the fix: TypeError: loop of ufunc does not support argument 0
+        of type Array which has no callable rint method.
+        """
+        ndx = pytest.importorskip("ndonnx")
+        q = Quantity(ndx.asarray(np.array([1.0, 2.0])), unit=u.mV)
+        try:
+            out = format(q, ".2f")
+        except u.BackendError:
+            return  # explicit rejection is an acceptable contract
+        assert isinstance(out, str)
+
+    def test_format_spec_torch_requires_grad_does_not_crash(self):
+        """``__format__('.2f')`` called ``np.asarray`` on the torch mantissa;
+        tensors with ``requires_grad=True`` refuse the conversion.
+        ``repr``/``str`` work for the same quantity.
+
+        Before the fix: RuntimeError: Can't call numpy() on Tensor that
+        requires grad.
+        """
+        torch = pytest.importorskip("torch")
+        q = Quantity(torch.tensor([1.5], requires_grad=True), unit=u.mV)
+        out = format(q, ".2f")
+        assert isinstance(out, str)


### PR DESCRIPTION
## Summary

Fixes nine confirmed bugs found in an audit of `Quantity.__repr__` / `__str__` / `__format__` / `_format_value` (`saiunit/_base_quantity.py`):

1. **`repr`/`str` crashed with `OverflowError`** on Python int mantissas exceeding int32 (e.g. `Quantity(2**40, u.mV)`): `_format_value` caught only `TypeError` from `jnp.asarray`. Now also catches `OverflowError` and falls back to `str`.
2. **`%` guard used the wrong predicate** (`is_unitless` vs `should_display_unit`): `f"{0.5*u.radian:.1%}"` produced the meaningless `'50.0% rad'`. Now rejected like `mV`.
3. **`%` as a fill character was falsely rejected**: the guard was a substring test, so the legal spec `'%>10'` raised. Now only the spec's type character (last char) is tested.
4. **Array `%` specs silently emitted wrong values** (no ×100, no `%` sign): `format(Quantity([0.5, 0.25]), '.1%')` gave `'[0.5 0.2]'`; now `'[50.0% 25.0%]'`.
5. **Array `e`/`g` specs ignored the format type** (treated as decimal rounding): `'.1e'` on `[1234.5]` gave `'[1234.5] mV'`; now `'[1.2e+03] mV'`. Arrays are formatted per element via `np.array2string(formatter=...)`.
6. **`f"{q:.2f}"` crashed under `jax.jit`** (scalar: tracer `__format__` TypeError; array: `TracerArrayConversionError`). Now degrades to the plain display, matching `_format_value`'s tracer handling.
7. **`f"{q:.2f}"` silently materialized dask graphs** via `np.asarray(self.mantissa)`. Now degrades lazily, consistent with `repr`/`str`.
8. **ndonnx arrays crashed with an opaque ufunc TypeError** on precision specs. Now degrade gracefully.
9. **torch tensors with `requires_grad=True` crashed** (`RuntimeError` from `__array__`). Now degrade gracefully; plain torch tensors gain proper per-element formatting.

Behavior otherwise unchanged: empty specs, scalar formatting, invalid-spec degradation for arrays (`format(q, 'xyz') == str(q)`), and `str`/`repr` output are all as before.

## Test plan

- New regression file `saiunit/_base_quantity_format_test.py`: 10 tests, one per bug (written first against the unfixed code, all failing; all pass after the fix).
- Full suite: 3556 passed + 57 sparse passed, 0 failed.
- `mypy saiunit/` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)