### PR TITLE
fix: resolve 48 audited bugs across saiunit.math APIs

### DIFF
--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -739,9 +739,10 @@ def unit_scale_align_to_first(*args) -> 'list[Quantity]':
         if not isinstance(items[0], Quantity):
             items[0] = Quantity(items[0])
         for i in range(1, len(items)):
-            fail_for_unit_mismatch(items[i], items[0], 'Non-matching unit for function "unit_scale_align_to_first"')
-            if not isinstance(items[i], Quantity):
-                items[i] = Quantity(items[i])
+            # ``in_unit`` both checks the dimension and rescales
+            # scaled-dimensionless quantities (e.g. mV/volt) onto the
+            # unitless first item, instead of only checking dimensions.
+            items[i] = _to_quantity(items[i]).in_unit(first_unit)
     else:
         for i in range(1, len(items)):
             # Route through _to_quantity so raw values (plain numbers, bare

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -2243,15 +2243,30 @@ class Quantity:
         # self // oc
         if isinstance(oc, SparseMatrix):
             return oc.__rfloordiv__(self)
-        r = self._binary_operation(oc, operator.floordiv, operator.truediv)
+        other = _to_quantity(oc)
+        # ``floor`` is not scale-linear, so the operands must be aligned
+        # before flooring (e.g. (1*kmeter) // (3*meter) is 333.0, not
+        # 1 // 3 == 0.0).
+        if other.unit.has_same_dim(self.unit):
+            # Same dimension: align to self's unit; the quotient is a plain
+            # dimensionless integral value.
+            other_value = other.in_unit(self.unit).mantissa
+            r = Quantity(operator.floordiv(self.mantissa, other_value), unit=UNITLESS)
+        else:
+            # Mixed dimensions: fold each unit's magnitude into its mantissa
+            # so the result does not depend on the unit representation, and
+            # attach the magnitude-1 quotient unit.
+            self_unit = self.unit if self.unit.magnitude == 1. else Unit(dim=self.unit.dim)
+            other_unit = other.unit if other.unit.magnitude == 1. else Unit(dim=other.unit.dim)
+            r = Quantity(
+                operator.floordiv(self.to_decimal(self_unit), other.to_decimal(other_unit)),
+                unit=self_unit / other_unit,
+            )
         return maybe_decimal(r)
 
     def __rfloordiv__(self, oc):
         # oc // self
-        rdiv = lambda a, b: operator.truediv(b, a)
-        rfloordiv = lambda a, b: operator.floordiv(b, a)
-        r = self._binary_operation(oc, rfloordiv, rdiv)
-        return maybe_decimal(r)
+        return _to_quantity(oc).__floordiv__(self)
 
     def __ifloordiv__(self, oc):
         # a //= b
@@ -2923,6 +2938,28 @@ class Quantity:
         # is JIT-safe (no `bool(traced_array)` or traced unit exponents).
         axis = args[0] if args else kwds.get('axis', None)
         dim_exponent = _reduction_count_from_shape(self.shape, axis)
+
+        # A ``where`` mask excludes elements from the product, so masked-out
+        # elements must not count toward the unit exponent either. Mirror
+        # nanprod: derive the exponent from the effective element count when
+        # the mask is concrete, and require the counts to be uniform.
+        # Skipped under tracing because traced booleans cannot drive a
+        # Python ``if``.
+        where = kwds.get('where', None)
+        if where is not None and not self.is_unitless and not _is_tracer(where):
+            counts = xp.sum(xp.broadcast_to(xp.where(where, 1, 0), self.shape), axis=axis)
+            if counts.ndim > 0:
+                first = counts.ravel()[0]
+                if not bool(xp.all(counts == first)):
+                    raise ValueError(
+                        "prod with a `where` mask keeping a non-uniform number of "
+                        "elements is not supported for quantities with units, because "
+                        "the resulting elements would have different unit exponents."
+                    )
+                dim_exponent = int(first)
+            else:
+                dim_exponent = int(counts)
+
         r = Quantity(prod_res, unit=self.unit ** dim_exponent)
         return maybe_decimal(r)
 
@@ -2970,7 +3007,10 @@ class Quantity:
         # tracing because traced booleans cannot drive a Python ``if``.
         if not _is_tracer(self.mantissa):
             nan_mask = xp.isnan(self.mantissa)
-            non_nan_counts = xp.sum(xp.where(nan_mask, 0, 1), *args, **kwds)
+            # ``initial`` seeds the product, not the element count — forwarding
+            # it to the count ``sum`` would inflate the unit exponent.
+            count_kwds = {k: v for k, v in kwds.items() if k != 'initial'}
+            non_nan_counts = xp.sum(xp.where(nan_mask, 0, 1), *args, **count_kwds)
             if non_nan_counts.ndim > 0:
                 first = non_nan_counts.ravel()[0]
                 if not bool(xp.all(non_nan_counts == first)):

--- a/saiunit/math/_activation.py
+++ b/saiunit/math/_activation.py
@@ -511,7 +511,15 @@ def leaky_relu(
     """
     x = maybe_custom_array(x)
     x_arr = asarray(x)
-    return where(get_mantissa(x_arr) >= 0, x_arr, negative_slope * x_arr)
+    # leaky_relu is homogeneous of degree 1, so it is unit-preserving.
+    # Compute on the mantissa and reattach the unit: multiplying the Quantity
+    # itself by ``negative_slope`` would collapse a scaled-dimensionless
+    # Quantity (e.g. mV/volt) to a plain array and break the unit-aware where.
+    m = get_mantissa(x_arr)
+    out = where(m >= 0, m, negative_slope * m)
+    if isinstance(x_arr, Quantity):
+        return Quantity(out, unit=x_arr.unit)
+    return out
 
 
 @set_module_as('saiunit.math')

--- a/saiunit/math/_activation_test.py
+++ b/saiunit/math/_activation_test.py
@@ -977,6 +977,52 @@ class TestDocstringExamples:
 
 
 # ---------------------------------------------------------------------------
+# leaky_relu unit handling tests
+# ---------------------------------------------------------------------------
+
+class TestLeakyReluUnits:
+    """Regression tests for leaky_relu unit handling.
+
+    leaky_relu is homogeneous of degree 1, so it is unit-preserving like relu.
+    It previously crashed on scaled-dimensionless Quantities (e.g. mV/volt)
+    because ``negative_slope * x`` collapsed the Quantity to a plain array
+    while the other branch of the unit-aware ``where`` stayed a Quantity.
+    """
+
+    def test_leaky_relu_plain_array_matches_jax(self):
+        """Plain-array behavior must match jax.nn.leaky_relu exactly."""
+        x = jnp.array([-3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0])
+        np.testing.assert_array_equal(um.leaky_relu(x), jax.nn.leaky_relu(x))
+        np.testing.assert_array_equal(
+            um.leaky_relu(x, negative_slope=0.2),
+            jax.nn.leaky_relu(x, negative_slope=0.2),
+        )
+
+    def test_leaky_relu_scaled_dimensionless_quantity(self):
+        """leaky_relu must not crash on a scaled-dimensionless Quantity (mV/volt)."""
+        q = Quantity(jnp.array([-1.0, 1.0]), unit=u.mV / u.volt)
+        result = um.leaky_relu(q)
+        assert isinstance(result, Quantity)
+        assert result.unit == u.mV / u.volt
+        expected = jax.nn.leaky_relu(q.to_decimal())
+        np.testing.assert_allclose(result.to_decimal(), expected, rtol=1e-6)
+
+    def test_leaky_relu_unitful_quantity_consistent_with_relu(self):
+        """Unitful input behaves like relu: Quantity out, unit preserved."""
+        q = Quantity(jnp.array([-2.0, -1.0, 0.0, 1.0]), unit=u.mV)
+        relu_result = um.relu(q)
+        assert isinstance(relu_result, Quantity)
+        assert relu_result.unit == u.mV
+
+        result = um.leaky_relu(q)
+        assert isinstance(result, Quantity)
+        assert result.unit == relu_result.unit
+        np.testing.assert_allclose(
+            result.mantissa, jax.nn.leaky_relu(q.mantissa), rtol=1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
 # unit_to_scale tests
 # ---------------------------------------------------------------------------
 

--- a/saiunit/math/_einops.py
+++ b/saiunit/math/_einops.py
@@ -562,6 +562,9 @@ def einreduce(
         (4, 3)
     """
     x = maybe_custom_array_tree(x)
+    if isinstance(x, (list, tuple)):
+        # a list/tuple of tensors is accepted: stack it into a single array/Quantity
+        x = asarray(x)
     shape = _get_shape(x)
     try:
         hashable_axes_lengths = tuple(axes_lengths.items())
@@ -716,8 +719,21 @@ def einshape(
     else:
         composition = exp.composition
     result = {}
-    for (axis_name,), axis_length in zip(composition, _shape):  # type: ignore
-        if axis_name != "_":
+    # axes is either '_' (ellipsis placeholder), [] (anonymous axis of length 1),
+    # [AnonymousAxis] or [axis_name]
+    for axes, axis_length in zip(composition, _shape):  # type: ignore
+        if isinstance(axes, str):
+            # '_' placeholder inserted for dimensions covered by the ellipsis
+            continue
+        if len(axes) == 0:
+            if axis_length != 1:
+                raise RuntimeError(f"Length of axis is not 1: {pattern} {_shape}")
+            continue
+        (axis_name,) = axes
+        if isinstance(axis_name, AnonymousAxis):
+            if axis_name.value != axis_length:
+                raise RuntimeError(f"Length of anonymous axis does not match: {pattern} {_shape}")
+        elif axis_name != "_":
             result[axis_name] = axis_length
     return result
 
@@ -1052,7 +1068,7 @@ def einsum(
     >>> u.math.einsum('ij,j', M, x) # implicit form
     Array([14, 38, 62, 86], dtype=float32) * mvolt
     >>> u.math.einsum(M, (0, 1), x, (1,), (0,)) # explicit form via indices
-    Array([14, 38, 62, 86], dtype=float32)
+    Array([14, 38, 62, 86], dtype=float32) * mvolt
     >>> u.math.einsum(M, (0, 1), x, (1,))  # implicit form via indices
     Array([14, 38, 62, 86], dtype=float32) * mvolt
 

--- a/saiunit/math/_einops_test.py
+++ b/saiunit/math/_einops_test.py
@@ -321,6 +321,28 @@ def test_list_inputs():
     )
 
 
+def test_list_input_reduce_without_reshape():
+    # recipe needs no initial reshape/transpose, so the list must be stacked up front
+    x = [jnp.ones(3), jnp.ones(3)]
+    result = einreduce(x, "b a -> b", "sum")
+    assert not isinstance(result, list)
+    assert np.array_equal(np.asarray(result), np.asarray([3.0, 3.0]))
+
+
+def test_list_input_rearrange_identity():
+    x = [jnp.arange(3.0), jnp.arange(3.0, 6.0)]
+    result = einrearrange(x, "b a -> b a")
+    assert not isinstance(result, list)
+    assert np.array_equal(np.asarray(result), np.stack([np.arange(3.0), np.arange(3.0, 6.0)]))
+
+
+def test_list_input_quantity_preserves_unit():
+    x = [jnp.ones(3) * u.mV, jnp.ones(3) * u.mV]
+    result = einreduce(x, "b a -> b", "sum")
+    assert isinstance(result, u.Quantity)
+    assert_quantity(result, jnp.array([3.0, 3.0]), u.mV)
+
+
 def bit_count(x):
     return sum((x >> i) & 1 for i in range(20))
 
@@ -850,3 +872,20 @@ def test_einshape_rejects_composite_axes():
     x = jnp.zeros((6, 4))
     with pytest.raises(RuntimeError):
         u.math.einshape(x, '(a b) c')
+
+
+def test_einshape_unitary_anonymous_axis():
+    assert u.math.einshape(jnp.zeros((2, 1, 5)), 'a 1 b') == {'a': 2, 'b': 5}
+    with pytest.raises(RuntimeError):
+        u.math.einshape(jnp.zeros((2, 3, 5)), 'a 1 b')
+
+
+def test_einshape_anonymous_axis_validation():
+    assert u.math.einshape(jnp.zeros((2, 5, 3)), 'a 5 b') == {'a': 2, 'b': 3}
+    with pytest.raises(RuntimeError):
+        u.math.einshape(jnp.zeros((2, 5, 3)), 'a 7 b')
+
+
+def test_einshape_with_ellipsis():
+    x = jnp.zeros((2, 3, 5, 7))
+    assert u.math.einshape(x, 'a ... b') == {'a': 2, 'b': 7}

--- a/saiunit/math/_exprel.py
+++ b/saiunit/math/_exprel.py
@@ -131,6 +131,35 @@ def _get_threshold(dtype) -> float:
         return 1e-4
 
 
+def _get_deriv_threshold(dtype) -> float:
+    """
+    Get the Taylor/direct switch-over threshold for the *derivative* of exprel.
+
+    The derivative's direct form cancels catastrophically near zero (its
+    numerator behaves like x²/2 while the terms being subtracted are O(1)),
+    so it needs a much larger Taylor region than the value path. With a
+    Taylor order of at least ``_DERIV_MIN_TAYLOR_ORDER`` the truncation error
+    inside these thresholds is negligible at the respective precision.
+    """
+    if dtype == jnp.float64:
+        return 0.05
+    elif dtype == jnp.float32:
+        return 0.1
+    elif dtype == jnp.float16:
+        return 0.5
+    elif dtype == jnp.bfloat16:
+        return 0.5
+    else:
+        return 0.1
+
+
+# Minimum Taylor order used in the derivative's small-|x| branch. The
+# derivative thresholds above are much larger than the value-path ones, so a
+# low user-selected order would truncate too early (e.g. order 2 at |x|=0.1
+# has ~7e-5 relative error). Order 10 keeps truncation below ~1e-13 there.
+_DERIV_MIN_TAYLOR_ORDER = 10
+
+
 def _exprel_coefficients(order: int):
     """
     Generate Taylor coefficients for exprel using Horner's method.
@@ -280,16 +309,21 @@ def _exprel_deriv_taylor(x, order: Optional[int] = None):
     return result
 
 
-def _exprel_deriv_direct(x):
+def _exprel_deriv_direct(x, order: Optional[int] = None):
     """
     Direct computation of d/dx[(exp(x) - 1) / x].
 
-    f'(x) = [(x-1)*exp(x) + 1] / x²
-          = [exp(x) - (exp(x) - 1)/x] / x
-          = [exp(x) - exprel(x)] / x
+    Substituting exp(x) = x * exprel(x) + 1 into
+    f'(x) = [(x-1)*exp(x) + 1] / x² gives
+
+    f'(x) = [(x-1) * exprel(x) + 1] / x
+
+    which loses only one power of x to cancellation near zero (instead of
+    two for the naive form, whose numerator ≈ x²/2 while the subtracted
+    terms are O(1)). Building on the exprel primitive also keeps this
+    expression differentiable to arbitrary order with the same stability.
     """
-    exp_x = jnp.exp(x)
-    return ((x - 1) * exp_x + 1) / (x * x)
+    return ((x - 1) * exprel(x, order=order) + 1) / x
 
 
 def _exprel_deriv(x, order: Optional[int] = None):
@@ -309,12 +343,19 @@ def _exprel_deriv(x, order: Optional[int] = None):
         exprel'(x) computed in a numerically stable way.
     """
     dtype = x.dtype
-    threshold = _get_threshold(dtype)
+    threshold = _get_deriv_threshold(dtype)
     abs_x = jnp.abs(x)
     is_small = abs_x <= threshold
 
+    # The derivative threshold is far larger than the value-path one, so the
+    # Taylor branch must use a high enough order regardless of the (value)
+    # order requested by the caller.
+    if order is None:
+        order = _current_order
+    taylor_order = max(order, _DERIV_MIN_TAYLOR_ORDER)
+
     # Guard the direct branch against ``x == 0``. ``_exprel_deriv_direct`` is
-    # ``((x-1)*exp(x)+1)/x**2`` — a removable ``0/0`` at ``x = 0``. ``where``
+    # ``((x-1)*exprel(x)+1)/x`` — a removable ``0/0`` at ``x = 0``. ``where``
     # masks the *value*, but under differentiation (e.g. ``grad(grad(exprel))``)
     # the unselected branch's gradient is still evaluated, and ``d/dx`` of the
     # direct form is NaN at 0, poisoning the result via ``0 * NaN``. Feeding the
@@ -324,12 +365,12 @@ def _exprel_deriv(x, order: Optional[int] = None):
 
     return jnp.where(
         is_small,
-        _exprel_deriv_taylor(x, order),
-        _exprel_deriv_direct(safe_x)
+        _exprel_deriv_taylor(x, taylor_order),
+        _exprel_deriv_direct(safe_x, order)
     )
 
 
-def exprel(x, /, order: int = 2):
+def exprel(x, /, order: Optional[int] = None):
     """Compute ``(exp(x) - 1) / x`` in a numerically stable way.
 
     This function handles the removable singularity at ``x = 0`` by
@@ -344,7 +385,9 @@ def exprel(x, /, order: int = 2):
         Input array.
     order : int, optional
         The order of the Taylor series expansion to use for small
-        ``|x|``. Default is 2.
+        ``|x|``. Must be an integer in the range [2, 20]. If not given,
+        the module-level default set by :func:`set_exprel_order` is used
+        (initially 5).
 
     Returns
     -------
@@ -369,7 +412,16 @@ def exprel(x, /, order: int = 2):
         Array([1.        , 1.7182819 , 0.63212055], dtype=float32)
     """
     require_jax("saiunit.math.exprel (custom JAX primitive)")
+    if order is None:
+        order = _current_order
+    if not isinstance(order, int) or order < 2 or order > 20:
+        raise ValueError(f"order must be an integer between 2 and 20, got {order}")
     x = jnp.asarray(x)
+    if not jnp.issubdtype(x.dtype, jnp.inexact):
+        # Promote integer/bool inputs: the implementation always produces a
+        # floating result, so binding with an integer aval would make the
+        # abstract eval (and hence JIT lowering) inconsistent with the impl.
+        x = x.astype(jnp.result_type(float, x.dtype))
     return exprel_p.bind(x, order=order)
 
 

--- a/saiunit/math/_exprel_test.py
+++ b/saiunit/math/_exprel_test.py
@@ -29,6 +29,8 @@ Tests cover:
 # import os
 # os.environ['JAX_ENABLE_X64'] = 'True'
 
+from math import factorial
+
 import brainstate  # type: ignore[import-untyped]
 import jax
 import jax.numpy as jnp
@@ -206,6 +208,90 @@ class TestExprelGradients:
         assert grads.shape == x.shape
         assert not jnp.any(jnp.isnan(grads))
         assert not jnp.any(jnp.isinf(grads))
+
+
+def _grad_reference(x):
+    """Float64 numpy reference for d/dx exprel.
+
+    Uses the direct expression ``((x-1)*exp(x)+1)/x**2`` for ``|x| > 0.01``
+    (no catastrophic cancellation there in float64) and a high-order Taylor
+    series below.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    out = np.empty_like(x)
+    small = np.abs(x) <= 0.01
+    xs = x[small]
+    # f'(x) = sum_{n>=0} (n+1)/(n+2)! x^n, Horner with order 12
+    acc = np.zeros_like(xs)
+    for n in range(12, -1, -1):
+        acc = acc * xs + (n + 1) / factorial(n + 2)
+    out[small] = acc
+    xl = x[~small]
+    out[~small] = ((xl - 1.0) * np.exp(xl) + 1.0) / (xl * xl)
+    return out
+
+
+def _second_deriv_reference(x):
+    """Float64 numpy reference for d²/dx² exprel.
+
+    f''(x) = ((x² - 2x + 2)·exp(x) - 2) / x³ for ``|x| > 0.01``,
+    Taylor series ``sum_{m>=0} (m+1)(m+2)/(m+3)! x^m`` below (f''(0) = 1/3).
+    """
+    x = float(x)
+    if abs(x) <= 0.01:
+        acc = 0.0
+        for m in range(12, -1, -1):
+            acc = acc * x + (m + 1) * (m + 2) / factorial(m + 3)
+        return acc
+    return ((x * x - 2.0 * x + 2.0) * np.exp(x) - 2.0) / x ** 3
+
+
+class TestExprelGradientAccuracy:
+    """Regression tests for gradient accuracy just above the value-path Taylor threshold.
+
+    The value path switches from Taylor to ``expm1(x)/x`` at a tiny threshold
+    (1e-4 for float32). Reusing that threshold for the derivative is wrong:
+    the direct derivative ``((x-1)*exp(x)+1)/x²`` cancels catastrophically for
+    small ``|x|`` (numerator ≈ x²/2), e.g. float32 grad at 1.2e-4 evaluated to
+    0.0 instead of ~0.5. The derivative needs its own, much larger threshold.
+    """
+
+    def test_float32_grad_accuracy_sweep(self):
+        """float32 jax.grad(exprel) over ±logspace(-8, 1) vs float64 reference."""
+        xs = np.logspace(-8, 1, 200)
+        xs = np.concatenate([-xs[::-1], xs]).astype(np.float32)
+        grads = jax.vmap(jax.grad(exprel))(jnp.asarray(xs))
+        ref = _grad_reference(xs)
+        rel_err = np.abs(np.asarray(grads, dtype=np.float64) - ref) / np.abs(ref)
+        assert np.max(rel_err) < 1e-5, \
+            f"max rel err {np.max(rel_err):.3e} at x={xs[np.argmax(rel_err)]}"
+
+    def test_float64_grad_accuracy_spot_checks(self):
+        """float64 gradients above the old 1e-7 threshold must be accurate."""
+        with brainstate.environ.context(precision=64):
+            for val in [2e-7, 1e-6, 1e-4, 1e-3, 1e-2, 0.1, 1.0]:
+                for sign in (1.0, -1.0):
+                    x = jnp.float64(sign * val)
+                    grad = jax.grad(exprel)(x)
+                    ref = _grad_reference(np.array([sign * val]))[0]
+                    rel_err = abs(float(grad) - ref) / abs(ref)
+                    assert rel_err < 1e-12, \
+                        f"float64 grad at x={sign * val}: got {float(grad)}, " \
+                        f"expected {ref}, rel err {rel_err:.3e}"
+
+    def test_grad_of_grad_spot_checks(self):
+        """Second derivative spot checks; f''(0) = 1/3.
+
+        Previously broken: float32 grad-of-grad at 1.2e-4 evaluated to 8336.0.
+        """
+        for val in [0.0, 1.2e-4, 1e-3, 0.1, 1.0]:
+            d2 = jax.grad(jax.grad(exprel))(jnp.float32(val))
+            ref = _second_deriv_reference(val)
+            assert not jnp.isnan(d2), f"grad-of-grad at x={val} is NaN"
+            rel_err = abs(float(d2) - ref) / abs(ref)
+            assert rel_err < 1e-3, \
+                f"grad-of-grad at x={val}: got {float(d2)}, expected {ref}, " \
+                f"rel err {rel_err:.3e}"
 
 
 class TestExprelDtypes:
@@ -488,6 +574,30 @@ class TestExprelTaylorOrder:
         with pytest.raises(ValueError):
             set_exprel_order(3.5)  # Not an integer
 
+    def test_set_exprel_order_affects_default_call(self):
+        """set_exprel_order must change the order bound when order isn't given."""
+        original_order = get_exprel_order()
+        try:
+            set_exprel_order(8)
+            jaxpr = jax.make_jaxpr(exprel)(jnp.float32(0.1))
+            orders = [eqn.params['order'] for eqn in jaxpr.jaxpr.eqns
+                      if eqn.primitive.name == 'exprel']
+            assert orders == [8], f"expected bound order [8], got {orders}"
+
+            # Explicit order= must still take precedence.
+            jaxpr = jax.make_jaxpr(lambda v: exprel(v, order=3))(jnp.float32(0.1))
+            orders = [eqn.params['order'] for eqn in jaxpr.jaxpr.eqns
+                      if eqn.primitive.name == 'exprel']
+            assert orders == [3], f"expected bound order [3], got {orders}"
+        finally:
+            set_exprel_order(original_order)
+
+    def test_exprel_invalid_order_argument(self):
+        """exprel must validate order with the same rules as set_exprel_order."""
+        for bad_order in [-1, 0, 1, 21, 3.5]:
+            with pytest.raises(ValueError):
+                exprel(jnp.float32(0.0), order=bad_order)
+
     def test_higher_order_improves_accuracy(self):
         """Test that higher order improves accuracy."""
         original_order = get_exprel_order()
@@ -654,6 +764,24 @@ class TestExprelJIT:
         # Allow small tolerance for numerical differences between JIT and eager
         assert jnp.allclose(result, expected, rtol=1e-4), \
             f"JIT grad differs from eager grad: {result} vs {expected}"
+
+    def test_jit_integer_input(self):
+        """JIT-compiled exprel must accept integer input (promote to float)."""
+        x = jnp.arange(3)
+        eager = exprel(x)
+        jitted = jax.jit(exprel)(x)
+        assert jnp.issubdtype(jitted.dtype, jnp.floating)
+        assert jitted.dtype == eager.dtype
+        np.testing.assert_allclose(jitted, eager, rtol=1e-6)
+
+    def test_jit_bool_input(self):
+        """JIT-compiled exprel must accept bool input (promote to float)."""
+        x = jnp.array([True, False, True])
+        eager = exprel(x)
+        jitted = jax.jit(exprel)(x)
+        assert jnp.issubdtype(jitted.dtype, jnp.floating)
+        assert jitted.dtype == eager.dtype
+        np.testing.assert_allclose(jitted, eager, rtol=1e-6)
 
     def test_jit_multiple_calls(self):
         """Test that JIT produces consistent results across multiple calls."""

--- a/saiunit/math/_fun_accept_unitless.py
+++ b/saiunit/math/_fun_accept_unitless.py
@@ -70,7 +70,7 @@ def _dimensionless_required_message(func: Union[Callable, str], x: Quantity, arg
     )
 
 
-def _invalid_unit_to_scale_type_message(func: Callable, unit_to_scale: Any) -> str:
+def _invalid_unit_to_scale_type_message(func: Union[Callable, str], unit_to_scale: Any) -> str:
     name = _func_name(func)
     return (
         f'{name} expects "unit_to_scale" to be a Unit instance, but got '
@@ -78,7 +78,7 @@ def _invalid_unit_to_scale_type_message(func: Callable, unit_to_scale: Any) -> s
     )
 
 
-def _unit_to_scale_without_quantity_message(func: Callable, x: Any) -> str:
+def _unit_to_scale_without_quantity_message(func: Union[Callable, str], x: Any) -> str:
     name = _func_name(func)
     return (
         f'{name} received "unit_to_scale" but input "x" is not a Quantity '
@@ -1041,6 +1041,8 @@ def _fun_accept_unitless_binary(
     kwargs = maybe_custom_array_tree(kwargs)
     kwargs = _strip_none_kwargs(kwargs)
 
+    if unit_to_scale is not None and not isinstance(x, Quantity) and not isinstance(y, Quantity):
+        raise TypeError(_unit_to_scale_without_quantity_message(func, x))
     if isinstance(x, Quantity):
         if unit_to_scale is None:
             if not x.dim.is_dimensionless:
@@ -1402,9 +1404,10 @@ def cov(
 @set_module_as('saiunit.math')
 def ldexp(
     x: Union[Quantity, ArrayLike],
-    y: ArrayLike,
+    y: Union[Quantity, ArrayLike],
+    unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> Union[Quantity, ArrayLike]:
+) -> Array:
     """
     Returns x * 2**y, element-wise.
 
@@ -1415,24 +1418,43 @@ def ldexp(
     ----------
     x : array_like, Quantity
       Array of multipliers.
-    y : array_like, int
-      Array of twos exponents.
+    y : array_like, Quantity
+      Array of twos exponents. Must be dimensionless with integral values.
       If ``x.shape != y.shape``, they must be broadcastable to a common
       shape (which becomes the shape of the output).
+    unit_to_scale : Unit, optional
+      Unit used to convert ``x`` (not ``y``) to a dimensionless number first.
 
     Returns
     -------
-    out : ndarray, quantity or scalar
+    out : Array
       The result of ``x * 2**y``.
       This is a scalar if both `x` and `y` are scalars.
-
-      This is a Quantity if the product of the square of the unit of `x` and the unit of `y` is not dimensionless.
     """
     x, y = maybe_custom_array_tree((x, y))
     if isinstance(x, Quantity):
-        if not x.dim.is_dimensionless:
-            raise TypeError(_dimensionless_required_message('ldexp', x, arg_name='x'))
-        x = x.mantissa
+        if unit_to_scale is None:
+            if not x.dim.is_dimensionless:
+                raise TypeError(_dimensionless_required_message('ldexp', x, arg_name='x'))
+            x = x.to_decimal()
+        else:
+            if not isinstance(unit_to_scale, Unit):
+                raise TypeError(_invalid_unit_to_scale_type_message('ldexp', unit_to_scale))
+            x = x.to_decimal(unit_to_scale)
+    elif unit_to_scale is not None:
+        raise TypeError(_unit_to_scale_without_quantity_message('ldexp', x))
+    if isinstance(y, Quantity):
+        if not y.dim.is_dimensionless:
+            raise TypeError(_dimensionless_required_message('ldexp', y, arg_name='y'))
+        y = y.to_decimal()
+        # ``ldexp`` requires an integral exponent, but ``to_decimal`` yields
+        # floats when the unit carries a scale factor (e.g. ``mV / volt``).
+        if isinstance(y, float):
+            y = int(y)
+        elif hasattr(y, 'dtype'):
+            yp = get_backend(y)
+            if yp.isdtype(y.dtype, 'real floating'):
+                y = yp.astype(y, yp.int32)
     xp = get_backend(x, y)
     return _resolve_op('ldexp', xp)(x, y, **kwargs)
 

--- a/saiunit/math/_fun_accept_unitless_test.py
+++ b/saiunit/math/_fun_accept_unitless_test.py
@@ -771,3 +771,68 @@ def test_frexp_with_unit_to_scale():
     jm, je = jnp.frexp(jnp.array([1.0, 2.0, 4.0]))
     assert np.allclose(m, jm)
     assert np.allclose(e, je)
+
+
+def test_ldexp_scaled_dimensionless_x():
+    # A scale-carrying dimensionless unit (mV / volt = 1e-3) must be
+    # applied, not silently dropped.
+    x = u.Quantity(1., unit=u.mV / u.volt)
+    result = u.math.ldexp(x, 2)
+    expected = jnp.ldexp(0.001, 2)
+    assert np.allclose(result, expected)
+
+
+def test_ldexp_quantity_exponent():
+    result = u.math.ldexp(jnp.array([1.0]), u.Quantity(2))
+    expected = jnp.ldexp(jnp.array([1.0]), 2)
+    assert np.allclose(result, expected)
+
+
+def test_ldexp_scaled_dimensionless_exponent():
+    # mV / volt carries a 1e-3 scale: 2000 * 1e-3 == 2.
+    y = u.Quantity(2000., unit=u.mV / u.volt)
+    result = u.math.ldexp(jnp.array([1.0]), y)
+    expected = jnp.ldexp(jnp.array([1.0]), 2)
+    assert np.allclose(result, expected)
+
+
+def test_ldexp_scaled_dimensionless_exponent_array():
+    y = u.Quantity(jnp.array([1000., 2000.]), unit=u.mV / u.volt)
+    result = u.math.ldexp(jnp.array([1.0, 1.0]), y)
+    expected = jnp.ldexp(jnp.array([1.0, 1.0]), jnp.array([1, 2]))
+    assert np.allclose(result, expected)
+
+
+def test_ldexp_dimensionful_exponent_raises():
+    with pytest.raises(TypeError, match='requires a dimensionless "y"'):
+        u.math.ldexp(jnp.array([1.0]), 2 * u.meter)
+
+
+def test_ldexp_with_unit_to_scale():
+    x = jnp.array([1.0, 2.0]) * u.meter
+    result = u.math.ldexp(x, 2, unit_to_scale=u.cm)
+    expected = jnp.ldexp(jnp.array([100.0, 200.0]), 2)
+    assert np.allclose(result, expected)
+
+
+def test_ldexp_unit_to_scale_mismatch_raises():
+    x = jnp.array([1.0]) * u.meter
+    with pytest.raises(u.UnitMismatchError):
+        u.math.ldexp(x, 2, unit_to_scale=u.second)
+
+
+def test_ldexp_unit_to_scale_without_quantity_raises():
+    with pytest.raises(TypeError, match='received "unit_to_scale"'):
+        u.math.ldexp(jnp.array([1.0]), 2, unit_to_scale=u.meter)
+
+
+def test_binary_unit_to_scale_without_quantity_raises():
+    with pytest.raises(TypeError, match='received "unit_to_scale"'):
+        u.math.hypot(jnp.array([3.0]), jnp.array([4.0]), unit_to_scale=u.meter)
+
+
+def test_binary_unit_to_scale_with_only_y_quantity():
+    # unit_to_scale must still be accepted when only one input is a Quantity.
+    y = jnp.array([4.0]) * u.meter
+    result = u.math.hypot(jnp.array([3.0]), y, unit_to_scale=u.meter)
+    assert np.allclose(result, 5.0)

--- a/saiunit/math/_fun_array_creation.py
+++ b/saiunit/math/_fun_array_creation.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 from __future__ import annotations
 
+import inspect
 from collections.abc import Sequence
 from typing import (Union, Optional, List, Any, Tuple)
 
@@ -720,7 +721,7 @@ def empty_like(
         if not unit.is_unitless:
             prototype = prototype.in_unit(unit)
         return Quantity(
-            _safe_call_xp(xp.empty_like, (prototype.mantissa,), dict(dtype=dtype)),
+            _safe_call_xp(xp.empty_like, (prototype.mantissa,), dict(dtype=dtype, shape=shape)),
             unit=prototype.unit,
         )
     else:
@@ -905,21 +906,27 @@ def asarray(
             "pass an array, list, or Quantity."
         )
 
+    if unit is not None and not isinstance(unit, Unit):
+        raise TypeError(f'asarray requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
+
     # get leaves
     leaves, treedef = _tree.flatten(a, is_leaf=lambda x: isinstance(x, Quantity))
-    leaves = unit_scale_align_to_first(*leaves)
-    leaf_unit = leaves[0].unit
+    if leaves:
+        leaves = unit_scale_align_to_first(*leaves)
 
-    # get unit
-    if unit is not None and not leaf_unit.is_unitless:
-        if not isinstance(unit, Unit):
-            raise TypeError(f'asarray requires "unit" to be a Unit instance, got {type(unit).__name__}: {unit!r}.')
-        leaves = [leaf.in_unit(unit) for leaf in leaves]
-    else:
-        unit = leaf_unit
+        # get unit
+        if unit is not None:
+            # an explicit target unit is strict: every leaf must be
+            # convertible to it (``in_unit`` raises ``UnitMismatchError``
+            # otherwise, including for dimensionless leaves).
+            leaves = [leaf.in_unit(unit) for leaf in leaves]
+        else:
+            unit = leaves[0].unit
 
-    # reconstruct mantissa
-    a = treedef.unflatten([leaf.mantissa for leaf in leaves])  # type: ignore[attr-defined]
+        # reconstruct mantissa
+        a = treedef.unflatten([leaf.mantissa for leaf in leaves])  # type: ignore[attr-defined]
+    # with no leaves (e.g. ``asarray([])``) there are no units to align;
+    # the backend builds the empty array and ``unit`` (when given) wraps it.
     xp = _default_xp()
     # ``order`` is a numpy/jax-only kwarg; torch / dask / ndonnx ``asarray``
     # reject it. Only forward when explicitly provided.
@@ -929,7 +936,7 @@ def asarray(
     a = xp.asarray(a, dtype=dtype, **extra)
 
     # returns
-    if unit.is_unitless:
+    if unit is None or unit.is_unitless:
         return a
     return Quantity(a, unit=unit)
 
@@ -973,6 +980,8 @@ def arange(
     ------
     UnitMismatchError
         If ``start``, ``stop``, and ``step`` do not share the same unit.
+    TypeError
+        If neither ``start`` nor ``stop`` is given.
 
     Examples
     --------
@@ -989,10 +998,13 @@ def arange(
     stop = maybe_custom_array(stop) if stop is not None else stop
     step = maybe_custom_array(step) if step is not None else step
 
+    # numpy requires a stop: it may arrive positionally (``arange(n)``,
+    # carried in ``start``) or as the keyword, but one of the two must be given.
+    if start is None and stop is None:
+        raise TypeError('arange() requires stop to be specified.')
+
     # checking the dimension of the data
     non_none_data = [d for d in (start, stop, step) if d is not None]
-    if len(non_none_data) == 0:
-        raise ValueError('arange requires at least one of start, stop, or step to be provided.')
     d1 = non_none_data[0]
     for d2 in non_none_data[1:]:
         fail_for_unit_mismatch(
@@ -1014,7 +1026,11 @@ def arange(
     # ``stop``. Normalize the single-arg form ``arange(stop)`` to ``(0, stop)``
     # the way numpy does, then drop ``step`` when not given.
     if stop is None:
+        # single-argument ``arange(n)`` form: ``start`` is really the stop.
         head: Tuple[Any, ...] = (0, start)
+    elif start is None:
+        # keyword-only ``stop``: default start to 0 (in ``stop``'s unit).
+        head = (0, stop)
     else:
         head = (start, stop)
     pos = head if step is None else (*head, step)
@@ -1033,7 +1049,7 @@ def linspace(
     endpoint: Optional[bool] = True,
     retstep: Optional[bool] = False,
     dtype: Optional[DTypeLike] = None
-) -> Union[Quantity, Array]:
+) -> Union[Quantity, Array, Tuple[Union[Quantity, Array], Union[Quantity, Array]]]:
     """
     Return evenly spaced numbers over a specified interval.
 
@@ -1064,6 +1080,9 @@ def linspace(
     samples : Quantity or Array
         ``num`` equally spaced samples in the closed interval
         ``[start, stop]`` or the half-open interval ``[start, stop)``.
+    step : Quantity or Array
+        Only returned if ``retstep`` is ``True``: size of spacing between
+        samples.
 
     Raises
     ------
@@ -1098,6 +1117,13 @@ def linspace(
             xp.linspace, (start, stop),
             dict(num=num, endpoint=endpoint, retstep=retstep, dtype=dtype),
         )
+    if retstep:
+        # ``result`` is a ``(samples, step)`` pair; wrap each separately —
+        # a single Quantity over the tuple would try to concatenate them.
+        samples, step = result
+        if unit.is_unitless:
+            return samples, step
+        return Quantity(samples, unit=unit), Quantity(step, unit=unit)
     return result if unit.is_unitless else Quantity(result, unit=unit)
 
 
@@ -1175,6 +1201,28 @@ def logspace(
         )
 
 
+def _fill_diagonal_call(xp, a, val, wrap, inplace):
+    """Call ``xp.fill_diagonal`` normalizing in-place vs functional semantics.
+
+    JAX's ``fill_diagonal`` is functional and honours ``inplace`` (rejecting
+    ``True`` on immutable arrays).  numpy's mutates ``a`` in place and
+    returns ``None`` — and has no ``inplace`` kwarg, so the kwarg filter
+    would silently drop it.  On that path, operate on a copy when
+    ``inplace`` is ``False`` so the input is left untouched, and return the
+    filled array either way.
+    """
+    fn = xp.fill_diagonal
+    try:
+        functional = 'inplace' in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        functional = False
+    if functional:
+        return _safe_call_xp(fn, (a, val, wrap), dict(inplace=inplace))
+    target = a if inplace else xp.asarray(a, copy=True)
+    fn(target, val, wrap)
+    return target
+
+
 @set_module_as('saiunit.math')
 def fill_diagonal(
     a: Union[Quantity, ArrayLike],
@@ -1207,6 +1255,11 @@ def fill_diagonal(
     out : Quantity or Array
         The input array with the diagonal filled.
 
+    Raises
+    ------
+    TypeError
+        If ``val`` carries a unit but ``a`` is a plain array (not unitless).
+
     Examples
     --------
     .. code-block:: python
@@ -1225,22 +1278,28 @@ def fill_diagonal(
         if isinstance(a, Quantity):
             val = val.in_unit(a.unit)
             return Quantity(
-                _safe_call_xp(xp.fill_diagonal, (a.mantissa, val.mantissa, wrap), dict(inplace=inplace)),
+                _fill_diagonal_call(xp, a.mantissa, val.mantissa, wrap, inplace),
                 unit=a.unit,
             )
         else:
+            if not val.is_unitless:
+                raise TypeError(
+                    f'fill_diagonal requires "val" to be dimensionless when "a" is a plain array, '
+                    f'but got val with unit={val.unit}. '
+                    f'Either pass a plain number as val or wrap "a" as a Quantity.'
+                )
             return Quantity(
-                _safe_call_xp(xp.fill_diagonal, (a, val.mantissa, wrap), dict(inplace=inplace)),
+                _fill_diagonal_call(xp, a, val.mantissa, wrap, inplace),
                 unit=val.unit,
             )
     else:
         if isinstance(a, Quantity):
             return Quantity(
-                _safe_call_xp(xp.fill_diagonal, (a.mantissa, val, wrap), dict(inplace=inplace)),
+                _fill_diagonal_call(xp, a.mantissa, val, wrap, inplace),
                 unit=a.unit,
             )
         else:
-            return _safe_call_xp(xp.fill_diagonal, (a, val, wrap), dict(inplace=inplace))
+            return _fill_diagonal_call(xp, a, val, wrap, inplace)
 
 
 @set_module_as('saiunit.math')
@@ -1323,7 +1382,7 @@ def meshgrid(
 @set_module_as('saiunit.math')
 def vander(
     x: Union[Quantity, ArrayLike],
-    N: Optional[bool] = None,
+    N: Optional[int] = None,
     increasing: Optional[bool] = False,
     unit: Unit = UNITLESS
 ) -> Union[Quantity, Array]:
@@ -1373,7 +1432,7 @@ def vander(
             raise TypeError(
                 f'vander requires "x" to be dimensionless, '
                 f'but got x with unit={x.unit}. '
-                f'Pass "unit_to_scale" or strip the unit before calling vander.'
+                f'Strip the unit before calling vander, e.g. with x.to_decimal(unit).'
             )
         x = x.mantissa
     r = get_backend(x).vander(x, N=N, increasing=increasing)

--- a/saiunit/math/_fun_array_creation_test.py
+++ b/saiunit/math/_fun_array_creation_test.py
@@ -15,6 +15,7 @@
 
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from absl.testing import parameterized
 
@@ -739,3 +740,113 @@ def test_ones_respects_default_backend():
     with u.using_backend("numpy"):
         q = u.math.ones((3,), unit=meter)
         assert q.backend == "numpy"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for audit fixes.
+# ---------------------------------------------------------------------------
+
+
+class TestFillDiagonalNumpyBackend:
+    """``fill_diagonal`` on numpy-backed arrays must be functional by default."""
+
+    def test_fill_diagonal_numpy_returns_copy(self):
+        a = np.zeros((3, 3))
+        result = um.fill_diagonal(a, 5.0)
+        expected = np.zeros((3, 3))
+        np.fill_diagonal(expected, 5.0)
+        assert result is not None
+        assert_quantity(result, expected)
+        # inplace=False must leave the input untouched
+        assert (a == 0).all()
+
+    def test_fill_diagonal_numpy_inplace_mutates_and_returns(self):
+        a = np.zeros((3, 3))
+        result = um.fill_diagonal(a, 5.0, inplace=True)
+        expected = np.zeros((3, 3))
+        np.fill_diagonal(expected, 5.0)
+        assert_quantity(result, expected)
+        assert (a == expected).all()
+
+    def test_fill_diagonal_numpy_quantity(self):
+        aq = np.zeros((3, 3)) * u.mV
+        result = um.fill_diagonal(aq, 5.0 * u.mV)
+        expected = np.zeros((3, 3))
+        np.fill_diagonal(expected, 5.0)
+        assert_quantity(result, expected, unit=u.mV)
+        # inplace=False must leave the input untouched
+        assert (aq.mantissa == 0).all()
+
+
+def test_fill_diagonal_plain_array_quantity_val_raises():
+    with pytest.raises(TypeError):
+        um.fill_diagonal(jnp.zeros((3, 3)), 5.0 * u.mV)
+
+
+def test_empty_like_quantity_forwards_shape():
+    q = jnp.array([1.0, 2.0, 3.0]) * meter
+    result = um.empty_like(q, shape=(5,))
+    assert result.shape == (5,)
+    assert u.get_unit(result) == meter
+
+
+class TestAsarrayUnitStrictness:
+    """``asarray(..., unit=...)`` must honour the requested unit."""
+
+    def test_asarray_unit_on_dimensionless_input_raises(self):
+        with pytest.raises(u.UnitMismatchError):
+            um.asarray([1, 2, 3], unit=meter)
+
+    def test_asarray_unit_converts_matching_dimension(self):
+        result = um.asarray([1.0, 2.0] * u.mV, unit=u.volt)
+        assert_quantity(result, jnp.asarray([0.001, 0.002]), unit=u.volt)
+
+
+class TestAsarrayEmpty:
+    """``asarray([])`` must build an empty array instead of crashing."""
+
+    def test_asarray_empty_list(self):
+        result = um.asarray([])
+        expected = jnp.asarray([])
+        assert_quantity(result, expected)
+
+    def test_asarray_empty_list_with_unit(self):
+        result = um.asarray([], unit=meter)
+        assert isinstance(result, u.Quantity)
+        assert result.shape == (0,)
+        assert u.get_unit(result) == meter
+
+
+class TestArangeNoneHandling:
+    """``arange`` keyword-only forms must mirror numpy's semantics."""
+
+    def test_arange_stop_keyword_only(self):
+        result = um.arange(stop=5)
+        assert_quantity(result, jnp.arange(5))
+
+    def test_arange_stop_and_step_with_units(self):
+        result = um.arange(stop=3 * meter, step=1 * meter)
+        assert_quantity(result, jnp.arange(0, 3, 1), unit=meter)
+
+    def test_arange_step_only_raises(self):
+        with pytest.raises(TypeError):
+            um.arange(step=2)
+
+
+class TestLinspaceRetstep:
+    """``linspace(..., retstep=True)`` must wrap samples and step separately."""
+
+    def test_linspace_retstep_with_units(self):
+        samples, step = um.linspace(0 * meter, 10 * meter, 5, retstep=True)
+        assert_quantity(samples, jnp.linspace(0, 10, 5), unit=meter)
+        assert_quantity(step, jnp.asarray(2.5), unit=meter)
+
+    def test_linspace_retstep_plain(self):
+        samples, step = um.linspace(0, 10, 5, retstep=True)
+        assert_quantity(samples, jnp.linspace(0, 10, 5))
+        assert_quantity(step, jnp.asarray(2.5))
+
+
+def test_vander_unit_error_message_suggests_to_decimal():
+    with pytest.raises(TypeError, match='to_decimal'):
+        um.vander(jnp.array([1.0, 2.0, 3.0]) * meter, 3)

--- a/saiunit/math/_fun_change_unit.py
+++ b/saiunit/math/_fun_change_unit.py
@@ -21,7 +21,7 @@ from saiunit._jax_compat import jax, jnp
 from saiunit._typing import Array, ArrayLike, DTypeLike
 
 from saiunit._backend import get_backend
-from saiunit._base_unit import UNITLESS
+from saiunit._base_unit import UNITLESS, Unit
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
@@ -334,6 +334,24 @@ def square(
     return _fun_change_unit_unary('square', lambda u: u ** 2, x, **kwargs)
 
 
+def _check_prod_initial(initial, fun_name: str) -> Optional[ArrayLike]:
+    """Validate the ``initial`` argument of prod/nanprod.
+
+    A unitful ``initial`` would change the unit exponent of the result, so
+    only plain values and dimensionless quantities are supported (the
+    latter are unwrapped, folding any scale factor into the value).
+    """
+    if isinstance(initial, Quantity):
+        if not initial.dim.is_dimensionless:
+            raise TypeError(
+                f'{fun_name} does not support a unitful `initial` (got '
+                f'initial={initial}): it would change the unit exponent of '
+                f'the result. Pass a plain (dimensionless) value instead.'
+            )
+        return initial.to_decimal()
+    return initial
+
+
 @set_module_as('saiunit.math')
 def prod(
     x: Union[Quantity, ArrayLike],
@@ -364,7 +382,8 @@ def prod(
         If True, the axes which are reduced are left in the result as
         dimensions with size one.
     initial : scalar, optional
-        The starting value for this product.
+        The starting value for this product. Must be a plain value or a
+        dimensionless Quantity; a unitful ``initial`` raises ``TypeError``.
     where : array_like of bool, optional
         Elements to include in the product.
 
@@ -384,7 +403,8 @@ def prod(
         >>> u.math.prod(q)  # product is 6.0, unit is meter ** 2
     """
     x = maybe_custom_array(x)
-    extra = _strip_none_kwargs(dict(dtype=dtype, initial=initial, where=where))
+    initial_value = _check_prod_initial(initial, 'prod')
+    extra = _strip_none_kwargs(dict(dtype=dtype, initial=initial_value, where=where))
     if isinstance(x, Quantity):
         return x.prod(axis=axis, keepdims=keepdims, **extra)
     else:
@@ -422,7 +442,8 @@ def nanprod(
         If True, the axes which are reduced are left in the result as
         dimensions with size one.
     initial : scalar, optional
-        The starting value for this product.
+        The starting value for this product. Must be a plain value or a
+        dimensionless Quantity; a unitful ``initial`` raises ``TypeError``.
     where : array_like of bool, optional
         Elements to include in the product.
 
@@ -443,7 +464,8 @@ def nanprod(
         >>> u.math.nanprod(q)  # NaN treated as 1, result is 6.0
     """
     x = maybe_custom_array(x)
-    extra = _strip_none_kwargs(dict(dtype=dtype, initial=initial, where=where))
+    initial_value = _check_prod_initial(initial, 'nanprod')
+    extra = _strip_none_kwargs(dict(dtype=dtype, initial=initial_value, where=where))
     if isinstance(x, Quantity):
         return x.nanprod(axis=axis, keepdims=keepdims, **extra)
     else:
@@ -764,6 +786,26 @@ def true_divide(
                                    x, y, **kwargs)
 
 
+def _align_for_floor_division(x, y):
+    """Prepare mantissas and result units for floor-based division.
+
+    ``floor`` is not scale-linear, so the operands must be aligned before
+    flooring.  Same-dimension operands are aligned to ``x``'s unit: the
+    quotient is then dimensionless and the remainder keeps ``x``'s unit.
+    Mixed-dimension operands are folded to magnitude-1 (base) units so the
+    result does not depend on the unit representation of either operand.
+
+    Returns ``(x_value, y_value, quotient_unit, remainder_unit)``.
+    """
+    xq = x if isinstance(x, Quantity) else Quantity(x)
+    yq = y if isinstance(y, Quantity) else Quantity(y)
+    if xq.unit.has_same_dim(yq.unit):
+        return xq.mantissa, yq.in_unit(xq.unit).mantissa, UNITLESS, xq.unit
+    xu = xq.unit if xq.unit.magnitude == 1. else Unit(dim=xq.unit.dim)
+    yu = yq.unit if yq.unit.magnitude == 1. else Unit(dim=yq.unit.dim)
+    return xq.to_decimal(xu), yq.to_decimal(yu), xu / yu, xu
+
+
 @set_module_as('saiunit.math')
 def divmod(
     x: Union[Quantity, ArrayLike],
@@ -774,8 +816,13 @@ def divmod(
     Return element-wise quotient and remainder simultaneously.
 
     Equivalent to ``(x // y, x % y)``, but faster because it avoids
-    redundant work. The quotient carries unit ``x.unit / y.unit`` and the
-    remainder carries ``x.unit``.
+    redundant work. When `x` and `y` share a dimension, the operands are
+    aligned to ``x.unit`` first (``floor`` is not scale-linear): the
+    quotient is dimensionless and the remainder carries ``x.unit``. For
+    mixed dimensions, both operands are folded to magnitude-1 (base) units
+    so the result does not depend on the unit representation; the quotient
+    then carries the base ``x.unit / y.unit`` and the remainder the base
+    unit of ``x``.
 
     Parameters
     ----------
@@ -788,10 +835,10 @@ def divmod(
     Returns
     -------
     out1 : ndarray or Quantity
-        Element-wise quotient resulting from floor division. Unit is
-        ``x.unit / y.unit``.
+        Element-wise quotient resulting from floor division.
     out2 : ndarray or Quantity
-        Element-wise remainder from floor division. Unit is ``x.unit``.
+        Element-wise remainder from floor division, with the dimension
+        of `x`.
 
     Examples
     --------
@@ -804,18 +851,12 @@ def divmod(
     """
     x = maybe_custom_array(x)
     y = maybe_custom_array(y)
-    if isinstance(x, Quantity) and isinstance(y, Quantity):
-        xp = get_backend(x.mantissa, y.mantissa)
-        r = _resolve_op('divmod', xp)(x.mantissa, y.mantissa, **kwargs)
-        return Quantity(r[0], unit=x.unit / y.unit), Quantity(r[1], unit=x.unit)
-    elif isinstance(x, Quantity):
-        xp = get_backend(x.mantissa, y)
-        r = _resolve_op('divmod', xp)(x.mantissa, y, **kwargs)  # type: ignore[arg-type]
-        return Quantity(r[0], unit=x.unit / UNITLESS), Quantity(r[1], unit=x.unit)
-    elif isinstance(y, Quantity):
-        xp = get_backend(x, y.mantissa)
-        r = _resolve_op('divmod', xp)(x, y.mantissa, **kwargs)
-        return Quantity(r[0], unit=UNITLESS / y.unit), Quantity(r[1], unit=UNITLESS)
+    if isinstance(x, Quantity) or isinstance(y, Quantity):
+        xv, yv, quot_unit, rem_unit = _align_for_floor_division(x, y)
+        xp = get_backend(xv, yv)
+        r = _resolve_op('divmod', xp)(xv, yv, **kwargs)
+        return (maybe_decimal(Quantity(r[0], unit=quot_unit)),
+                maybe_decimal(Quantity(r[1], unit=rem_unit)))
     else:
         xp = get_backend(x, y)
         return _resolve_op('divmod', xp)(x, y, **kwargs)
@@ -936,17 +977,24 @@ def power(
                 )
             y = y.mantissa
         xp = get_backend(x.mantissa, y)
+        if x.dim.is_dimensionless:
+            # A dimensionless base yields a plain result for any exponent —
+            # including array exponents, which ``x.unit ** y`` cannot
+            # express. ``to_decimal`` folds any scale factor into the value.
+            return _resolve_op('power', xp)(x.to_decimal(), y, **kwargs)
         return maybe_decimal(Quantity(_resolve_op('power', xp)(x.mantissa, y, **kwargs), unit=x.unit ** y))
     elif isinstance(y, Quantity):
-        if not y.is_unitless:
+        if not y.dim.is_dimensionless:
             raise TypeError(
                 f'power requires the exponent "y" to be dimensionless, '
                 f'but got y with unit={y.unit}. '
                 f'Strip the unit from y before raising a value to a power.'
             )
-        y = y.mantissa
-        xp = get_backend(x, y)
-        return maybe_decimal(Quantity(_resolve_op('power', xp)(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
+        # ``x`` carries no unit here and the exponent is dimensionless, so
+        # the result is plain; ``to_decimal`` folds any scale factor of y.
+        y_value = y.to_decimal()
+        xp = get_backend(x, y_value)
+        return _resolve_op('power', xp)(x, y_value, **kwargs)
     else:
         xp = get_backend(x, y)
         return _resolve_op('power', xp)(x, y, **kwargs)
@@ -961,8 +1009,12 @@ def floor_divide(
     """
     Return the largest integer smaller or equal to the division of the inputs.
 
-    Equivalent to the Python ``//`` operator. The resulting unit is
-    ``x.unit / y.unit``.
+    Equivalent to the Python ``//`` operator. ``floor`` is not scale-linear,
+    so when `x` and `y` share a dimension the operands are aligned to
+    ``x.unit`` first and the result is a plain (dimensionless) integral
+    value. For mixed dimensions, both operands are folded to magnitude-1
+    (base) units so the result does not depend on the unit representation;
+    the result then carries the base ``x.unit / y.unit``.
 
     Parameters
     ----------
@@ -976,7 +1028,7 @@ def floor_divide(
     -------
     out : ndarray or Quantity
         ``floor(x / y)``, element-wise. This is a scalar if both `x` and
-        `y` are scalars. The resulting unit is ``x.unit / y.unit``.
+        `y` are scalars.
 
     Examples
     --------
@@ -987,7 +1039,17 @@ def floor_divide(
         >>> b = u.math.array([2.0, 3.0]) * u.second
         >>> u.math.floor_divide(a, b)  # unit is meter / second
     """
-    return _fun_change_unit_binary('floor_divide', lambda ux, uy: ux / uy, x, y, **kwargs)
+    x = maybe_custom_array(x)
+    y = maybe_custom_array(y)
+    kwargs = _strip_none_kwargs(kwargs)
+    if isinstance(x, Quantity) or isinstance(y, Quantity):
+        xv, yv, quot_unit, _ = _align_for_floor_division(x, y)
+        xp = get_backend(xv, yv)
+        r = _dispatch_call(_resolve_op('floor_divide', xp), (xv, yv), kwargs)
+        return maybe_decimal(Quantity(r, unit=quot_unit))
+    else:
+        xp = get_backend(x, y)
+        return _dispatch_call(_resolve_op('floor_divide', xp), (x, y), kwargs)
 
 
 @set_module_as('saiunit.math')
@@ -1043,17 +1105,24 @@ def float_power(
                 )
             y = y.mantissa
         xp = get_backend(x.mantissa, y)
+        if x.dim.is_dimensionless:
+            # A dimensionless base yields a plain result for any exponent —
+            # including array exponents, which ``x.unit ** y`` cannot
+            # express. ``to_decimal`` folds any scale factor into the value.
+            return _resolve_op('float_power', xp)(x.to_decimal(), y, **kwargs)
         return maybe_decimal(Quantity(_resolve_op('float_power', xp)(x.mantissa, y, **kwargs), unit=x.unit ** y))
     elif isinstance(y, Quantity):
-        if not y.is_unitless:
+        if not y.dim.is_dimensionless:
             raise TypeError(
                 f'float_power requires the exponent "y" to be dimensionless, '
                 f'but got y with unit={y.unit}. '
                 f'Strip the unit from y before raising a value to a power.'
             )
-        y = y.mantissa
-        xp = get_backend(x, y)
-        return maybe_decimal(Quantity(_resolve_op('float_power', xp)(x, y, **kwargs), unit=x ** y))
+        # ``x`` carries no unit here and the exponent is dimensionless, so
+        # the result is plain; ``to_decimal`` folds any scale factor of y.
+        y_value = y.to_decimal()
+        xp = get_backend(x, y_value)
+        return _resolve_op('float_power', xp)(x, y_value, **kwargs)
     else:
         xp = get_backend(x, y)
         return _resolve_op('float_power', xp)(x, y, **kwargs)

--- a/saiunit/math/_fun_change_unit_test.py
+++ b/saiunit/math/_fun_change_unit_test.py
@@ -658,3 +658,154 @@ def test_cumproduct_is_cumprod_alias():
     assert u.math.cumproduct is u.math.cumprod
     x = jnp.array([1.0, 2.0, 3.0, 4.0])
     assert jnp.allclose(u.math.cumproduct(x), u.math.cumprod(x))
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: scale alignment in divmod / floor_divide
+# ---------------------------------------------------------------------------
+
+
+def test_divmod_same_dim_scale_alignment():
+    """Regression: divmod must align scales before flooring (7 m vs 2 km)."""
+    q, r = um.divmod(7.0 * u.meter, 2.0 * u.kmeter)
+    assert_quantity(q, 0.0)
+    assert_quantity(r, 7.0, unit=u.meter)
+    # identity: divmod(x, y) == (x // y, x % y)
+    fd = um.floor_divide(7.0 * u.meter, 2.0 * u.kmeter)
+    m = (7.0 * u.meter) % (2.0 * u.kmeter)
+    assert_quantity(fd, 0.0)
+    assert jnp.allclose(jnp.asarray(q), jnp.asarray(fd))
+    assert_quantity(r, m.to_decimal(u.meter), unit=u.meter)
+
+
+def test_divmod_same_dim_matches_floordiv_and_mod():
+    x = jnp.array([7.0, 9.5]) * u.meter
+    y = 2.0 * u.kmeter
+    q, r = um.divmod(x, y)
+    fd = um.floor_divide(x, y)
+    m = x % y
+    assert_quantity(q, jnp.asarray(fd))
+    assert_quantity(r, m.to_decimal(u.meter), unit=u.meter)
+
+
+def test_divmod_mixed_dim_representation_invariant():
+    """Regression: divmod(7.0, 2 km) must equal divmod(7.0, 2000 m)."""
+    q1, r1 = um.divmod(7.0, 2.0 * u.kmeter)
+    q2, r2 = um.divmod(7.0, 2000.0 * u.meter)
+    assert_quantity(q1, 0.0, unit=u.meter ** -1)
+    assert_quantity(q2, 0.0, unit=u.meter ** -1)
+    assert_quantity(r1, 7.0)
+    assert_quantity(r2, 7.0)
+
+
+def test_divmod_mixed_dim_identity():
+    x = 7.0 * u.kmeter
+    y = 3.0 * u.second
+    q, r = um.divmod(x, y)
+    fd = um.floor_divide(x, y)
+    assert_quantity(q, 2333.0, unit=u.meter / u.second)
+    assert_quantity(r, 1.0, unit=u.meter)
+    assert_quantity(fd, 2333.0, unit=u.meter / u.second)
+    # reconstruction: q * y + r == x
+    assert_quantity((q * y + r).in_unit(u.meter), 7000.0, unit=u.meter)
+
+
+def test_floor_divide_same_dim_scale_alignment():
+    """Regression: floor_divide must align scales before flooring."""
+    assert_quantity(um.floor_divide(7.0 * u.meter, 2.0 * u.kmeter), 0.0)
+    assert_quantity(um.floor_divide(1.0 * u.kmeter, 3.0 * u.meter), 333.0)
+
+
+def test_floordiv_operator_scale_alignment():
+    """Regression: Quantity.__floordiv__ must align scales before flooring."""
+    assert_quantity((1.0 * u.kmeter) // (3.0 * u.meter), 333.0)
+    assert_quantity((7.0 * u.meter) // (2.0 * u.kmeter), 0.0)
+
+
+def test_floordiv_operator_mixed_dim_representation_invariant():
+    r1 = (7.0 * u.kmeter) // 2.0
+    r2 = (7000.0 * u.meter) // 2.0
+    assert_quantity(r1, 3500.0, unit=u.meter)
+    assert_quantity(r2, 3500.0, unit=u.meter)
+
+
+def test_rfloordiv_operator_scale_alignment():
+    r = 7000.0 // u.Quantity(2.0, unit=u.kmeter / u.meter)
+    assert_quantity(r, 3.0)
+
+
+def test_floor_divide_plain_path_unchanged():
+    assert_quantity(um.floor_divide(7.0, 2.0), 3.0)
+    assert_quantity(um.floor_divide(jnp.array([7.0, 8.0]), 3.0), jnp.array([2.0, 2.0]))
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: prod with ``where=`` / unitful ``initial``
+# ---------------------------------------------------------------------------
+
+
+def test_prod_where_unit_exponent_counts_only_kept_elements():
+    """Regression: masked-out elements must not raise the unit exponent."""
+    q = jnp.array([2.0, 3.0]) * u.meter
+    r = um.prod(q, where=jnp.array([True, False]))
+    assert_quantity(r, 2.0, unit=u.meter)
+
+
+def test_prod_where_uniform_counts_along_axis():
+    q = jnp.array([[2.0, 3.0], [4.0, 5.0]]) * u.meter
+    r = um.prod(q, axis=1, where=jnp.array([[True, False], [False, True]]))
+    assert_quantity(r, jnp.array([2.0, 5.0]), unit=u.meter)
+
+
+def test_prod_where_non_uniform_counts_raise():
+    q = jnp.array([[2.0, 3.0], [4.0, 5.0]]) * u.meter
+    with pytest.raises(ValueError):
+        um.prod(q, axis=1, where=jnp.array([[True, False], [True, True]]))
+
+
+def test_prod_unitful_initial_raises():
+    q = jnp.array([2.0, 3.0]) * u.meter
+    with pytest.raises(TypeError):
+        um.prod(q, initial=2.0 * u.meter)
+    with pytest.raises(TypeError):
+        um.nanprod(q, initial=2.0 * u.meter)
+
+
+def test_prod_dimensionless_quantity_initial():
+    q = jnp.array([2.0, 3.0]) * u.meter
+    r = um.prod(q, initial=u.Quantity(2.0))
+    assert_quantity(r, 12.0, unit=u.meter ** 2)
+    r = um.nanprod(q, initial=u.Quantity(2.0))
+    assert_quantity(r, 12.0, unit=u.meter ** 2)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: power / float_power edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_power_plain_base_quantity_exponent():
+    """Regression: plain base with dimensionless Quantity exponent is plain."""
+    assert_quantity(um.power(2.0, u.Quantity(3.0)), 8.0)
+    assert_quantity(um.float_power(2.0, u.Quantity(3.0)), 8.0)
+
+
+def test_power_plain_base_unitful_exponent_raises():
+    with pytest.raises(TypeError):
+        um.power(2.0, 3.0 * u.meter)
+    with pytest.raises(TypeError):
+        um.float_power(2.0, 3.0 * u.meter)
+
+
+def test_power_unitless_quantity_base_array_exponent():
+    """Regression: unitless Quantity base with array exponent must not raise."""
+    r = um.power(u.Quantity(jnp.array([2.0, 3.0])), jnp.array([2.0, 3.0]))
+    assert_quantity(r, jnp.array([4.0, 27.0]))
+    r = um.float_power(u.Quantity(jnp.array([2.0, 3.0])), jnp.array([2.0, 3.0]))
+    assert_quantity(r, jnp.array([4.0, 27.0]))
+
+
+def test_power_scaled_dimensionless_base_array_exponent():
+    scaled = u.Quantity(jnp.array([2.0, 3.0]), unit=u.kmeter / u.meter)
+    r = um.power(scaled, jnp.array([1.0, 2.0]))
+    assert_quantity(r, jnp.array([2000.0, 9000000.0]))

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -323,7 +323,7 @@ def _fun_keep_unit_sequence(
 @set_module_as('saiunit.math')
 def concatenate(
     arrays: Union[Sequence[ArrayLike], Sequence[Quantity]],
-    axis: Optional[int] = None,
+    axis: Optional[int] = 0,
     dtype: Optional[DTypeLike] = None,
     **kwargs,
 ) -> Union[Array, Quantity]:
@@ -337,6 +337,7 @@ def concatenate(
       to `axis` (the first, by default).
     axis : int, optional
       The axis along which the arrays will be joined.  Default is 0.
+      If ``None``, the arrays are flattened before being concatenated.
     dtype : dtype, optional
       If provided, the concatenation will be done using this dtype. Otherwise, the
       array with the highest precision will be used.
@@ -356,8 +357,14 @@ def concatenate(
       >>> b = [3, 4] * u.second
       >>> u.math.concatenate([a, b])
     """
-    if axis is not None:
-        kwargs["axis"] = axis
+    if len(arrays) == 0:
+        raise ValueError('need at least one array to concatenate')
+    if axis is None:
+        # numpy/jax semantics: ``axis=None`` flattens every input before
+        # concatenating them along axis 0.
+        arrays = [_maybe_flatten(a) for a in arrays]
+        axis = 0
+    kwargs["axis"] = axis
     if dtype is not None:
         kwargs["dtype"] = dtype
     return _fun_keep_unit_sequence('concatenate', arrays, **kwargs)
@@ -1291,6 +1298,25 @@ def repeat(
       >>> a = [1, 2, 3] * u.second
       >>> u.math.repeat(a, 2)
     """
+    if total_repeat_length is not None:
+        a = maybe_custom_array(a)
+        mantissa = a.mantissa if isinstance(a, Quantity) else a
+        xp = get_backend(mantissa)
+        if xp is not jnp:
+            # Backends other than JAX don't accept ``total_repeat_length``
+            # (it would be silently dropped). Emulate ``jnp.repeat``:
+            # truncate when too long, pad with the final element when short.
+            r = _dispatch_call(
+                _resolve_op('repeat', xp), (mantissa, repeats),
+                _strip_none_kwargs(dict(axis=axis, **kwargs)),
+            )
+            gather_axis = 0 if axis is None else axis
+            length = r.shape[gather_axis]
+            indices = xp.clip(xp.arange(total_repeat_length), 0, length - 1)
+            r = _resolve_op('take', xp)(r, indices, axis=gather_axis)
+            if isinstance(a, Quantity):
+                return Quantity(r, unit=a.unit)
+            return r
     return _fun_keep_unit_unary('repeat', a, repeats, axis=axis, total_repeat_length=total_repeat_length, **kwargs)
 
 
@@ -1547,7 +1573,7 @@ def max(
     a: Union[Array, Quantity],
     axis: Optional[int] = None,
     keepdims: bool = False,
-    initial: Optional[Union[int, float, Quantity]] = None,
+    initial: Union[ArrayLike, Quantity, None] = None,
     where: Optional[Array] = None,
     **kwargs,
 ) -> Union[Array, Quantity]:
@@ -1584,6 +1610,8 @@ def max(
       >>> a = [1, 2, 3] * u.meter
       >>> u.math.max(a)
     """
+    if initial is not None:
+        initial = Quantity(initial).in_unit(get_unit(a)).mantissa
     return _fun_keep_unit_unary(
         'max', a, axis=axis, keepdims=keepdims,
         initial=initial, where=where, **kwargs,
@@ -1595,7 +1623,7 @@ def min(
     a: Union[Array, Quantity],
     axis: Optional[int] = None,
     keepdims: bool = False,
-    initial: Optional[Union[int, float, Quantity]] = None,
+    initial: Union[ArrayLike, Quantity, None] = None,
     where: Optional[Array] = None,
     **kwargs,
 ) -> Union[Array, Quantity]:
@@ -1632,6 +1660,8 @@ def min(
       >>> a = [1, 2, 3] * u.meter
       >>> u.math.min(a)
     """
+    if initial is not None:
+        initial = Quantity(initial).in_unit(get_unit(a)).mantissa
     return _fun_keep_unit_unary(
         'min', a, axis=axis, keepdims=keepdims,
         initial=initial, where=where, **kwargs,
@@ -1807,9 +1837,11 @@ def unflatten(
       >>> a = [1, 2, 3, 4, 5, 6] * u.meter
       >>> u.math.unflatten(a, 0, (2, 3))
     """
-    if x.ndim <= axis:
+    if axis < 0:
+        axis += x.ndim
+    if axis < 0 or axis >= x.ndim:
         raise ValueError(
-            f'unflatten requires "axis" to be less than x.ndim, '
+            f'unflatten requires "axis" to be a valid dimension of x, '
             f'but got axis={axis} and x.ndim={x.ndim}.'
         )
     shape = x.shape
@@ -1824,12 +1856,12 @@ def remove_diag(x: ArrayLike | Quantity, **kwargs) -> Array | Quantity:
     Parameters
     ----------
     x: Array, Quantity
-      The matrix with the shape of `(M, N)`.
+      The square matrix with the shape of `(N, N)`.
 
     Returns
     -------
     arr: Array, Quantity
-      The matrix without diagonal which has the shape of `(M, N-1)`.
+      The matrix without diagonal which has the shape of `(N, N-1)`.
 
     Examples
     --------
@@ -1847,6 +1879,11 @@ def remove_diag(x: ArrayLike | Quantity, **kwargs) -> Array | Quantity:
 
     if x.ndim != 2:
         raise ValueError(f'Only support 2D matrix, while we got a {x.ndim}D array.')
+    if x.shape[0] != x.shape[1]:
+        raise ValueError(
+            f'remove_diag only supports a square matrix of shape (N, N), '
+            f'while we got shape {x.shape}.'
+        )
     xp = get_backend(x)
     mask = ~xp.eye(x.shape[0], x.shape[1], dtype=bool)
     masked = x[mask]  # type: ignore[index]
@@ -1899,7 +1936,24 @@ def choose(
       >>> choices = [jnp.array([1, 2, 3]), jnp.array([4, 5, 6])]
       >>> u.math.choose(jnp.array([0, 1, 0]), choices)
     """
-    return _fun_keep_unit_unary('choose', a, choices=choices, mode=mode, **kwargs)
+    # The result's unit comes from ``choices``; the index must be unitless.
+    a = maybe_custom_array(a)
+    if isinstance(a, Quantity):
+        if not a.unit.is_unitless:
+            raise TypeError(
+                f'choose requires "a" to be a plain integer index array, '
+                f'but got a Quantity with unit={a.unit}. '
+                f'Strip the unit from the index before passing it to choose.'
+            )
+        index = a.mantissa
+    else:
+        index = a
+    leaves = unit_scale_align_to_first(*maybe_custom_array_tree(list(choices)))
+    unit = leaves[0].unit
+    mantissas = [c.mantissa for c in leaves]
+    xp = get_backend(index, *mantissas)
+    r = _dispatch_call(_resolve_op('choose', xp), (index, mantissas), dict(mode=mode, **kwargs))
+    return maybe_decimal(Quantity(r, unit=unit))
 
 
 @set_module_as('saiunit.math')
@@ -2700,11 +2754,11 @@ def ptp(
 def average(
     x: Union[Quantity, ArrayLike],
     axis: Union[int, Sequence[int], None] = None,
-    weights: Union[ArrayLike, None] = None,
+    weights: Union[ArrayLike, Quantity, None] = None,
     returned: bool = False,
     keepdims: bool = False,
     **kwargs,
-) -> Union[Quantity, Array]:
+) -> Union[Quantity, Array, Tuple[Union[Quantity, Array], Array]]:
     """
     Return the weighted average of the array elements.
 
@@ -2756,6 +2810,25 @@ def average(
       >>> a = [1.0, 2.0, 3.0] * u.second
       >>> u.math.average(a)
     """
+    if isinstance(weights, Quantity):
+        # The weights' unit cancels between the numerator and denominator
+        # of a weighted average; only the mantissa matters.
+        weights = weights.mantissa
+    if returned:
+        # ``returned=True`` makes the backend return ``(average, sum_of_weights)``.
+        # Routing that tuple through ``_fun_keep_unit_unary`` would stamp the
+        # data unit onto both elements; dispatch on the mantissa and wrap
+        # only the average.
+        x = maybe_custom_array(x)
+        call_kwargs = _strip_none_kwargs(
+            dict(axis=axis, weights=weights, returned=True, keepdims=keepdims, **kwargs)
+        )
+        if isinstance(x, Quantity):
+            xp = get_backend(x.mantissa)
+            avg, sum_of_weights = _dispatch_call(_resolve_op('average', xp), (x.mantissa,), call_kwargs)
+            return Quantity(avg, unit=x.unit), sum_of_weights
+        xp = get_backend(x)
+        return _dispatch_call(_resolve_op('average', xp), (x,), call_kwargs)
     return _fun_keep_unit_unary('average', x, axis=axis, weights=weights, returned=returned, keepdims=keepdims, **kwargs)
 
 
@@ -3205,8 +3278,15 @@ def intersect1d(
     unit = UNITLESS
     if isinstance(ar1, Quantity):
         unit = ar1.unit
-    ar1 = ar1.in_unit(unit).mantissa if isinstance(ar1, Quantity) else ar1
-    ar2 = ar2.in_unit(unit).mantissa if isinstance(ar2, Quantity) else ar2
+        ar1 = ar1.in_unit(unit).mantissa
+    if isinstance(ar2, Quantity):
+        ar2 = ar2.in_unit(unit).mantissa
+    elif not unit.is_unitless:
+        # ``ar1`` carries a scaled unit while ``ar2`` is a plain array; a
+        # scaled-dimensionless unit (e.g. mV/volt) passes the dimension
+        # check above but the plain side still needs the scale applied
+        # before the mantissas are compared.
+        ar2 = Quantity(ar2).in_unit(unit).mantissa
     xp = get_backend(ar1, ar2)
     result = _resolve_op('intersect1d', xp)(ar1, ar2, assume_unique=assume_unique, return_indices=return_indices, **kwargs)
     if return_indices:
@@ -3300,6 +3380,12 @@ def nan_to_num(
         r = _call(x.mantissa, xp)
         return r if x_unit.is_unitless else Quantity(r, unit=x_unit)
     else:
+        for name, val in (('nan', nan), ('posinf', posinf), ('neginf', neginf)):
+            if isinstance(val, Quantity):
+                raise TypeError(
+                    f'nan_to_num requires "{name}" to be dimensionless when x is a '
+                    f'plain array, but got a Quantity with unit={val.unit}.'
+                )
         nan_v = 0.0 if nan is None else nan
         posinf_v = posinf
         neginf_v = neginf
@@ -4181,12 +4267,14 @@ def interp(
     """
     x_unit = get_unit(x)
     fp, y_unit = split_mantissa_unit(fp)
+    # ``left`` / ``right`` are y-values, so they convert with fp's unit;
+    # ``period`` applies to the x-coordinates and keeps the x unit.
     x, xp, fp, left, right, period = (
         x.mantissa if isinstance(x, Quantity) else x,
         Quantity(xp).in_unit(x_unit).mantissa,
         fp,
-        Quantity(left).in_unit(x_unit).mantissa if left is not None else left,
-        Quantity(right).in_unit(x_unit).mantissa if right is not None else right,
+        Quantity(left).in_unit(y_unit).mantissa if left is not None else left,
+        Quantity(right).in_unit(y_unit).mantissa if right is not None else right,
         Quantity(period).in_unit(x_unit).mantissa if period is not None else period
     )
     backend = get_backend(x, xp, fp)
@@ -4237,9 +4325,9 @@ def clip(
 @set_module_as('saiunit.math')
 def histogram(
     x: Union[Array, Quantity],
-    bins: ArrayLike = 10,  # type: ignore[assignment]
+    bins: ArrayLike | Quantity = 10,  # type: ignore[assignment]
     range: Optional[Sequence[ArrayLike | Quantity]] = None,
-    weights: Optional[ArrayLike] = None,
+    weights: Optional[ArrayLike | Quantity] = None,
     density: Optional[bool] = None,
     **kwargs,
 ) -> Tuple[Array, Array | Quantity]:
@@ -4300,6 +4388,10 @@ def histogram(
     if isinstance(x, Quantity):
         unit = x.unit
         x = x.mantissa  # type: ignore[assignment]
+    if isinstance(bins, Quantity):
+        bins = bins.in_unit(unit).mantissa
+    if isinstance(weights, Quantity):
+        weights = weights.mantissa
     if range is not None:
         range = (
             Quantity(range[0]).in_unit(unit).mantissa,
@@ -4559,7 +4651,7 @@ def take(
 def select(
     condlist: list[Union[ArrayLike]],
     choicelist: Union[Quantity, ArrayLike],
-    default: int = 0,
+    default: Union[Quantity, ArrayLike, int, float] = 0,
     **kwargs,
 ) -> Union[Quantity, Array]:
     """
@@ -4606,6 +4698,17 @@ def select(
     leaves, treedef = tree.flatten(choicelist, is_leaf=lambda x: isinstance(x, Quantity))
     leaves = unit_scale_align_to_first(*leaves)
     unit = leaves[0].unit
+    if isinstance(default, Quantity):
+        default = default.in_unit(unit).mantissa
+    elif not unit.is_unitless:
+        # ``0`` is jnp.select's documented default and is unit-neutral; any
+        # other plain default would silently acquire the choicelist's unit.
+        if not (isinstance(default, (int, float)) and default == 0):
+            raise TypeError(
+                f'select requires "default" to carry the same unit as "choicelist" '
+                f'(unit={unit}) when the choices are Quantities; a plain default '
+                f'of 0 is allowed. Got default={default!r}.'
+            )
     mantissas = [x.mantissa for x in leaves]
     xp = get_backend(*mantissas)
     new_choicelist = treedef.unflatten(mantissas)  # type: ignore[attr-defined]
@@ -5100,15 +5203,13 @@ def gather(input: Array | Quantity, dim: int, index: Array, **kwargs):
             # Use the provided index for the gather dimension
             indices.append(index)
         else:
-            # Create meshgrid indices for other dimensions
+            # Create meshgrid indices for other dimensions, ranging over the
+            # extent of ``index`` (which may be smaller than ``input``).
             shape = [1] * ndim
-            shape[i] = idx_shape[i] if i < len(idx_shape) else input.shape[i]
-            idx = xp.arange(input.shape[i], **kwargs).reshape(shape)
+            shape[i] = idx_shape[i]
+            idx = xp.arange(idx_shape[i]).reshape(shape)
             # Broadcast to match index shape
-            broadcast_shape = list(idx_shape)
-            if i < len(idx_shape):
-                broadcast_shape[i] = input.shape[i]
-            indices.append(xp.broadcast_to(idx, idx_shape, **kwargs))
+            indices.append(xp.broadcast_to(idx, idx_shape))
 
     result = input[tuple(indices)]
     if unit.is_unitless:

--- a/saiunit/math/_fun_keep_unit_test.py
+++ b/saiunit/math/_fun_keep_unit_test.py
@@ -728,9 +728,15 @@ class TestFunKeepUnitArrayManipulation(parameterized.TestCase):
         result = u.math.choose(jnp.array([0, 1, 2]), choices)
         self.assertTrue(jnp.all(result == jnp.choose(jnp.array([0, 1, 2]), choices)))
 
+        # the unit lives on the choices, not on the index; a dimensioned
+        # Quantity index is rejected
         q = [0, 1, 2] * u.second
         q = q.astype(jnp.int64)
-        result_q = u.math.choose(q, choices)
+        with pytest.raises(TypeError):
+            u.math.choose(q, choices)
+
+        q_choices = [c * u.second for c in choices]
+        result_q = u.math.choose(jnp.array([0, 1, 2]), q_choices)
         expected_q = jnp.choose(jnp.array([0, 1, 2]), choices)
         assert_quantity(result_q, expected_q, u.second)
 
@@ -1284,3 +1290,262 @@ def test_promote_dtypes_common_type_and_unit():
     # Values are unchanged.
     assert jnp.allclose(out[0].mantissa, jnp.array([1.0, 2.0, 3.0]))
     assert jnp.allclose(out[1].mantissa, jnp.array([4.0, 5.0, 6.0]))
+
+
+# ---------------------------------------------------------------
+# Regression tests (math audit)
+# ---------------------------------------------------------------
+
+
+def test_unit_scale_align_to_first_unitless_first_rescales():
+    # A scaled-dimensionless Quantity following a plain first item must be
+    # rescaled onto the (unitless) first unit, not passed through raw.
+    aligned = u.unit_scale_align_to_first(jnp.array([1., 2.]), jnp.array([1., 2.]) * (u.mV / u.volt))
+    assert jnp.allclose(aligned[1].mantissa, jnp.array([0.001, 0.002]))
+
+    r = u.math.concatenate([jnp.array([1., 2.]), jnp.array([1., 2.]) * (u.mV / u.volt)])
+    assert not isinstance(r, u.Quantity)
+    assert jnp.allclose(r, jnp.array([1., 2., 0.001, 0.002]))
+
+    r = u.math.stack([jnp.array([1., 2.]), jnp.array([1., 2.]) * (u.mV / u.volt)])
+    assert not isinstance(r, u.Quantity)
+    assert jnp.allclose(r, jnp.array([[1., 2.], [0.001, 0.002]]))
+
+    # a dimensioned later item still raises
+    with pytest.raises(u.UnitMismatchError):
+        u.unit_scale_align_to_first(jnp.array([1., 2.]), jnp.array([1., 2.]) * u.meter)
+
+
+def test_unit_scale_align_to_first_all_plain_unchanged():
+    aligned = u.unit_scale_align_to_first(jnp.array([1, 2]), jnp.array([3, 4]))
+    assert all(isinstance(q, u.Quantity) for q in aligned)
+    assert jnp.array_equal(aligned[1].mantissa, jnp.array([3, 4]))
+    # consumers still unwrap plain inputs to plain arrays
+    r = u.math.concatenate([jnp.array([1, 2]), jnp.array([3, 4])])
+    assert not isinstance(r, u.Quantity)
+    assert jnp.array_equal(r, jnp.array([1, 2, 3, 4]))
+
+
+def test_choose_quantity_choices():
+    index = jnp.array([0, 1, 0])
+    choices = [jnp.array([1., 2., 3.]) * u.meter, jnp.array([4., 5., 6.]) * u.meter]
+    result = u.math.choose(index, choices)
+    assert isinstance(result, u.Quantity)
+    assert_quantity(result, jnp.array([1., 5., 3.]), u.meter)
+
+
+def test_choose_dimensioned_index_raises():
+    choices = [jnp.array([1., 2., 3.]), jnp.array([4., 5., 6.])]
+    with pytest.raises(TypeError, match='choose'):
+        u.math.choose(jnp.array([0, 1, 0]) * u.meter, choices)
+
+
+def test_choose_unitless_quantity_index():
+    index = u.Quantity(jnp.array([0, 1, 0]))
+    choices = [jnp.array([1., 2., 3.]) * u.meter, jnp.array([4., 5., 6.]) * u.meter]
+    result = u.math.choose(index, choices)
+    assert_quantity(result, jnp.array([1., 5., 3.]), u.meter)
+
+
+def test_interp_left_right_use_fp_unit():
+    x = jnp.array([0.5, 2.5]) * u.second
+    xs = jnp.array([1., 2.]) * u.second
+    fp = jnp.array([10., 20.]) * u.meter
+    result = u.math.interp(x, xs, fp, left=0 * u.meter, right=30 * u.meter)
+    assert_quantity(result, jnp.array([0., 30.]), u.meter)
+
+
+def test_interp_left_scaled_fp_unit():
+    # x and fp share the dimension at different scales: left must be
+    # converted into fp's unit, not x's.
+    x = jnp.array([0.5]) * u.meter
+    xs = jnp.array([1., 2.]) * u.meter
+    fp = jnp.array([10., 20.]) * u.kmeter
+    result = u.math.interp(x, xs, fp, left=1 * u.kmeter)
+    assert_quantity(result, jnp.array([1.]), u.kmeter)
+
+
+def test_average_returned_tuple():
+    a = jnp.array([1., 2., 3.]) * u.meter
+    avg, wsum = u.math.average(a, weights=jnp.array([1., 1., 2.]), returned=True)
+    assert isinstance(avg, u.Quantity)
+    assert_quantity(avg, 2.25, u.meter)
+    assert not isinstance(wsum, u.Quantity)
+    assert jnp.allclose(wsum, 4.0)
+
+    # 2-D shapes survive
+    a2 = jnp.array([[1., 2.], [3., 4.]]) * u.meter
+    avg2, wsum2 = u.math.average(a2, axis=0, returned=True)
+    assert avg2.shape == (2,)
+    assert wsum2.shape == (2,)
+    assert_quantity(avg2, jnp.array([2., 3.]), u.meter)
+
+    # plain input stays plain
+    avg3, wsum3 = u.math.average(jnp.array([1., 2., 3.]), returned=True)
+    assert not isinstance(avg3, u.Quantity)
+    assert jnp.allclose(avg3, 2.0)
+    assert jnp.allclose(wsum3, 3.0)
+
+
+def test_average_quantity_weights():
+    a = jnp.array([1., 2., 3.]) * u.meter
+    result = u.math.average(a, weights=u.Quantity(jnp.array([1., 1., 2.])))
+    assert_quantity(result, 2.25, u.meter)
+    # the weights' unit cancels in a weighted average
+    result = u.math.average(a, weights=jnp.array([1., 1., 2.]) * u.second)
+    assert_quantity(result, 2.25, u.meter)
+
+
+def test_max_min_quantity_initial():
+    a = jnp.array([1., 2.]) * u.meter
+    assert_quantity(u.math.max(a, initial=5 * u.meter), 5.0, u.meter)
+    assert_quantity(u.math.min(a, initial=0 * u.meter), 0.0, u.meter)
+    # plain data + plain initial still works
+    r = u.math.max(jnp.array([1., 2.]), initial=5.0)
+    assert not isinstance(r, u.Quantity)
+    assert r == 5.0
+
+
+def test_max_min_plain_initial_on_unitful_data_raises():
+    a = jnp.array([1., 2.]) * u.meter
+    with pytest.raises(u.UnitMismatchError):
+        u.math.max(a, initial=5.0)
+    with pytest.raises(u.UnitMismatchError):
+        u.math.min(a, initial=5.0)
+
+
+def test_unflatten_negative_axis():
+    a = jnp.arange(6.) * u.meter
+    result = u.math.unflatten(a, -1, (2, 3))
+    assert result.shape == (2, 3)
+    assert_quantity(result, jnp.arange(6.).reshape(2, 3), u.meter)
+
+    result = u.math.unflatten(jnp.array([5.]) * u.meter, -1, (1, 1))
+    assert result.shape == (1, 1)
+
+
+def test_unflatten_axis_out_of_bounds():
+    a = jnp.arange(6.) * u.meter
+    with pytest.raises(ValueError):
+        u.math.unflatten(a, 1, (2, 3))
+    with pytest.raises(ValueError):
+        u.math.unflatten(a, -2, (2, 3))
+
+
+def test_concatenate_axis_none_flattens():
+    a = jnp.array([[1., 2.], [3., 4.]]) * u.meter
+    b = jnp.array([5., 6.]) * u.meter
+    result = u.math.concatenate([a, b], axis=None)
+    expected = jnp.concatenate([jnp.array([[1., 2.], [3., 4.]]), jnp.array([5., 6.])], axis=None)
+    assert_quantity(result, expected, u.meter)
+
+    r = u.math.concatenate([jnp.array([[1, 2], [3, 4]]), jnp.array([5, 6])], axis=None)
+    assert jnp.array_equal(r, jnp.array([1, 2, 3, 4, 5, 6]))
+
+    # the default stays axis=0
+    result = u.math.concatenate([a, a])
+    assert result.shape == (4, 2)
+
+
+def test_concatenate_empty_raises_value_error():
+    with pytest.raises(ValueError, match='at least one array'):
+        u.math.concatenate([])
+
+
+def test_repeat_total_repeat_length_numpy_backend():
+    import numpy as np
+    # truncation, as jnp.repeat does
+    r = u.math.repeat(np.array([1, 2]), 3, total_repeat_length=4)
+    assert r.shape == (4,)
+    assert np.array_equal(r, np.array([1, 1, 1, 2]))
+    # padding with the final element, as jnp.repeat does
+    r = u.math.repeat(np.array([1, 2]), 3, total_repeat_length=8)
+    assert np.array_equal(r, np.array([1, 1, 1, 2, 2, 2, 2, 2]))
+    # along an axis
+    r = u.math.repeat(np.array([[1, 2], [3, 4]]), 2, axis=1, total_repeat_length=3)
+    assert np.array_equal(r, np.array([[1, 1, 2], [3, 3, 4]]))
+    # Quantity input keeps the unit
+    q = u.Quantity(np.array([1., 2.]), unit=meter)
+    rq = u.math.repeat(q, 3, total_repeat_length=4)
+    assert isinstance(rq, u.Quantity)
+    assert rq.unit == meter
+    assert np.array_equal(rq.mantissa, np.array([1., 1., 1., 2.]))
+    # the jax path is unchanged
+    rj = u.math.repeat(jnp.array([1, 2]) * meter, 3, total_repeat_length=4)
+    assert_quantity(rj, jnp.array([1, 1, 1, 2]), meter)
+
+
+def test_select_quantity_default():
+    conds = [jnp.array([True, False, False])]
+    choices = [jnp.array([1., 2., 3.]) * u.mV]
+    result = u.math.select(conds, choices, default=5 * u.mV)
+    assert_quantity(result, jnp.array([1., 5., 5.]), u.mV)
+    # a default in another scale of the same dimension is rescaled
+    result = u.math.select(conds, choices, default=0.005 * u.volt)
+    assert_quantity(result, jnp.array([1., 5., 5.]), u.mV)
+
+
+def test_select_plain_default_with_unitful_choices():
+    conds = [jnp.array([True, False])]
+    choices = [jnp.array([1., 2.]) * u.mV]
+    # a plain non-zero default would silently acquire the choicelist's unit
+    with pytest.raises(TypeError):
+        u.math.select(conds, choices, default=5.0)
+    # plain zero stays allowed (jnp's documented default, unit-neutral)
+    result = u.math.select(conds, choices, default=0)
+    assert_quantity(result, jnp.array([1., 0.]), u.mV)
+
+
+def test_histogram_quantity_bins_and_weights():
+    x = jnp.array([1., 2., 3.]) * u.second
+    hist, edges = u.math.histogram(x, bins=jnp.array([0., 2., 4.]) * u.second)
+    assert jnp.array_equal(hist, jnp.array([1., 2.]))
+    assert isinstance(edges, u.Quantity)
+    assert_quantity(edges, jnp.array([0., 2., 4.]), u.second)
+    # bins in a different scale of the same dimension are rescaled
+    hist, edges = u.math.histogram(x, bins=jnp.array([0., 2000., 4000.]) * u.ms)
+    assert jnp.array_equal(hist, jnp.array([1., 2.]))
+    # Quantity weights are unwrapped
+    hist, _ = u.math.histogram(x, bins=jnp.array([0., 2., 4.]) * u.second,
+                               weights=u.Quantity(jnp.array([1., 1., 2.])))
+    assert jnp.allclose(hist, jnp.array([1., 3.]))
+
+
+def test_gather_index_smaller_than_input():
+    a = jnp.arange(1., 10.).reshape(3, 3) * u.mV
+    index = jnp.array([[0, 1], [2, 0]])
+    result = u.math.gather(a, 1, index)
+    assert isinstance(result, u.Quantity)
+    assert_quantity(result, jnp.array([[1., 2.], [6., 4.]]), u.mV)
+
+    result = u.math.gather(a, 0, index)
+    assert_quantity(result, jnp.array([[1., 5.], [7., 2.]]), u.mV)
+
+
+def test_intersect1d_scaled_dimensionless_vs_plain():
+    q = jnp.array([1., 2., 3.]) * (u.mV / u.volt)   # values 0.001, 0.002, 0.003
+    plain = jnp.array([0.001, 0.002, 5.0])
+    result = u.math.intersect1d(q, plain)
+    assert isinstance(result, u.Quantity)
+    assert jnp.allclose(result.to_decimal(u.mV / u.volt), jnp.array([1., 2.]))
+    # symmetric: plain first
+    result2 = u.math.intersect1d(plain, q)
+    assert not isinstance(result2, u.Quantity)
+    assert jnp.allclose(result2, jnp.array([0.001, 0.002]))
+
+
+def test_remove_diag_non_square_raises():
+    with pytest.raises(ValueError, match='square'):
+        u.math.remove_diag(jnp.arange(6.).reshape(3, 2) * u.second)
+    with pytest.raises(ValueError, match='square'):
+        u.math.remove_diag(jnp.arange(6.).reshape(2, 3))
+
+
+def test_nan_to_num_plain_array_quantity_replacement_raises():
+    x = jnp.array([1.0, jnp.nan])
+    with pytest.raises(TypeError, match='nan_to_num'):
+        u.math.nan_to_num(x, nan=1 * u.meter)
+    with pytest.raises(TypeError, match='nan_to_num'):
+        u.math.nan_to_num(x, posinf=1 * u.meter)
+    with pytest.raises(TypeError, match='nan_to_num'):
+        u.math.nan_to_num(x, neginf=1 * u.meter)

--- a/saiunit/math/_fun_remove_unit.py
+++ b/saiunit/math/_fun_remove_unit.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 from __future__ import annotations
 
+import functools
 from typing import (Union, Optional, Sequence)
 
 import numpy as np
@@ -24,6 +25,7 @@ from saiunit._typing import Array, ArrayLike
 from saiunit._backend import get_backend
 from saiunit._base_getters import get_unit
 from saiunit._base_quantity import Quantity
+from saiunit._base_unit import UNITLESS
 from ._fun_keep_unit import _resolve_op, _strip_none_kwargs, _dispatch_call
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
 
@@ -83,7 +85,12 @@ def get_promote_dtypes(
     # dtype-like inputs (unlike ``np.promote_types`` which is binary).
     leaves, _ = tree.flatten(args)
     if HAS_JAX:
-        return jnp.promote_types(*leaves, **kwargs)  # type: ignore[return-value]
+        # ``jnp.promote_types`` is binary; reduce over the leaves so any
+        # number of inputs works (it is preferred over ``jnp.result_type``
+        # because it does not canonicalize dtypes under x64-disabled mode).
+        if len(leaves) == 1:
+            return jnp.promote_types(leaves[0], leaves[0])  # type: ignore[return-value]
+        return functools.reduce(jnp.promote_types, leaves)  # type: ignore[return-value]
     return np.result_type(*leaves, **kwargs)  # type: ignore[return-value]
 
 
@@ -917,13 +924,11 @@ def isclose(
                 f'Either pass a Quantity for x with matching units, or strip the unit from y.'
             )
         y = y.mantissa
-    if rtol is None:
-        rtol = 1e-5 * unit
-    if atol is None:
-        atol = 1e-8 * unit
-    atol = Quantity(atol).in_unit(unit).mantissa  # type: ignore[assignment]
-    rtol = Quantity(rtol).in_unit(unit).mantissa  # type: ignore[assignment]
-    return _fun_logic_binary('isclose', x, y, rtol=rtol, atol=atol, equal_nan=equal_nan, **kwargs)
+    # rtol multiplies |y| so it is mathematically dimensionless; atol is
+    # compared against the data and therefore carries the data's unit.
+    rtol_val = 1e-5 if rtol is None else Quantity(rtol).in_unit(UNITLESS).mantissa
+    atol_val = 1e-8 if atol is None else Quantity(atol).in_unit(unit).mantissa
+    return _fun_logic_binary('isclose', x, y, rtol=rtol_val, atol=atol_val, equal_nan=equal_nan, **kwargs)
 
 
 @set_module_as('saiunit.math')
@@ -1004,14 +1009,12 @@ def allclose(
     else:
         x_val = x
         y_val = y
-    if rtol is None:
-        rtol = 1e-5 * unit
-    if atol is None:
-        atol = 1e-8 * unit
-    rtol = Quantity(rtol).in_unit(unit).mantissa  # type: ignore[assignment]
-    atol = Quantity(atol).in_unit(unit).mantissa  # type: ignore[assignment]
+    # rtol multiplies |y| so it is mathematically dimensionless; atol is
+    # compared against the data and therefore carries the data's unit.
+    rtol_val = 1e-5 if rtol is None else Quantity(rtol).in_unit(UNITLESS).mantissa
+    atol_val = 1e-8 if atol is None else Quantity(atol).in_unit(unit).mantissa
     xp = get_backend(x_val, y_val)
-    return xp.allclose(x_val, y_val, rtol=rtol, atol=atol, equal_nan=equal_nan, **kwargs)  # type: ignore[arg-type]
+    return xp.allclose(x_val, y_val, rtol=rtol_val, atol=atol_val, equal_nan=equal_nan, **kwargs)  # type: ignore[arg-type]
 
 
 @set_module_as('saiunit.math')
@@ -1482,15 +1485,18 @@ def flatnonzero(
         >>> u.math.flatnonzero(jnp.array([0, 1, 0, 2]), size=2)
         Array([1, 3], dtype=int32)
     """
-    a = maybe_custom_array(a)
     fill_value = maybe_custom_array(fill_value)
-    a_unit = get_unit(a)
+    if isinstance(fill_value, Quantity):
+        raise TypeError(
+            f'flatnonzero returns an index array, so "fill_value" must be a plain '
+            f'(unitless) value, but got a Quantity with unit={fill_value.unit}.'
+        )
     # ``size`` and ``fill_value`` are JAX-only; suppress them when on NumPy.
     extra = {}
     if size is not None:
         extra['size'] = size
     if fill_value is not None:
-        extra['fill_value'] = Quantity(fill_value).in_unit(a_unit).mantissa  # type: ignore[assignment]
+        extra['fill_value'] = fill_value  # type: ignore[assignment]
     return _fun_remove_unit_unary('flatnonzero', a, **extra, **kwargs)
 
 

--- a/saiunit/math/_fun_remove_unit_test.py
+++ b/saiunit/math/_fun_remove_unit_test.py
@@ -597,17 +597,55 @@ class Test_allclose(unittest.TestCase):
 
         a = val * u.mV
         b = val * u.mV
+        # atol carries the data's dimension: plain or mismatched units raise
         with pytest.raises(u.UnitMismatchError):
             assert u.math.allclose(a, b, atol=1e-3)
         with pytest.raises(u.UnitMismatchError):
             assert u.math.allclose(a, b, atol=1e-3 * u.ms)
         assert u.math.allclose(a, b, atol=1e-3 * u.mV)
 
-        with pytest.raises(u.UnitMismatchError):
-            assert u.math.allclose(a, b, rtol=1e-8)
+        # rtol is dimensionless: plain floats and dimensionless Quantities
+        # work, unitful rtol raises regardless of the data's unit
+        assert u.math.allclose(a, b, rtol=1e-8)
+        assert u.math.allclose(a, b, rtol=u.Quantity(1e-8))
         with pytest.raises(u.UnitMismatchError):
             assert u.math.allclose(a, b, rtol=1e-8 * u.ms)
-        assert u.math.allclose(a, b, rtol=1e-8 * u.mV)
+        with pytest.raises(u.UnitMismatchError):
+            assert u.math.allclose(a, b, rtol=1e-8 * u.mV)
+
+    def test_rtol_dimensionless(self):
+        x = jnp.array([1.0, 2.0]) * u.volt
+        y = x * 1.005
+        # plain float rtol works on unitful data
+        assert u.math.allclose(x, y, rtol=1e-2)
+        assert not u.math.allclose(x, y, rtol=1e-3)
+        assert u.math.isclose(x, y, rtol=1e-2).all()
+        # dimensionless Quantity rtol works
+        assert u.math.allclose(x, y, rtol=u.Quantity(1e-2))
+        # unitful rtol is rejected
+        with pytest.raises(u.UnitMismatchError):
+            u.math.allclose(x, y, rtol=2e-4 * u.mV)
+        with pytest.raises(u.UnitMismatchError):
+            u.math.isclose(x, y, rtol=2e-4 * u.mV)
+
+    def test_rtol_scale_invariance(self):
+        # identical physical data must give identical results regardless of
+        # the display unit
+        x_v = jnp.array([1.0, 2.0]) * u.volt
+        y_v = x_v * 1.005
+        x_mv = x_v.in_unit(u.mV)
+        y_mv = y_v.in_unit(u.mV)
+        assert bool(u.math.allclose(x_v, y_v, rtol=1e-2)) == bool(u.math.allclose(x_mv, y_mv, rtol=1e-2))
+        assert bool(u.math.allclose(x_v, y_v, rtol=1e-3)) == bool(u.math.allclose(x_mv, y_mv, rtol=1e-3))
+        assert jnp.array_equal(u.math.isclose(x_v, y_v, rtol=1e-2),
+                               u.math.isclose(x_mv, y_mv, rtol=1e-2))
+
+    def test_atol_compatible_unit_rescales(self):
+        x = jnp.array([1.0, 2.0]) * u.meter
+        y = x + 1e-3 * u.meter
+        assert u.math.allclose(x, y, rtol=0.0, atol=2 * u.mmeter)
+        assert not u.math.allclose(x, y, rtol=0.0, atol=0.5 * u.mmeter)
+        assert u.math.isclose(x, y, rtol=0.0, atol=2 * u.mmeter).all()
 
 
 # =========================================================================
@@ -737,6 +775,17 @@ def test_flatnonzero_numpy_backend_default_kwargs():
     assert np.array_equal(r, np.array([1, 3]))
 
 
+def test_flatnonzero_fill_value_is_unitless_index():
+    """Regression: fill_value pads the returned index array, so it must be
+    a plain (unitless) value even when the input carries a unit."""
+    q = jnp.array([0.0, 1.0, 0.0, 2.0]) * u.meter
+    r = u.math.flatnonzero(q, size=4, fill_value=0)
+    assert jnp.array_equal(r, jnp.array([1, 3, 0, 0]))
+    # an index cannot carry a unit
+    with pytest.raises(TypeError):
+        u.math.flatnonzero(q, size=4, fill_value=2 * u.meter)
+
+
 def test_nonzero_numpy_backend_default_kwargs():
     """Regression: nonzero must not forward JAX-only kwargs to NumPy."""
     import numpy as np
@@ -746,6 +795,15 @@ def test_nonzero_numpy_backend_default_kwargs():
     r = u.math.nonzero(q)
     assert isinstance(r, tuple)
     assert np.array_equal(r[0], np.array([1, 3]))
+
+
+def test_get_promote_dtypes_variadic():
+    """Regression: get_promote_dtypes must accept one or three-plus args,
+    not just exactly two."""
+    import numpy as np
+    assert bm.get_promote_dtypes(jnp.float32, jnp.int32) == np.dtype('float32')
+    assert bm.get_promote_dtypes(jnp.float32) == np.dtype('float32')
+    assert bm.get_promote_dtypes(jnp.float32, jnp.int32, jnp.float64) == np.dtype('float64')
 
 
 def test_iscomplexobj_matches_jnp():

--- a/saiunit/math/_misc.py
+++ b/saiunit/math/_misc.py
@@ -491,6 +491,10 @@ def finfo(a: Union[Quantity, ArrayLike]) -> jnp.finfo:
     a = maybe_custom_array(a)
     if isinstance(a, Quantity):
         return jnp.finfo(a.mantissa)
+    elif isinstance(a, (int, float, complex)) and not hasattr(a, 'dtype'):
+        # ``ml_dtypes.finfo`` rejects raw Python scalars: resolve the dtype
+        # first (this respects the JAX x64 configuration).
+        return jnp.finfo(jnp.result_type(a))
     else:
         return jnp.finfo(a)
 
@@ -500,6 +504,10 @@ def iinfo(a: Union[Quantity, ArrayLike]) -> jnp.iinfo:
     a = maybe_custom_array(a)
     if isinstance(a, Quantity):
         return jnp.iinfo(a.mantissa)
+    elif isinstance(a, (int, float, complex)) and not hasattr(a, 'dtype'):
+        # ``ml_dtypes.iinfo`` rejects raw Python scalars: resolve the dtype
+        # first (this respects the JAX x64 configuration).
+        return jnp.iinfo(jnp.result_type(a))
     else:
         return jnp.iinfo(a)
 
@@ -532,7 +540,7 @@ def broadcast_shapes(*shapes):
 environ = None  # type: ignore[assignment]
 
 
-@set_module_as('brainstate.math')
+@set_module_as('saiunit.math')
 def get_dtype(a):
     """Get the dtype of an array, ``Quantity``, or Python scalar.
 
@@ -562,23 +570,25 @@ def get_dtype(a):
         global environ
         if isinstance(a, bool):
             return bool
-        elif isinstance(a, int):
+        elif isinstance(a, (int, float, complex)):
             if environ is None:
-                from brainstate import environ  # type: ignore[import-untyped]
-            return environ.ditype()
-        elif isinstance(a, float):
-            if environ is None:
-                from brainstate import environ
-            return environ.dftype()
-        elif isinstance(a, complex):
-            if environ is None:
-                from brainstate import environ
-            return environ.dctype()
+                try:
+                    from brainstate import environ  # type: ignore[import-untyped]
+                except ImportError:
+                    # ``brainstate`` is an optional dependency: fall back to
+                    # JAX's default scalar promotion (respects the x64 config).
+                    return jnp.asarray(a).dtype
+            if isinstance(a, int):
+                return environ.ditype()
+            elif isinstance(a, float):
+                return environ.dftype()
+            else:
+                return environ.dctype()
         else:
             raise ValueError(f'Can not get dtype of {a}.')
 
 
-@set_module_as('brainstate.math')
+@set_module_as('saiunit.math')
 def is_float(array):
     """Check if the array has a floating-point dtype.
 
@@ -607,7 +617,7 @@ def is_float(array):
     return jnp.issubdtype(get_dtype(array), jnp.floating)
 
 
-@set_module_as('brainstate.math')
+@set_module_as('saiunit.math')
 def is_int(array):
     """Check if the array has an integer dtype.
 
@@ -706,10 +716,16 @@ def gradient(
     xp = get_backend(f_mantissa, *varargs_mantissa)
 
     if len(varargs) == 0:
+        grad = xp.gradient(f_mantissa, axis=axis)  # type: ignore[arg-type]
         if isinstance(f, Quantity) and not is_unitless(f):
-            return Quantity(xp.gradient(f.mantissa, axis=axis), unit=f.unit)
-        else:
-            return xp.gradient(f)  # type: ignore[arg-type]
+            # ``xp.gradient`` returns a single array for a scalar ``axis``
+            # (or a 1-D input) and a list of per-axis arrays otherwise.
+            # Preserve that contract instead of stacking the list into one
+            # Quantity of shape (ndim, ...).
+            if isinstance(grad, (list, tuple)):
+                return [Quantity(g, unit=f.unit) for g in grad]
+            return Quantity(grad, unit=f.unit)
+        return grad
     elif len(varargs) == 1:
         unit = get_unit(f) / get_unit(varargs[0])
         grad = xp.gradient(f_mantissa, varargs_mantissa[0], axis=axis)  # type: ignore[arg-type]
@@ -725,7 +741,10 @@ def gradient(
     else:
         unit_list = [get_unit(f) / get_unit(v) for v in varargs]
         result_list = xp.gradient(f_mantissa, *varargs_mantissa, axis=axis)  # type: ignore[arg-type]
-        return [(Quantity(r, unit=unit) if unit is not None else r) for r, unit in zip(result_list, unit_list)]
+        return [
+            (r if isinstance(unit, Unit) and unit.is_unitless else Quantity(r, unit=unit))
+            for r, unit in zip(result_list, unit_list)
+        ]
 
 
 # window funcs

--- a/saiunit/math/_misc_test.py
+++ b/saiunit/math/_misc_test.py
@@ -285,6 +285,13 @@ def test_finfo_iinfo_with_quantities_and_dtypes():
     assert u.math.iinfo(jnp.int16).dtype == jnp.iinfo(jnp.int16).dtype
 
 
+def test_finfo_iinfo_with_python_scalars():
+    # Python scalars must be accepted by resolving their dtype first
+    # (ml_dtypes' finfo/iinfo reject raw Python scalars).
+    assert u.math.finfo(1.0).dtype == jnp.asarray(1.0).dtype
+    assert u.math.iinfo(1).dtype == jnp.asarray(1).dtype
+
+
 def test_broadcast_shapes_and_result_type_issubdtype():
     assert u.math.broadcast_shapes((2, 1), (1, 3)) == (2, 3)
     assert u.math.issubdtype(jnp.float32, jnp.floating)
@@ -314,6 +321,34 @@ def test_get_dtype_and_is_float_is_int():
         # assert u.math.get_dtype(3 + 0j) == brainstate.environ.dctype()
 
 
+def test_get_dtype_without_brainstate():
+    # brainstate is a dev-only dependency: get_dtype/is_float/is_int must
+    # handle Python scalars without it. Run in a subprocess with the
+    # brainstate import halted so this test process is not poisoned.
+    import subprocess
+    import sys
+    code = '\n'.join([
+        "import sys",
+        "sys.modules['brainstate'] = None  # halt any 'import brainstate'",
+        "import jax.numpy as jnp",
+        "import saiunit as u",
+        "assert u.math.get_dtype(True) is bool",
+        "assert u.math.get_dtype(3) == jnp.asarray(3).dtype",
+        "assert u.math.get_dtype(3.0) == jnp.asarray(3.0).dtype",
+        "assert u.math.get_dtype(1 + 2j) == jnp.asarray(1 + 2j).dtype",
+        "assert u.math.is_float(3.0)",
+        "assert u.math.is_int(3)",
+    ])
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_get_dtype_is_float_is_int_module_is_saiunit_math():
+    assert u.math.get_dtype.__module__ == 'saiunit.math'
+    assert u.math.is_float.__module__ == 'saiunit.math'
+    assert u.math.is_int.__module__ == 'saiunit.math'
+
+
 def test_gradient_quantity_no_spacing_returns_quantity():
     f = jnp.array([0.0, 1.0, 4.0, 9.0], dtype=jnp.float32) * meter
     g = u.math.gradient(f)
@@ -340,6 +375,58 @@ def test_gradient_with_unit_spacing_and_multi_axis():
     assert isinstance(gy, u.Quantity) and isinstance(gx, u.Quantity)
     assert_quantity(gy, jnp.gradient(f.mantissa, dy.mantissa, axis=0), unit=meter / second)
     assert_quantity(gx, jnp.gradient(f.mantissa, dx.mantissa, axis=1), unit=meter / second)
+
+
+def test_gradient_plain_array_respects_axis():
+    # `axis` must be forwarded for plain arrays: a scalar axis yields a single
+    # array (not a list of gradients along ALL axes), a tuple yields a list.
+    f = jnp.arange(12.0, dtype=jnp.float32).reshape(3, 4)
+    g0 = u.math.gradient(f, axis=0)
+    assert not isinstance(g0, (list, tuple)), f"expected a single array, got {type(g0).__name__}"
+    np.testing.assert_allclose(g0, jnp.gradient(f, axis=0))
+    g01 = u.math.gradient(f, axis=(0, 1))
+    assert isinstance(g01, list) and len(g01) == 2
+    for got, expected in zip(g01, jnp.gradient(f, axis=(0, 1))):
+        np.testing.assert_allclose(got, expected)
+
+
+def test_gradient_unitless_quantity_no_spacing():
+    # a unitless Quantity must not be passed raw to the backend
+    f = u.Quantity(jnp.array([1.0, 2.0, 4.0], dtype=jnp.float32))
+    g = u.math.gradient(f)
+    assert not isinstance(g, u.Quantity)
+    np.testing.assert_allclose(g, jnp.gradient(f.mantissa))
+
+
+def test_gradient_multidim_quantity_no_spacing_returns_list():
+    # numpy/jax return one array per axis: the unitful branch must return a
+    # LIST of Quantities, not a single stacked Quantity of shape (ndim, ...).
+    f = jnp.arange(12.0, dtype=jnp.float32).reshape(3, 4) * meter
+    grads = u.math.gradient(f)
+    assert isinstance(grads, list) and len(grads) == 2
+    for got, expected in zip(grads, jnp.gradient(f.mantissa)):
+        assert isinstance(got, u.Quantity)
+        assert_quantity(got, expected, unit=meter)
+    # a scalar axis yields a single Quantity
+    g0 = u.math.gradient(f, axis=0)
+    assert isinstance(g0, u.Quantity)
+    assert_quantity(g0, jnp.gradient(f.mantissa, axis=0), unit=meter)
+
+
+def test_gradient_multi_vararg_unitless_returns_raw_arrays():
+    # fully-unitless results must be raw arrays, not Quantity(unit="1"),
+    # so they remain consumable by plain jnp functions.
+    f = jnp.arange(12.0, dtype=jnp.float32).reshape(3, 4)
+    gy, gx = u.math.gradient(f, 0.5, 2.0)
+    assert not isinstance(gy, u.Quantity) and not isinstance(gx, u.Quantity)
+    np.testing.assert_allclose(gy, jnp.gradient(f, 0.5, 2.0)[0])
+    np.testing.assert_allclose(gx, jnp.gradient(f, 0.5, 2.0)[1])
+    jnp.sum(gy)  # must not raise
+    # mixed spacings: only the unitful one yields a Quantity
+    gy, gx = u.math.gradient(f, 0.5 * second, 2.0)
+    assert isinstance(gy, u.Quantity)
+    assert_quantity(gy, jnp.gradient(f, 0.5, 2.0)[0], unit=second ** -1)
+    assert not isinstance(gx, u.Quantity)
 
 
 def test_gradient_edge_order_not_supported():


### PR DESCRIPTION
## Summary

A full audit of `saiunit.math` (every public function across `_fun_keep_unit`, `_fun_change_unit`, `_fun_accept_unitless`, `_fun_remove_unit`, `_fun_array_creation`, `_einops`, `_exprel`, `_activation`, `_misc`) found **48 bugs**, each confirmed with an executed repro. This PR fixes all of them, each with a regression test.

### High severity — silently wrong results or units (15)
- **concatenate/stack/append family**: scaled-dimensionless Quantities (e.g. unit `mV/volt`) lost their 1e-3 factor when the first input was a plain array (`_base_getters.unit_scale_align_to_first`)
- **choose**: took the result unit from the *index* array and crashed on Quantity choices
- **interp**: `left`/`right` were converted with x's unit instead of fp's
- **average(returned=True)**: collapsed `(avg, weight_sum)` into one mislabeled Quantity
- **divmod / floor_divide / `Quantity.__floordiv__`**: floored unaligned mantissas — `1*kmeter // 3*meter` returned `0.0` instead of `333.0`; `divmod(7*m, 2*km)` returned remainder `1 m` instead of `7 m`
- **prod(where=...)**: unit exponent counted masked-out elements (`prod([2,3]*m, where=[T,F])` → `2 m²` instead of `2 m`)
- **ldexp**: dropped the scale factor of scaled-dimensionless inputs
- **isclose/allclose**: plain `rtol` raised; *unitful* rtol produced display-unit-dependent booleans (same physical data: `False` in volt, `True` in mV). rtol is now correctly dimensionless
- **fill_diagonal** (numpy backend): returned `None` and mutated the input despite `inplace=False`
- **empty_like**: silently ignored `shape=` for Quantity prototypes
- **asarray(unit=...)**: silently dropped the requested unit for dimensionless input
- **exprel**: `jax.grad` was catastrophically wrong above the Taylor threshold (`grad(1.2e-4)` → `0.0`, true `0.5`; `grad²` off by 4–5 orders) — the derivative now has its own dtype-aware threshold and Taylor order; f32 sweep max rel err is now 4.2e-6
- **gradient**: ignored `axis=` for plain/unitless inputs
- **einshape**: crashed on `'1'` axes and silently accepted anonymous-axis size mismatches

### Medium — crashes on valid input / wrong structure (24)
`max`/`min` Quantity `initial=`; `unflatten` negative axis; `concatenate(axis=None)` flatten semantics; `repeat(total_repeat_length=)` on the numpy backend; `average` Quantity weights; `select` Quantity default; `histogram` Quantity bins/weights; `gather` with index smaller than input; `intersect1d` scaled-dimensionless vs plain; `power`/`float_power` with Quantity exponents or unitless-Quantity bases; `prod` Quantity `initial`; `ldexp` Quantity exponent + `unit_to_scale` support; `flatnonzero` fill_value (an index, not data); `get_promote_dtypes` with 1 or 3+ args; `asarray([])`; `arange(stop=...)`; `linspace(retstep=True)` with units; `fill_diagonal` unit-stamping on plain arrays; `jit(exprel)` on int/bool; `leaky_relu` on scaled-dimensionless Quantities; `gradient` on unitless/multi-dim Quantities; `get_dtype`/`is_float`/`is_int` without brainstate installed; `einreduce`/`einrearrange` on list input

### Low — error quality, dead config, docs (9)
`set_exprel_order` was a documented no-op (now effective); `exprel` order validation; clear errors for `concatenate([])`, `remove_diag` non-square input, `nan_to_num` unit mismatch; `vander` error message and `N` type; `finfo` on Python scalars; `set_module_as('brainstate.math')` copy-paste; stale `einsum`/`ldexp` docstrings

## Test plan

- ~90 new regression tests, each confirmed failing before its fix (red→green)
- Full suite: `pytest saiunit/` → **3785 passed, 0 failed, 183 skipped**
- `mypy saiunit/` → exit 0