### PR TITLE
fix: harden Quantity APIs against 20 edge-case bugs

### DIFF
--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -162,6 +162,10 @@ def get_dim(obj) -> Dimension:
         return obj
     if isinstance(obj, Quantity):
         return obj.dim
+    if isinstance(obj, (str, bytes)):
+        # Quantity() rejects str/bytes mantissas, but get_dim keeps its
+        # duck-typing contract: anything without units is dimensionless.
+        return DIMENSIONLESS
     try:
         return Quantity(obj).dim
     except TypeError:
@@ -207,6 +211,10 @@ def get_unit(obj) -> 'Unit':
         return obj
     if isinstance(obj, Quantity):
         return obj.unit
+    if isinstance(obj, (str, bytes)):
+        # Quantity() rejects str/bytes mantissas, but get_unit keeps its
+        # duck-typing contract: anything without units is unitless.
+        return UNITLESS
     try:
         return Quantity(obj).unit
     except TypeError:
@@ -736,7 +744,10 @@ def unit_scale_align_to_first(*args) -> 'list[Quantity]':
                 items[i] = Quantity(items[i])
     else:
         for i in range(1, len(items)):
-            items[i] = items[i].in_unit(first_unit)
+            # Route through _to_quantity so raw values (plain numbers, bare
+            # arrays, Unit objects) raise a proper UnitMismatchError instead
+            # of an AttributeError on ``.in_unit``.
+            items[i] = _to_quantity(items[i]).in_unit(first_unit)
     return items
 
 

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -221,8 +221,11 @@ def _check_units_and_collect_values(lst) -> tuple[ArrayLike, Unit]:
         if isinstance(item, (list, tuple)):
             val, unit = _check_units_and_collect_values(item)
             values.append(val)
-            if unit != UNITLESS:
-                units.append(unit)
+            # Always record the sub-unit (UNITLESS included): skipping
+            # UNITLESS desynchronizes ``values`` and ``units``, turning the
+            # unit-mismatch TypeError below into an AssertionError in
+            # ``_zoom_values_with_units``.
+            units.append(unit)
         elif isinstance(item, Quantity):
             values.append(item.mantissa)
             units.append(item.unit)
@@ -278,6 +281,50 @@ def _reduction_count_from_shape(shape, axis) -> int:
     for a in axis:
         n *= int(shape[int(a)])
     return n
+
+
+def _is_comparable_operand(oc) -> bool:
+    """True if ``oc`` is numeric / array-like and may be compared with a
+    Quantity.
+
+    Non-numeric objects (None, str, dict, …) must make the comparison
+    dunders return ``NotImplemented`` — Python then falls back to identity
+    for ``==`` / ``!=`` and raises a plain TypeError for orderings —
+    instead of leaking a misleading ``UnitMismatchError``.
+    """
+    if isinstance(oc, (Quantity, Unit, numbers.Number, np.ndarray,
+                       np.generic, _JaxArray, list, tuple)):
+        return True
+    from saiunit._misc import maybe_custom_array
+    if maybe_custom_array(oc) is not oc:
+        return True
+    from saiunit._backend import (
+        is_cupy_array, is_torch_array, is_dask_array, is_ndonnx_array,
+    )
+    return (
+        is_cupy_array(oc) or is_torch_array(oc)
+        or is_dask_array(oc) or is_ndonnx_array(oc)
+    )
+
+
+def _cast_mantissa_dtype(mantissa, dtype):
+    """Cast ``mantissa`` to ``dtype``, preserving its backend.
+
+    Plain Python / NumPy scalars are promoted through the active default
+    backend (mirroring the list/tuple constructor path).
+    """
+    if isinstance(mantissa, np.ndarray):
+        return mantissa if mantissa.dtype == dtype else mantissa.astype(dtype)
+    if HAS_JAX and isinstance(mantissa, _JaxArray):
+        return jnp.asarray(mantissa, dtype=dtype)
+    if isinstance(mantissa, np.generic):
+        return np.asarray(mantissa, dtype=dtype)
+    if isinstance(mantissa, numbers.Number):
+        from saiunit._backend import _xp_for, get_default_backend
+        xp = _xp_for(get_default_backend() or ("jax" if HAS_JAX else "numpy"))
+        return xp.asarray(mantissa, dtype=dtype)
+    from saiunit._backend import get_backend as _gb
+    return _gb(mantissa).asarray(mantissa, dtype=dtype)
 
 
 def _is_concrete_zero(mantissa) -> bool:
@@ -549,6 +596,15 @@ class Quantity:
                 unit = UNITLESS
             assert isinstance(unit, Unit), f"Expected a Unit, got {type(unit).__name__}: {unit!r}"
 
+            # str/bytes are unambiguous user errors (e.g. a unit string passed
+            # positionally); accepting them as "pytree leaves" only defers the
+            # crash to the first arithmetic op with a confusing message.
+            if isinstance(mantissa, (str, bytes)):
+                raise TypeError(
+                    f"Cannot create a Quantity from a {type(mantissa).__name__} "
+                    f"mantissa: {mantissa!r}. Did you mean Quantity(value, unit={mantissa!r})?"
+                )
+
             # Handle custom arrays in the mantissa tree structure
             mantissa = maybe_custom_array_tree(mantissa)
 
@@ -588,6 +644,8 @@ class Quantity:
                     raise ValueError("Cannot create a Quantity object with a different unit.")
                 mantissa = mantissa.in_unit(unit)
                 mantissa = mantissa.mantissa
+                if dtype is not None:
+                    mantissa = _cast_mantissa_dtype(mantissa, dtype)
 
             elif isinstance(mantissa, (np.ndarray, _JaxArray)):
                 # Preserve the input backend: NumPy stays NumPy, JAX stays JAX.
@@ -599,7 +657,10 @@ class Quantity:
                 # skip if dtype matches or is not provided
 
             elif isinstance(mantissa, ((jnp.number,) if HAS_JAX else ()) + (numbers.Number,)):
-                pass  # keep as-is; jnp.array conversion deferred to use-site
+                # keep as-is; jnp.array conversion deferred to use-site —
+                # unless an explicit dtype was requested.
+                if dtype is not None:
+                    mantissa = _cast_mantissa_dtype(mantissa, dtype)
 
             else:
                 # cupy / torch / dask / ndonnx mantissas: preserve the input's
@@ -832,10 +893,12 @@ class Quantity:
             from saiunit._backend import get_backend as _gb
             xp = _gb(self_value)
             mantissa = xp.asarray(mantissa, dtype=self.dtype)
-        # check
-        if mantissa.shape != self_value.shape:
-            raise ValueError(f"The shape of the original data is {self_value.shape}, "
-                             f"while we got {mantissa.shape}.")
+        # check (``np.shape`` also handles plain-scalar mantissas)
+        if mantissa.shape != np.shape(self_value):
+            raise ValueError(f"The shape of the original data is {np.shape(self_value)}, "
+                             f"while we got {mantissa.shape}. In-place updates cannot "
+                             f"change the shape of a Quantity; use the functional form "
+                             f"(e.g. Quantity(new_mantissa, unit=q.unit)) instead.")
         # Dtype check: use numpy-canonical comparison for numpy-backed Quantity,
         # otherwise apply jax's result-type (which may downcast under x32 mode).
         expected_dtype = self_value.dtype if is_numpy_array(self_value) else _result_type(self_value)
@@ -1455,9 +1518,13 @@ class Quantity:
     def flat(self):
         """1-D iterator over the mantissa elements, unit preserved."""
         m = self._mantissa
-        if hasattr(m, "flat"):
+        try:
+            # JAX arrays *define* ``.flat`` but raise NotImplementedError on
+            # access (which also leaks straight through ``hasattr``).
             flat = m.flat
-        else:
+        except NotImplementedError:
+            flat = iter(get_backend(self).reshape(m, (-1,)))
+        except AttributeError:
             _reject_lazy_materialization(m, "Quantity.flat")
             flat = np.asarray(m).flat
         for v in flat:
@@ -1958,10 +2025,29 @@ class Quantity:
         return Quantity(abs(self.mantissa), unit=self.unit)
 
     def __invert__(self) -> 'Quantity':
+        # Bitwise NOT of a unit-bearing value is meaningless; the other
+        # bitwise operators (&, |, ^) reject units as well.
+        if not self.unit.is_unitless:
+            raise NotImplementedError(
+                "Bitwise operations are not supported for quantities with units"
+            )
         return Quantity(~self.mantissa, unit=self.unit)  # type: ignore[operator]
 
     def _comparison(self, other: Any, operator_str: str, operation: Callable):
+        if not _is_comparable_operand(other):
+            return NotImplemented
         other = _to_quantity(other)
+        # 0-as-any-dimension: a concrete zero compares with any dimension,
+        # matching the convention already used by addition/subtraction
+        # (so e.g. ``3*mV > 0`` works like ``0 + 3*mV`` does).
+        if (other.unit.is_unitless
+                and not self.unit.is_unitless
+                and _is_concrete_zero(other.mantissa)):
+            other = Quantity(other.mantissa, unit=self.unit)
+        elif (self.unit.is_unitless
+                and not other.unit.is_unitless
+                and _is_concrete_zero(self.mantissa)):
+            self = Quantity(self.mantissa, unit=other.unit)
         try:
             other_value = other.in_unit(self.unit).mantissa
         except UnitMismatchError as e:
@@ -2059,9 +2145,11 @@ class Quantity:
 
         # update the mantissa in-place or not
         if inplace:
-            if _is_tracer(self.mantissa):
-                # Under JIT/vmap/grad, mutation isn't supported; degrade to the
-                # functional form so `q += x` still works (Python rebinds the name).
+            if _is_tracer(self.mantissa) or isinstance(self.mantissa, numbers.Number):
+                # Under JIT/vmap/grad, mutation isn't supported; for plain
+                # Python scalars there is nothing to mutate either. Degrade to
+                # the functional form so `q += x` still works (Python rebinds
+                # the name).
                 return r
             self.update_mantissa(r.mantissa)
             return self
@@ -2220,6 +2308,11 @@ class Quantity:
             powered = m ** oc
         else:
             powered = get_backend(self).asarray(m) ** oc
+        if self.unit.is_unitless:
+            # A dimensionless base stays dimensionless for any exponent —
+            # including array exponents, which ``unit ** oc`` cannot express.
+            # (maybe_decimal would strip the Quantity wrapper here anyway.)
+            return powered
         r = Quantity(powered, unit=self.unit ** oc)
         return maybe_decimal(r)
 
@@ -2288,7 +2381,15 @@ class Quantity:
 
     def __ilshift__(self, oc) -> 'Quantity':
         # self <<= oc
-        r = self.__lshift__(oc)
+        # Do not route through __lshift__: maybe_decimal strips the Quantity
+        # wrapper for unitless results, which broke the in-place form.
+        if isinstance(oc, Quantity):
+            if not oc.is_unitless:
+                raise ValueError("The shift amount must be dimensionless")
+            oc = oc.mantissa
+        r = Quantity(self.mantissa << oc, unit=self.unit)
+        if _is_tracer(self.mantissa) or isinstance(self.mantissa, numbers.Number):
+            return r
         self.update_mantissa(r.mantissa)
         return self
 
@@ -2309,7 +2410,15 @@ class Quantity:
 
     def __irshift__(self, oc) -> 'Quantity':
         # self >>= oc
-        r = self.__rshift__(oc)
+        # Do not route through __rshift__: maybe_decimal strips the Quantity
+        # wrapper for unitless results, which broke the in-place form.
+        if isinstance(oc, Quantity):
+            if not oc.is_unitless:
+                raise ValueError("The shift amount must be dimensionless")
+            oc = oc.mantissa
+        r = Quantity(self.mantissa >> oc, unit=self.unit)
+        if _is_tracer(self.mantissa) or isinstance(self.mantissa, numbers.Number):
+            return r
         self.update_mantissa(r.mantissa)
         return self
 
@@ -2320,7 +2429,12 @@ class Quantity:
         :param ndigits: The number of decimals to round to.
         :return: The rounded Quantity.
         """
-        return Quantity(round(self.mantissa, ndigits), unit=self.unit)  # type: ignore[arg-type,call-overload]
+        # ``round(mantissa, ndigits)`` requires a ``__round__`` on the
+        # mantissa, which numpy arrays do not define. Scalars keep the
+        # builtin behaviour; everything else goes through the backend round.
+        if isinstance(self.mantissa, numbers.Number):
+            return Quantity(round(self.mantissa, ndigits), unit=self.unit)  # type: ignore[arg-type,call-overload]
+        return self.round(0 if ndigits is None else ndigits)
 
     def __reduce__(self):
         """
@@ -2710,9 +2824,14 @@ class Quantity:
         return maybe_decimal(r)
 
     def searchsorted(self, v, side: str = 'left', sorter=None) -> Array:
-        """Find indices where elements should be inserted to maintain order."""
-        if isinstance(v, Quantity):
-            v = v.in_unit(self.unit).mantissa
+        """Find indices where elements should be inserted to maintain order.
+
+        ``v`` must be compatible with the unit of ``self``: a plain number
+        against a unit-bearing array raises :class:`UnitMismatchError`
+        (consistent with comparison operators) instead of being silently
+        interpreted in ``self``'s unit.
+        """
+        v = _to_quantity(v).in_unit(self.unit).mantissa
         return get_backend(self, v).searchsorted(self.mantissa, v, side=side, sorter=sorter)
 
     def fill(self, value: 'Quantity') -> 'Quantity':
@@ -2766,7 +2885,12 @@ class Quantity:
             >>> q.item(0)
             Quantity(10., "mV")
         """
-        return Quantity(self.mantissa.item(*args), unit=self.unit)
+        m = self.mantissa
+        if isinstance(m, numbers.Number):
+            # Python scalars have no ``.item``; promote through numpy so the
+            # optional flat-index arguments keep numpy semantics.
+            return Quantity(np.asarray(m).item(*args), unit=self.unit)
+        return Quantity(m.item(*args), unit=self.unit)
 
     def prod(self, *args, **kwds) -> 'Quantity':
         """
@@ -2798,7 +2922,7 @@ class Quantity:
         # reduction axis. Derive it from the static shape so the computation
         # is JIT-safe (no `bool(traced_array)` or traced unit exponents).
         axis = args[0] if args else kwds.get('axis', None)
-        dim_exponent = _reduction_count_from_shape(self.mantissa.shape, axis)
+        dim_exponent = _reduction_count_from_shape(self.shape, axis)
         r = Quantity(prod_res, unit=self.unit ** dim_exponent)
         return maybe_decimal(r)
 
@@ -2838,7 +2962,7 @@ class Quantity:
         # Unit exponent is the count of elements along the reduction axis.
         # Use the static shape so the result is JIT-safe.
         axis = args[0] if args else kwds.get('axis', None)
-        dim_exponent = _reduction_count_from_shape(self.mantissa.shape, axis)
+        dim_exponent = _reduction_count_from_shape(self.shape, axis)
 
         # Eager (non-traced) inputs: verify NaN counts are uniform along the
         # reduction axis. Otherwise different output elements would carry
@@ -3007,11 +3131,14 @@ class Quantity:
             return Quantity(xp.reshape(self.mantissa, shape), unit=self.unit)
 
     def resize(self, new_shape) -> 'Quantity':
-        """Change shape and size of array in-place."""
+        """Change shape and size of array in-place (``numpy.resize`` semantics:
+        the data is repeated or truncated to fill the new shape)."""
         # ``resize`` is not in the array-API spec; both numpy and jax expose it.
+        # Rebind the mantissa directly: ``update_mantissa`` rejects any shape
+        # change, which made this method unusable for actual resizes.
         xp = get_backend(self)
         resize_fn = getattr(xp, "resize", None) or np.resize
-        self.update_mantissa(resize_fn(self.mantissa, new_shape))
+        self._mantissa = resize_fn(self.mantissa, new_shape)
         return self
 
     def sort(self, axis=-1, stable=True, order=None) -> 'Quantity':
@@ -3042,6 +3169,11 @@ class Quantity:
             >>> q.sort()
             Quantity([1. 2. 3.], "mV")
         """
+        if order is not None:
+            raise NotImplementedError(
+                "The `order` parameter (structured-array field ordering) is "
+                "not supported by Quantity.sort."
+            )
         xp = get_backend(self)
         # array-API sort has different kw names; try the standard first, fall back to numpy/jnp.
         try:
@@ -3189,8 +3321,42 @@ class Quantity:
             if not self.is_unitless:
                 raise TypeError(f"fill_value must be a Quantity when the unit {self.unit}. But got {fill_value}")
         if is_numpy_array(self._mantissa):
-            # NumPy ``take`` has a different signature; emulate the saiunit semantics.
-            taken = np.take(self.mantissa, indices, axis=axis, mode=mode if mode else 'raise')
+            # NumPy ``take`` only understands 'raise'/'wrap'/'clip'. Translate
+            # the JAX-style modes ('promise_in_bounds', 'fill', 'drop') and
+            # emulate ``fill_value`` for the fill/drop modes.
+            if mode is None or mode in ('raise', 'wrap'):
+                taken = np.take(self.mantissa, indices, axis=axis, mode=mode if mode else 'raise')
+                return Quantity(taken, unit=self.unit)
+            if mode not in ('clip', 'promise_in_bounds', 'fill', 'drop'):
+                raise ValueError(f"Invalid mode {mode!r} for Quantity.take")
+            arr = self.mantissa
+            n = arr.size if axis is None else arr.shape[axis]
+            idx = np.asarray(indices)
+            # Wrap valid negative indices once (numpy 'raise' semantics), then
+            # clamp so the gather itself is always in-bounds.
+            idx_norm = np.where(idx < 0, idx + n, idx)
+            oob = (idx_norm < 0) | (idx_norm >= n)
+            idx_clipped = np.clip(idx_norm, 0, max(n - 1, 0))
+            taken = np.take(arr, idx_clipped, axis=axis)
+            if mode in ('fill', 'drop') and np.any(oob):
+                fv = fill_value
+                if fv is None:
+                    # Mirror jnp.take's documented defaults.
+                    dt = taken.dtype
+                    if np.issubdtype(dt, np.inexact):
+                        fv = np.nan
+                    elif dt == np.bool_:
+                        fv = True
+                    elif np.issubdtype(dt, np.unsignedinteger):
+                        fv = np.iinfo(dt).max
+                    else:
+                        fv = np.iinfo(dt).min
+                if axis is None:
+                    mask = oob.reshape(idx.shape)
+                else:
+                    ax = axis % arr.ndim
+                    mask = oob.reshape((1,) * ax + idx.shape + (1,) * (arr.ndim - ax - 1))
+                taken = np.where(mask, np.asarray(fv, dtype=taken.dtype), taken)
             return Quantity(taken, unit=self.unit)
         if is_jax_array(self._mantissa):
             return Quantity(
@@ -3611,7 +3777,10 @@ class Quantity:
         if isinstance(array, Quantity):
             fail_for_dimension_mismatch(self, array, "expand_as (Quantity)")
             array = array.mantissa
-        return Quantity(get_backend(self).broadcast_to(self.mantissa, array), unit=self.unit)
+        # Accept either an actual array (use its shape) or a raw shape tuple;
+        # passing the array itself to ``broadcast_to`` crashed.
+        shape = array.shape if hasattr(array, "shape") else array
+        return Quantity(get_backend(self).broadcast_to(self.mantissa, shape), unit=self.unit)
 
     def pow(self, oc) -> 'Quantity':
         """
@@ -3862,8 +4031,17 @@ class _IndexUpdateRef:
         Returns the value of ``x`` that would result from the NumPy-style
         :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] *= y``.
 
+        ``values`` must be dimensionless: a partial update cannot change the
+        unit of the whole array (the untouched elements would silently be
+        re-labelled with the new unit).
         """
         values = Quantity(values)
+        if not values.is_unitless:
+            raise TypeError(
+                f"at[...].multiply requires a dimensionless scale factor, "
+                f"but got {values}. Use Quantity.__mul__ for unit-changing "
+                f"multiplication."
+            )
         return Quantity(
             self._scatter(
                 "multiply", values.mantissa,
@@ -3871,7 +4049,7 @@ class _IndexUpdateRef:
                 unique_indices=unique_indices,
                 mode=mode,
             ),
-            unit=self.unit * values.unit,
+            unit=self.unit,
         )
 
     mul = multiply
@@ -3888,8 +4066,17 @@ class _IndexUpdateRef:
         Returns the value of ``x`` that would result from the NumPy-style
         :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] /= y``.
 
+        ``values`` must be dimensionless: a partial update cannot change the
+        unit of the whole array (the untouched elements would silently be
+        re-labelled with the new unit).
         """
         values = Quantity(values)
+        if not values.is_unitless:
+            raise TypeError(
+                f"at[...].divide requires a dimensionless scale factor, "
+                f"but got {values}. Use Quantity.__truediv__ for unit-changing "
+                f"division."
+            )
         return Quantity(
             self._scatter(
                 "divide", values.mantissa,
@@ -3897,7 +4084,7 @@ class _IndexUpdateRef:
                 unique_indices=unique_indices,
                 mode=mode,
             ),
-            unit=self.unit / values.unit,
+            unit=self.unit,
         )
 
     div = divide

--- a/saiunit/_base_quantity_edge_test.py
+++ b/saiunit/_base_quantity_edge_test.py
@@ -1,0 +1,335 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for Quantity API edge cases and bug fixes."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import saiunit as u
+from saiunit import Quantity, UnitMismatchError
+
+
+class TestScatterFactorUnits:
+    """at[].multiply / at[].divide must not re-label untouched elements."""
+
+    def test_multiply_unit_bearing_factor_raises(self):
+        q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+        with pytest.raises(TypeError, match="dimensionless"):
+            q.at[0].multiply(2.0 * u.ms)
+
+    def test_divide_unit_bearing_factor_raises(self):
+        q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+        with pytest.raises(TypeError, match="dimensionless"):
+            q.at[0].divide(2.0 * u.ms)
+
+    def test_multiply_dimensionless_keeps_unit(self):
+        q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+        r = q.at[0].multiply(2.0)
+        assert r.unit == u.mV
+        np.testing.assert_allclose(np.asarray(r.mantissa), [2.0, 2.0, 3.0])
+
+
+class TestSearchsorted:
+    def test_plain_number_against_unit_bearing_raises(self):
+        q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+        with pytest.raises(UnitMismatchError):
+            q.searchsorted(2.5)
+
+    def test_quantity_value_is_scaled(self):
+        q = jnp.array([1.0, 2.0, 3.0]) * u.volt
+        idx = q.searchsorted(Quantity(1500.0, unit=u.mV))
+        assert int(idx) == 1
+
+    def test_unitless_plain_number_ok(self):
+        q = Quantity(jnp.array([1.0, 2.0, 3.0]))
+        assert int(q.searchsorted(2.5)) == 2
+
+
+class TestResize:
+    def test_resize_grows(self):
+        q = Quantity(jnp.arange(4.0), unit=u.mV).resize((8,))
+        assert q.shape == (8,)
+        assert q.unit == u.mV
+
+    def test_resize_reshapes_numpy(self):
+        q = Quantity(np.arange(4.0), unit=u.mV).resize((2, 2))
+        assert q.shape == (2, 2)
+
+
+class TestExpandAs:
+    def test_expand_as_quantity(self):
+        q = Quantity(jnp.ones(3), unit=u.mV)
+        r = q.expand_as(Quantity(jnp.zeros((2, 3)), unit=u.mV))
+        assert r.shape == (2, 3)
+        assert r.unit == u.mV
+
+    def test_expand_as_raw_array(self):
+        q = Quantity(jnp.ones(3), unit=u.mV)
+        r = q.expand_as(jnp.zeros((2, 3)))
+        assert r.shape == (2, 3)
+
+    def test_expand_as_shape_tuple_still_works(self):
+        q = Quantity(jnp.ones(3), unit=u.mV)
+        r = q.expand_as((2, 3))
+        assert r.shape == (2, 3)
+
+
+class TestInplaceShift:
+    def test_ilshift_unitless_array(self):
+        q = Quantity(jnp.array([4, 8]))
+        q <<= 1
+        np.testing.assert_array_equal(np.asarray(q.mantissa), [8, 16])
+
+    def test_irshift_unitless_array(self):
+        q = Quantity(jnp.array([4, 8]))
+        q >>= 1
+        np.testing.assert_array_equal(np.asarray(q.mantissa), [2, 4])
+
+    def test_ilshift_scalar_mantissa(self):
+        q = Quantity(4)
+        q <<= 1
+        assert int(q.mantissa) == 8
+
+
+class TestFlat:
+    def test_flat_jax_backend(self):
+        q = Quantity(jnp.arange(3.0), unit=u.mV)
+        elements = list(q.flat)
+        assert len(elements) == 3
+        assert all(e.unit == u.mV for e in elements)
+
+    def test_flat_numpy_backend(self):
+        q = Quantity(np.arange(3.0), unit=u.mV)
+        assert len(list(q.flat)) == 3
+
+
+class TestBuiltinRound:
+    def test_round_numpy_backed(self):
+        q = Quantity(np.array([1.234, 2.567]), unit=u.mV)
+        r = round(q, 1)
+        np.testing.assert_allclose(np.asarray(r.mantissa), [1.2, 2.6])
+        assert r.unit == u.mV
+
+    def test_round_jax_backed(self):
+        q = Quantity(jnp.array([1.234, 2.567]), unit=u.mV)
+        r = round(q, 1)
+        np.testing.assert_allclose(np.asarray(r.mantissa), [1.2, 2.6], rtol=1e-6)
+
+    def test_round_scalar_mantissa(self):
+        r = round(Quantity(1.234, unit=u.mV), 1)
+        assert r.mantissa == pytest.approx(1.2)
+
+
+class TestScalarMantissaInplace:
+    def test_iadd_scalar_mantissa(self):
+        q = Quantity(1.0, unit=u.mV)
+        q += 2.0 * u.mV
+        assert q.mantissa == pytest.approx(3.0)
+        assert q.unit == u.mV
+
+    def test_iadd_zero_compat(self):
+        q = Quantity(0)
+        q += 3 * u.ms
+        assert q.unit == u.ms
+        assert float(q.mantissa) == pytest.approx(3.0)
+
+    def test_isub_scalar_mantissa(self):
+        q = Quantity(5.0, unit=u.mV)
+        q -= 2.0 * u.mV
+        assert q.mantissa == pytest.approx(3.0)
+
+
+class TestScalarMantissaMethods:
+    def test_item(self):
+        r = Quantity(3.0, unit=u.mV).item()
+        assert isinstance(r, Quantity)
+        assert r.mantissa == pytest.approx(3.0)
+
+    def test_prod(self):
+        r = Quantity(3.0, unit=u.mV).prod()
+        assert r.unit == u.mV
+        assert float(r.mantissa) == pytest.approx(3.0)
+
+    def test_nanprod(self):
+        r = Quantity(3.0, unit=u.mV).nanprod()
+        assert r.unit == u.mV
+
+
+class TestClipBounds:
+    def test_plain_bound_against_unit_bearing_raises_unit_mismatch(self):
+        q = jnp.array([1.0, 5.0]) * u.mV
+        with pytest.raises(UnitMismatchError):
+            q.clip(min=2.0)
+
+    def test_quantity_bounds_scale(self):
+        q = jnp.array([1.0, 5.0]) * u.mV
+        r = q.clip(max=Quantity(0.002, unit=u.volt))
+        np.testing.assert_allclose(np.asarray(r.mantissa), [1.0, 2.0])
+
+
+class TestListConstructor:
+    def test_mixed_unitless_sublist_raises_type_error(self):
+        with pytest.raises(TypeError, match="same units"):
+            Quantity([[1 * u.mV, 2 * u.mV], [3, 4]])
+
+    def test_mixed_order_independent(self):
+        with pytest.raises(TypeError, match="same units"):
+            Quantity([[1, 2], jnp.array([3.0, 4.0]) * u.mV])
+
+    def test_all_unitless_nested_ok(self):
+        q = Quantity([[1, 2], [3, 4]])
+        assert q.shape == (2, 2)
+
+    def test_all_united_nested_ok(self):
+        q = Quantity([[1 * u.mV, 2 * u.mV], [3 * u.mV, 4 * u.mV]])
+        assert q.unit == u.mV
+        assert q.shape == (2, 2)
+
+
+class TestZeroComparison:
+    def test_gt_zero(self):
+        assert bool((3.0 * u.mV) > 0)
+
+    def test_eq_zero(self):
+        assert not bool((3.0 * u.mV) == 0)
+        assert bool((0.0 * u.mV) == 0)
+
+    def test_le_zero(self):
+        assert bool((-1.0 * u.mV) <= 0)
+
+    def test_nonzero_plain_still_raises(self):
+        with pytest.raises(UnitMismatchError):
+            (3.0 * u.mV) > 1.0
+
+    def test_different_dim_nonzero_still_raises(self):
+        with pytest.raises(UnitMismatchError):
+            (3.0 * u.mV) > (1.0 * u.ms)
+
+
+class TestComparisonContract:
+    def test_eq_none_is_false(self):
+        assert ((3.0 * u.mV) == None) is False  # noqa: E711
+
+    def test_ne_none_is_true(self):
+        assert ((3.0 * u.mV) != None) is True  # noqa: E711
+
+    def test_eq_string_is_false(self):
+        assert ((3.0 * u.mV) == "foo") is False
+
+    def test_ordering_with_none_raises_type_error(self):
+        with pytest.raises(TypeError):
+            (3.0 * u.mV) < None
+
+    def test_eq_same_dim_still_elementwise(self):
+        q = jnp.array([1.0, 2.0]) * u.mV
+        r = q == jnp.array([1.0, 3.0]) * u.mV
+        np.testing.assert_array_equal(np.asarray(r), [True, False])
+
+
+class TestTakeNumpyModes:
+    def test_mode_fill_with_fill_value(self):
+        q = Quantity(np.array([1.0, 2.0]), unit=u.mV)
+        r = q.take(np.array([0, 5]), mode='fill', fill_value=Quantity(0.0, unit=u.mV))
+        np.testing.assert_allclose(np.asarray(r.mantissa), [1.0, 0.0])
+        assert r.unit == u.mV
+
+    def test_mode_fill_default_nan(self):
+        q = Quantity(np.array([1.0, 2.0]), unit=u.mV)
+        r = q.take(np.array([0, 5]), mode='fill')
+        assert np.isnan(np.asarray(r.mantissa)[1])
+
+    def test_mode_clip(self):
+        q = Quantity(np.array([1.0, 2.0]), unit=u.mV)
+        r = q.take(np.array([0, 5]), mode='clip')
+        np.testing.assert_allclose(np.asarray(r.mantissa), [1.0, 2.0])
+
+    def test_mode_fill_negative_valid_index_wraps(self):
+        q = Quantity(np.array([1.0, 2.0, 3.0]), unit=u.mV)
+        r = q.take(np.array([-1, 0]), mode='fill', fill_value=Quantity(9.0, unit=u.mV))
+        np.testing.assert_allclose(np.asarray(r.mantissa), [3.0, 1.0])
+
+    def test_mode_fill_with_axis(self):
+        q = Quantity(np.arange(6.0).reshape(2, 3), unit=u.mV)
+        r = q.take(np.array([0, 5]), axis=1, mode='fill', fill_value=Quantity(-1.0, unit=u.mV))
+        np.testing.assert_allclose(np.asarray(r.mantissa), [[0.0, -1.0], [3.0, -1.0]])
+
+    def test_default_mode_raises_on_oob(self):
+        q = Quantity(np.array([1.0, 2.0]), unit=u.mV)
+        with pytest.raises(IndexError):
+            q.take(np.array([5]))
+
+
+class TestConstructorDtype:
+    def test_scalar_dtype(self):
+        assert Quantity(3, dtype=jnp.float32).dtype == jnp.float32
+
+    def test_quantity_input_dtype(self):
+        q = Quantity(3.0, unit=u.mV)
+        assert Quantity(q, dtype=jnp.float16).dtype == jnp.float16
+
+    def test_unit_mantissa_dtype(self):
+        assert Quantity(u.mV, dtype=jnp.float16).dtype == jnp.float16
+
+    def test_numpy_scalar_dtype(self):
+        q = Quantity(np.float32(3.0), dtype=np.float64)
+        assert q.dtype == np.float64
+
+
+class TestUnitlessPowArrayExponent:
+    def test_unitless_base_array_exponent(self):
+        r = Quantity(2.0) ** jnp.array([1.0, 2.0])
+        np.testing.assert_allclose(np.asarray(r), [2.0, 4.0])
+
+    def test_unit_bearing_base_array_exponent_still_raises(self):
+        with pytest.raises(TypeError):
+            (2.0 * u.mV) ** jnp.array([1.0, 2.0])
+
+    def test_unit_bearing_scalar_exponent(self):
+        r = (2.0 * u.mV) ** 2
+        assert r.unit == u.mV ** 2
+
+
+class TestConstructorGarbage:
+    def test_str_mantissa_rejected(self):
+        with pytest.raises(TypeError, match="str"):
+            Quantity("foo")
+
+    def test_bytes_mantissa_rejected(self):
+        with pytest.raises(TypeError, match="bytes"):
+            Quantity(b"foo")
+
+
+class TestInvert:
+    def test_invert_unit_bearing_raises(self):
+        with pytest.raises(NotImplementedError):
+            ~Quantity(jnp.array([1, 2]), unit=u.mV)
+
+    def test_invert_unitless_ok(self):
+        r = ~Quantity(jnp.array([1, 2]))
+        np.testing.assert_array_equal(np.asarray(r.mantissa), [-2, -3])
+
+
+class TestSortOrder:
+    def test_order_param_rejected(self):
+        q = Quantity(jnp.array([3.0, 1.0]), unit=u.mV)
+        with pytest.raises(NotImplementedError):
+            q.sort(order='field')
+
+    def test_sort_still_works(self):
+        q = Quantity(jnp.array([3.0, 1.0, 2.0]), unit=u.mV)
+        q.sort()
+        np.testing.assert_allclose(np.asarray(q.mantissa), [1.0, 2.0, 3.0])

--- a/saiunit/_scatter_test.py
+++ b/saiunit/_scatter_test.py
@@ -361,13 +361,16 @@ def test_add_requires_compatible_unit(backend):
         q.at[0].add(5.0)  # plain number, but quantity is not unitless
 
 
-def test_multiply_changes_unit(backend):
+def test_multiply_unit_bearing_factor_raises(backend):
     if backend == "ndonnx":
         pytest.skip()
     q = _make_quantity([2.0, 4.0, 8.0], mV, backend)
-    r = q.at[1].multiply(3.0 * meter)
-    # Unit of the whole array becomes mV*m (JAX semantics)
-    assert r.unit == mV * meter
+    # A unit-bearing factor would silently re-label the untouched elements
+    # (e.g. 2 mV -> 2 mV*m), so it must be rejected.
+    with pytest.raises(TypeError, match="dimensionless"):
+        q.at[1].multiply(3.0 * meter)
+    with pytest.raises(TypeError, match="dimensionless"):
+        q.at[1].divide(3.0 * meter)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A systematic audit of the core `Quantity` class surfaced 20 bugs/edge cases, all verified by executing code against `main`. This PR fixes all of them, with a regression test per item in the new `saiunit/_base_quantity_edge_test.py` (60 tests).

### Silent wrong results
- **`at[].multiply` / `at[].divide` with a unit-bearing factor corrupted untouched elements**: `([1,2,3]*mV).at[0].multiply(2*ms)` returned `[2,2,3] mV·ms`, silently re-labelling elements 1–2. Both now require a dimensionless factor (same rule as `scatter_mul`/`scatter_div`).
- **`searchsorted` accepted plain numbers against unit-bearing arrays** without any check, silently reading them in `self`'s unit. Now raises `UnitMismatchError`, consistent with comparisons.

### Crashes
- `resize()` could never resize (rejected by `update_mantissa`'s shape guard).
- `expand_as()` passed the array itself, not its shape, to `broadcast_to` (the existing test only passed because it handed in a `.shape` tuple).
- `<<=` / `>>=` crashed on unitless Quantities (`maybe_decimal` stripped the wrapper).
- `.flat` crashed on JAX mantissas (JAX's `.flat` raises `NotImplementedError`, which leaks through `hasattr`).
- builtin `round(q)` crashed on numpy-backed Quantities (`np.ndarray` has no `__round__`).
- `q += x`, `item()`, `prod()`/`nanprod()` crashed on python-scalar mantissas (including the documented zero-compat idiom `q = Quantity(0); q += 3*ms`).
- `clip()` with plain numeric bounds raised `AttributeError` instead of `UnitMismatchError` (root cause in `unit_scale_align_to_first`, fixed there).

### Wrong error types / inconsistencies
- List constructor mixing unitless sublists with unit-bearing items raised `AssertionError` (values/units desync; would mis-scale under `python -O`). Now a proper `TypeError`.
- **Zero-compat extended to comparisons**: `3*mV > 0` / `q == 0` now work like `0 + 3*mV` already did. Nonzero plain numbers and dimension mismatches still raise.
- **Python equality contract**: `q == None` / `q == "str"` returned `UnitMismatchError` crashes; now `NotImplemented` → `False`/`True`, and orderings with junk raise plain `TypeError`.
- `take(mode=...)` on the numpy backend rejected JAX-style modes and ignored `fill_value`; modes are now translated and fill emulated (incl. jnp's default fill values).
- `Quantity(x, dtype=...)` silently ignored `dtype` for scalar, `np.generic`, `Quantity`, and `Unit` inputs.

### Minor
- `Quantity(2.0) ** jnp.array([...])` now works (dimensionless base, any exponent shape).
- `Quantity("foo")` / `Quantity(b"...")` rejected at construction with a helpful message; `get_dim`/`get_unit` keep their duck-typing contract (str → dimensionless).
- `~q` now raises for unit-bearing quantities, consistent with `&`, `|`, `^`.
- `sort(order=...)` raises instead of silently ignoring the parameter.
- In-place shape-change errors now explain the constraint.

### Deliberate scope decisions
- `Quantity(None)` remains allowed (pytree placeholder round-trips depend on arbitrary leaves).
- `q[0] = 0` and `clip(min=0)` stay strict (zero-compat extended only to comparisons).
- `at[].power` still changes the unit of the whole array — same incoherence as `at[].multiply` had, but it is explicitly pinned as intended behavior in `test_power_integer` and cannot be made unit-preserving (any exponent ≠ 1 changes the unit). Worth a follow-up discussion.

### Behavior change requiring a test update
`test_multiply_changes_unit` in `_scatter_test.py` asserted the corrupting `at[].multiply` behavior; it is replaced by `test_multiply_unit_bearing_factor_raises`.

## Verification
- `pytest saiunit/` — 3673 passed, 0 failed
- `mypy saiunit/` — exit 0 (only pre-existing informational notes)