### PR TITLE
fix: correct unit propagation and dtype handling in saiunit.autograd

### DIFF
--- a/saiunit/autograd/_autograd_edge_test.py
+++ b/saiunit/autograd/_autograd_edge_test.py
@@ -1,0 +1,221 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for edge cases in ``saiunit.autograd``.
+
+These tests intentionally avoid the optional ``brainstate`` dependency so
+they run in every CI configuration.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import saiunit as u
+import saiunit.autograd as suauto
+
+
+# ---------------------------------------------------------------------------
+# vector_grad: unit propagation bugs
+# ---------------------------------------------------------------------------
+
+def test_vector_grad_single_quantity_in_container_keeps_unit():
+    # A single Quantity leaf wrapped in a dict must take its unit from the
+    # leaf, not from the (unitless) container.
+    def f(x):
+        return {'o': x ** 2}
+
+    grad = suauto.vector_grad(f)(jnp.array([3.0, 4.0]) * u.ms)
+    assert u.get_unit(grad) == u.ms
+    assert u.math.allclose(grad, jnp.array([6.0, 8.0]) * u.ms)
+
+
+def test_vector_grad_single_quantity_in_nested_container_keeps_unit():
+    def f(x):
+        return {'a': {'b': x ** 2}}
+
+    grad = suauto.vector_grad(f)(jnp.array([3.0, 4.0]) * u.ms)
+    assert u.get_unit(grad) == u.ms
+
+
+def test_vector_grad_unit_aware_false_returns_bare_mantissa():
+    # With unit_aware=False the gradient must not carry a (wrong) unit.
+    # d/dx x**3 = 3 x**2; the true unit would be ms**2, and stamping the
+    # input unit ms would be physically wrong, so we return a plain array.
+    def f(x):
+        return x ** 3
+
+    grad = suauto.vector_grad(f, unit_aware=False)(jnp.array([2.0]) * u.ms)
+    assert not isinstance(grad, u.Quantity)
+    assert jnp.allclose(grad, jnp.array([12.0]))
+
+
+def test_vector_grad_rejects_integer_output():
+    def f(x):
+        return (x > 1.0).astype(jnp.int32)
+
+    with pytest.raises(TypeError, match="real-valued outputs|inexact"):
+        suauto.vector_grad(f)(jnp.array([3.0]))
+
+
+def test_vector_grad_is_column_sum_not_diagonal():
+    # vector_grad is a ones-cotangent VJP == column sums of the Jacobian,
+    # which equals the diagonal only for element-wise functions.
+    A = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+
+    def f(x):
+        return A @ x
+
+    grad = suauto.vector_grad(f)(jnp.array([1.0, 1.0]))
+    assert jnp.allclose(grad, A.sum(axis=0))  # column sums: [4, 6]
+
+
+# ---------------------------------------------------------------------------
+# jacrev / jacfwd: dtype handling parity with jax
+# ---------------------------------------------------------------------------
+
+def test_jacrev_accepts_complex_input():
+    # Reverse-mode C->R differentiation is allowed by jax.jacrev.
+    def f(x):
+        return jnp.abs(x) ** 2
+
+    x = jnp.array(1.0 + 2.0j)
+    got = suauto.jacrev(f)(x)
+    ref = jax.jacrev(f)(x)
+    assert np.allclose(np.asarray(u.get_mantissa(got)), np.asarray(ref), atol=1e-4)
+
+
+def test_jacfwd_rejects_complex_input_without_holomorphic():
+    # Forward-mode over a non-holomorphic complex input is meaningless;
+    # jax.jacfwd raises and points at holomorphic=True.
+    def f(x):
+        return jnp.abs(x) ** 2
+
+    with pytest.raises(TypeError, match="holomorphic"):
+        suauto.jacfwd(f)(jnp.array(1.0 + 2.0j))
+
+
+def test_jacfwd_allows_real_to_complex_output():
+    # Non-holomorphic jacfwd imposes no constraint on the output dtype.
+    def f(x):
+        return jnp.exp(1j * x)
+
+    x = jnp.array(0.5)
+    got = suauto.jacfwd(f)(x)
+    ref = jax.jacfwd(f)(x)
+    assert np.allclose(np.asarray(u.get_mantissa(got)), np.asarray(ref), atol=1e-4)
+
+
+def test_jacrev_accepts_bfloat16_input():
+    def f(x):
+        return x ** 2
+
+    x = jnp.array(3.0, dtype=jnp.bfloat16)
+    got = suauto.jacrev(f)(x)
+    assert jnp.allclose(u.get_mantissa(got).astype(jnp.float32),
+                        jnp.array([6.0], dtype=jnp.float32))
+
+
+def test_jacfwd_accepts_bfloat16_input():
+    def f(x):
+        return x ** 2
+
+    x = jnp.array(3.0, dtype=jnp.bfloat16)
+    got = suauto.jacfwd(f)(x)
+    assert jnp.allclose(u.get_mantissa(got).astype(jnp.float32),
+                        jnp.array([6.0], dtype=jnp.float32))
+
+
+def test_jacrev_complex_output_error_mentions_holomorphic():
+    def f(x):
+        return jnp.exp(1j * x)
+
+    with pytest.raises(TypeError, match="holomorphic"):
+        suauto.jacrev(f)(jnp.array(0.5))
+
+
+def test_jacrev_integer_input_error_mentions_allow_int():
+    def f(x):
+        return x * 1.0
+
+    with pytest.raises(TypeError, match="allow_int"):
+        suauto.jacrev(f)(jnp.array(3))
+
+
+# ---------------------------------------------------------------------------
+# float0: integer-arg gradients must not become void-dtype Quantities
+# ---------------------------------------------------------------------------
+
+def test_value_and_grad_float0_not_wrapped_in_quantity():
+    # Unit-ful loss + allow_int over an integer arg used to produce a
+    # void-dtype Quantity that crashes on any arithmetic.
+    def loss(i, x):
+        return u.math.sum(x ** 2) * u.mV
+
+    _, grads = suauto.value_and_grad(loss, argnums=(0, 1), allow_int=True)(
+        jnp.array(3), jnp.array([2.0])
+    )
+    grad_i = grads[0]
+    assert not isinstance(grad_i, u.Quantity)
+    assert grad_i.dtype == jax.dtypes.float0
+
+
+def test_jacrev_float0_not_wrapped_in_quantity():
+    def f(i, x):
+        return x ** 2
+
+    jac = suauto.jacrev(f, argnums=(0, 1), allow_int=True)(
+        jnp.array(2), jnp.array(3.0) * u.ms
+    )
+    assert not isinstance(jac[0], u.Quantity)
+    assert jac[0].dtype == jax.dtypes.float0
+
+
+# ---------------------------------------------------------------------------
+# Eager validation of the differentiated callable
+# ---------------------------------------------------------------------------
+
+def test_grad_rejects_non_callable():
+    with pytest.raises(TypeError, match="callable"):
+        suauto.grad(42)
+
+
+def test_value_and_grad_rejects_non_callable():
+    with pytest.raises(TypeError, match="callable"):
+        suauto.value_and_grad(42)
+
+
+def test_grad_rejects_generator_function():
+    def gen(x):
+        yield x
+
+    with pytest.raises(TypeError, match="generator"):
+        suauto.grad(gen)
+
+
+def test_value_and_grad_has_aux_non_tuple_return():
+    # has_aux=True but the function returns a bare scalar.
+    def f(x):
+        return x ** 2
+
+    with pytest.raises(TypeError, match="pair|two-element|aux"):
+        suauto.value_and_grad(f, has_aux=True)(jnp.array(1.0))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/saiunit/autograd/_jacobian.py
+++ b/saiunit/autograd/_jacobian.py
@@ -26,7 +26,7 @@ from saiunit._base_getters import get_magnitude, get_unit, maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import safe_map
 from saiunit._misc import maybe_custom_array_tree
-from ._misc import _ensure_index, _check_callable, _argnums_partial
+from ._misc import _ensure_index, _check_callable, _argnums_partial, _is_float0
 
 __all__ = [
     'jacrev',
@@ -43,21 +43,90 @@ def _is_quantity(x):
     return isinstance(x, Quantity)
 
 
-def _check_dtype(x, *, holomorphic: bool, allowed_dtype=np.floating, name: str = ""):
-    """Validate leaf dtype for Jacobian computation."""
+def _leaf_dtype(x):
     try:
-        dtype = x.dtype
+        return x.dtype
     except AttributeError:
-        dtype = np.result_type(x)
+        return np.result_type(x)
+
+
+def _dtype_name(dtype) -> str:
+    try:
+        return np.dtype(dtype).name
+    except TypeError:
+        return str(dtype)
+
+
+# The four checkers below mirror jax's own input/output dtype validation for
+# reverse- and forward-mode differentiation. ``jax.dtypes.issubdtype`` is used
+# (not ``np.issubdtype``) so that extended dtypes such as ``bfloat16`` are
+# recognised as floating-point.
+
+def _check_input_dtype_revderiv(x, *, holomorphic: bool, allow_int: bool, name: str):
+    dtype = _leaf_dtype(x)
     if holomorphic:
-        if not np.issubdtype(dtype, np.complexfloating):
+        if not jax.dtypes.issubdtype(dtype, np.complexfloating):
             raise TypeError(
-                f"{name} with holomorphic=True requires complex dtype, got {dtype}."
+                f"{name} with holomorphic=True requires inputs with complex dtype, "
+                f"but got {_dtype_name(dtype)}."
             )
-    elif allowed_dtype is not None and not np.issubdtype(dtype, allowed_dtype):
+    elif not allow_int and not jax.dtypes.issubdtype(dtype, np.inexact):
         raise TypeError(
-            f"{name} requires {allowed_dtype.__name__} inputs, got {dtype}."
+            f"{name} requires real- or complex-valued inputs (input dtype that is a "
+            f"sub-dtype of np.inexact), but got {_dtype_name(dtype)}. If you want to "
+            f"use Boolean- or integer-valued inputs, set allow_int to True."
         )
+
+
+def _check_output_dtype_revderiv(x, *, holomorphic: bool, name: str):
+    dtype = _leaf_dtype(x)
+    if holomorphic:
+        if not jax.dtypes.issubdtype(dtype, np.complexfloating):
+            raise TypeError(
+                f"{name} with holomorphic=True requires outputs with complex dtype, "
+                f"but got {_dtype_name(dtype)}."
+            )
+    elif jax.dtypes.issubdtype(dtype, np.complexfloating):
+        raise TypeError(
+            f"{name} requires real-valued outputs (output dtype that is a sub-dtype "
+            f"of np.floating), but got {_dtype_name(dtype)}. For holomorphic "
+            f"differentiation, pass holomorphic=True. For differentiation of "
+            f"non-holomorphic functions involving complex outputs, use jax.vjp directly."
+        )
+    elif not jax.dtypes.issubdtype(dtype, np.floating):
+        raise TypeError(
+            f"{name} requires real-valued outputs (output dtype that is a sub-dtype "
+            f"of np.floating), but got {_dtype_name(dtype)}. For differentiation of "
+            f"functions with integer outputs, use jax.vjp directly."
+        )
+
+
+def _check_input_dtype_jacfwd(x, *, holomorphic: bool, name: str = "jacfwd"):
+    dtype = _leaf_dtype(x)
+    if holomorphic:
+        if not jax.dtypes.issubdtype(dtype, np.complexfloating):
+            raise TypeError(
+                f"{name} with holomorphic=True requires inputs with complex dtype, "
+                f"but got {_dtype_name(dtype)}."
+            )
+    elif not jax.dtypes.issubdtype(dtype, np.floating):
+        raise TypeError(
+            f"{name} requires real-valued inputs (input dtype that is a sub-dtype of "
+            f"np.floating), but got {_dtype_name(dtype)}. For holomorphic "
+            f"differentiation, pass holomorphic=True. For differentiation of "
+            f"non-holomorphic functions involving complex or integer inputs, use "
+            f"jax.jvp directly."
+        )
+
+
+def _check_output_dtype_jacfwd(x, *, holomorphic: bool, name: str = "jacfwd"):
+    dtype = _leaf_dtype(x)
+    if holomorphic and not jax.dtypes.issubdtype(dtype, np.complexfloating):
+        raise TypeError(
+            f"{name} with holomorphic=True requires outputs with complex dtype, "
+            f"but got {_dtype_name(dtype)}."
+        )
+    # Non-holomorphic jacfwd imposes no constraint on the output dtype.
 
 
 def _split(x, indices, axis):
@@ -121,11 +190,17 @@ def _assign_jacobian_units(outputs, inputs, jac_tree):
     for i in range(len(out_leaves)):
         for j in range(inner_size):
             leaf = out_paths_leaves[i * inner_size + j]
-            new_leaves.append(
-                maybe_decimal(
-                    Quantity(get_magnitude(leaf), unit=out_units[i] / in_units[j])
+            mantissa = get_magnitude(leaf)
+            if _is_float0(mantissa):
+                # Gradient w.r.t. an integer/boolean input: leave float0 as-is
+                # rather than wrapping it in a void-dtype Quantity.
+                new_leaves.append(mantissa)
+            else:
+                new_leaves.append(
+                    maybe_decimal(
+                        Quantity(mantissa, unit=out_units[i] / in_units[j])
+                    )
                 )
-            )
     return jax.tree.unflatten(out_treedef, new_leaves)
 
 
@@ -237,18 +312,17 @@ def jacrev(
     """
     _check_callable(fun)
     argnums = _ensure_index(argnums)
-    input_dtype = None if allow_int else np.floating
 
     @wraps(fun)
     def jacfun(*args, **kwargs):
         args, kwargs = maybe_custom_array_tree((args, kwargs))
         argnums_, f_partial, dyn_args = _argnums_partial(fun, argnums, args, kwargs)
-        jax.tree.map(partial(_check_dtype, holomorphic=holomorphic, allowed_dtype=input_dtype, name="jacrev"), dyn_args)
+        jax.tree.map(partial(_check_input_dtype_revderiv, holomorphic=holomorphic, allow_int=allow_int, name="jacrev"), dyn_args)
         if not has_aux:
             y, pullback = jax.vjp(f_partial, *dyn_args)
         else:
             y, pullback, aux = jax.vjp(f_partial, *dyn_args, has_aux=True)
-        jax.tree.map(partial(_check_dtype, holomorphic=holomorphic, name="jacrev"), y)
+        jax.tree.map(partial(_check_output_dtype_revderiv, holomorphic=holomorphic, name="jacrev"), y)
         jac = jax.vmap(pullback)(_std_basis(y))
         jac = jac[0] if isinstance(argnums_, int) else jac
         jac_tree = jax.tree.map(
@@ -420,14 +494,14 @@ def jacfwd(
     def jacfun(*args, **kwargs):
         args, kwargs = maybe_custom_array_tree((args, kwargs))
         argnums_, f_partial, dyn_args = _argnums_partial(fun, argnums, args, kwargs)
-        jax.tree.map(partial(_check_dtype, holomorphic=holomorphic, allowed_dtype=np.inexact, name="jacfwd"), dyn_args)
+        jax.tree.map(partial(_check_input_dtype_jacfwd, holomorphic=holomorphic, name="jacfwd"), dyn_args)
         if not has_aux:
             pushfwd: Callable = partial(jax.jvp, f_partial, dyn_args)
             y, jac = jax.vmap(pushfwd, out_axes=(None, -1))(_std_basis(dyn_args))
         else:
             pushfwd: Callable = partial(jax.jvp, f_partial, dyn_args, has_aux=True)
             y, jac, aux = jax.vmap(pushfwd, out_axes=(None, -1, None))(_std_basis(dyn_args))
-        jax.tree.map(partial(_check_dtype, holomorphic=holomorphic, name="jacfwd"), y)
+        jax.tree.map(partial(_check_output_dtype_jacfwd, holomorphic=holomorphic, name="jacfwd"), y)
         example_args = dyn_args[0] if isinstance(argnums_, int) else dyn_args
         jac_tree = jax.tree.map(
             lambda arr: _unravel_array_into_pytree(example_args, -1, arr, is_leaf=_is_quantity),

--- a/saiunit/autograd/_misc.py
+++ b/saiunit/autograd/_misc.py
@@ -20,7 +20,20 @@ import operator
 from functools import partial
 from typing import Any, Callable, Sequence
 
+import jax
+
 from .._compatible_import import concrete_or_error
+
+
+def _is_float0(x: Any) -> bool:
+    """Return ``True`` if ``x`` is a JAX ``float0`` array.
+
+    ``float0`` is the (void) tangent dtype JAX produces for the gradient of
+    an integer- or boolean-valued input under ``allow_int=True``. Such leaves
+    must not be wrapped in a :class:`~saiunit.Quantity`, which would yield a
+    void-dtype quantity that crashes on any arithmetic.
+    """
+    return getattr(x, "dtype", None) == jax.dtypes.float0
 
 
 def _ensure_index(x: Any) -> int | tuple[int, ...]:

--- a/saiunit/autograd/_value_and_grad.py
+++ b/saiunit/autograd/_value_and_grad.py
@@ -24,7 +24,7 @@ from saiunit._base_getters import get_mantissa, get_unit, maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
 from saiunit._misc import maybe_custom_array_tree
-from ._misc import _ensure_index
+from ._misc import _ensure_index, _check_callable, _is_float0
 
 __all__ = [
     'value_and_grad',
@@ -107,11 +107,18 @@ def value_and_grad(
         3.0 * msecond
     """
 
+    _check_callable(fun)
     argnums = concrete_or_error(_ensure_index, argnums)
 
     def fun_return_unitless_loss(*args, **kwargs):
         if has_aux:
-            loss, aux = fun(*args, **kwargs)
+            result = fun(*args, **kwargs)
+            if not (isinstance(result, (tuple, list)) and len(result) == 2):
+                raise TypeError(
+                    "value_and_grad with has_aux=True requires fun to return a "
+                    f"(loss, aux) pair, but got {type(result)}."
+                )
+            loss, aux = result
         else:
             loss = fun(*args, **kwargs)
             aux = None
@@ -135,10 +142,17 @@ def value_and_grad(
         # gradient Quantity conversion
         args_to_grad = jax.tree.map(lambda i: args[i], argnums)
         loss_unit = get_unit(loss)
+
+        def _to_grad_quantity(arg, grads):
+            mantissa = get_mantissa(grads)
+            if _is_float0(mantissa):
+                # Gradient w.r.t. an integer/boolean input (allow_int=True):
+                # keep float0 instead of building a void-dtype Quantity.
+                return mantissa
+            return maybe_decimal(Quantity(mantissa, unit=loss_unit / get_unit(arg)))
+
         gradient = jax.tree.map(
-            lambda arg, grads: maybe_decimal(
-                Quantity(get_mantissa(grads), unit=loss_unit / get_unit(arg))
-            ),
+            _to_grad_quantity,
             args_to_grad,
             gradient,
             is_leaf=lambda x: isinstance(x, Quantity)

--- a/saiunit/autograd/_vector_grad.py
+++ b/saiunit/autograd/_vector_grad.py
@@ -19,6 +19,7 @@ from functools import wraps
 from typing import Callable, Sequence
 
 import jax
+import numpy as np
 from jax import numpy as jnp
 
 from saiunit._base_getters import get_mantissa, get_unit, maybe_decimal
@@ -42,10 +43,11 @@ def vector_grad(
     Unit-aware element-wise gradient of a vector-valued function.
 
     Unlike :func:`grad` (which requires scalar outputs), ``vector_grad``
-    computes element-wise gradients for vector-valued functions by
-    using a VJP with an all-ones tangent vector. This is equivalent to
-    the diagonal of the Jacobian when the output has the same shape as
-    the input.
+    computes gradients for vector-valued functions by using a VJP with an
+    all-ones cotangent vector. The result is the column-wise sum of the
+    Jacobian (i.e. ``ones @ J``); this coincides with the element-wise
+    derivative — the diagonal of the Jacobian — only when ``func`` is
+    applied element-wise.
 
     Parameters
     ----------
@@ -130,12 +132,28 @@ def vector_grad(
             y, vjp_fn, aux = jax.vjp(f_partial, *dyn_args, has_aux=True)
         else:
             y, vjp_fn = jax.vjp(f_partial, *dyn_args)
+        # ``leaves``/``tree`` flatten through Quantity (raw arrays) and are used
+        # to build a cotangent matching ``y``'s structure. ``out_leaves`` treats
+        # each Quantity as a single leaf so the output unit and arity are read
+        # from the quantities themselves, not from a (unitless) container.
         leaves, tree = jax.tree.flatten(y)
+        out_leaves, _ = jax.tree.flatten(y, is_leaf=lambda x: isinstance(x, Quantity))
+
+        # Differentiating a non-inexact (e.g. integer or boolean) output yields
+        # meaningless zero gradients; reject it like ``jax.grad`` does.
+        for leaf in out_leaves:
+            dtype = getattr(get_mantissa(leaf), 'dtype', None)
+            if dtype is not None and not jax.dtypes.issubdtype(dtype, np.inexact):
+                raise TypeError(
+                    f'vector_grad requires real- or complex-valued (inexact) outputs, '
+                    f'but got {np.dtype(dtype).name}.'
+                )
+
         if unit_aware:
-            if len(leaves) != 1:
+            if len(out_leaves) != 1:
                 raise ValueError(
                     f'vector_grad with unit_aware=True requires the function to return a single '
-                    f'array, but got {len(leaves)} outputs.'
+                    f'array, but got {len(out_leaves)} outputs.'
                 )
         tangents = jax.tree.unflatten(tree, [jnp.ones(l.shape, dtype=l.dtype) for l in leaves])
         grads = vjp_fn(tangents)
@@ -143,12 +161,20 @@ def vector_grad(
             grads = grads[0]
         if unit_aware:
             args_to_grad = jax.tree.map(lambda i: args[i], argnums_)
-            r_unit = get_unit(y)
+            r_unit = get_unit(out_leaves[0])
             grads = jax.tree.map(
                 lambda arg, grad: maybe_decimal(
                     Quantity(get_mantissa(grad), unit=r_unit / get_unit(arg))
                 ),
                 args_to_grad,
+                grads,
+                is_leaf=lambda x: isinstance(x, Quantity)
+            )
+        else:
+            # Without unit awareness, strip any unit the VJP carried back from
+            # unit-ful inputs so the gradient does not advertise a wrong unit.
+            grads = jax.tree.map(
+                get_mantissa,
                 grads,
                 is_leaf=lambda x: isinstance(x, Quantity)
             )


### PR DESCRIPTION
## Summary

Fixes a batch of correctness bugs and edge-case divergences in `saiunit.autograd`, found by auditing every public API (`grad`, `value_and_grad`, `vector_grad`, `jacrev`, `jacfwd`, `jacobian`, `hessian`) against the JAX reference behavior.

### High severity (silent wrong results)
- **`vector_grad` dict/nested output → wrong unit.** The output unit was read from the *container* (`get_unit(y)` on a dict returns `UNITLESS`), so a single `Quantity` wrapped in a dict came back with the *reciprocal* unit (e.g. `kHz` instead of `ms`). Now the unit is read from the flattened leaf.
- **`vector_grad(unit_aware=False)` stamped the input unit.** The VJP carries gradients back through the input pytree, whose aux data is the input unit, so gradients advertised a physically wrong unit (`ms` for `d(x³)/dx`). Now stripped to plain arrays.
- **`jacfwd` silently accepted non-holomorphic complex inputs**, returning a meaningless real-axis derivative. Now rejected, matching `jax.jacfwd`.

### Medium severity (valid inputs rejected / JAX divergence)
- **`jacrev` rejected complex inputs** (C→R differentiation that `jax.jacrev` allows).
- **`jacfwd` rejected real→complex outputs** (allowed by `jax.jacfwd`).
- **`bfloat16` (and other `ml_dtypes`) rejected** because `np.issubdtype` doesn't recognize them — switched to `jax.dtypes.issubdtype`.
- **`float0` gradients wrapped in `Quantity`.** With `allow_int=True` over an integer arg, a unit-ful loss produced a void-dtype `Quantity` that crashes on any arithmetic. Now `float0` leaves are preserved as-is (matching `jax.grad`).

### Low severity (error quality / docs)
- Dtype error messages now mirror JAX's wording and mention `holomorphic=True` / `allow_int=True`.
- `grad`/`value_and_grad` now validate the callable eagerly (non-callables and generator functions get clear errors, like `jacrev`/`vector_grad`).
- `has_aux=True` with a non-pair return now raises a clear message instead of `iteration over a 0-d array`.
- `vector_grad` docstring corrected: it's the **column-wise sum of the Jacobian**, equal to the diagonal only for element-wise functions.
- `vector_grad` now rejects non-inexact (e.g. integer) outputs instead of silently returning zeros.

## Testing
- New `saiunit/autograd/_autograd_edge_test.py` (18 tests, no `brainstate` dependency) covering every fix above.
- Full autograd suite: **90 passed**.
- Full `saiunit/` suite: **3621 passed, 183 skipped**.
- `mypy saiunit/` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)