### PR TITLE
fix: resolve 42 audited bugs across saiunit.lax/fft/linalg/sparse APIs

### DIFF
--- a/saiunit/_sparse_base.py
+++ b/saiunit/_sparse_base.py
@@ -33,6 +33,27 @@ __all__ = [
 ]
 
 
+class _HashableIndex:
+    """Wraps an index array so it can live in pytree aux_data (hash/eq by content)."""
+    __slots__ = ('value', '_key')
+
+    def __init__(self, value):
+        self.value = value
+        self._key: Optional[tuple] = None
+
+    def _content_key(self) -> tuple:
+        if self._key is None:
+            arr = np.asarray(self.value)
+            self._key = (arr.shape, str(arr.dtype), arr.tobytes())
+        return self._key
+
+    def __eq__(self, other):
+        return isinstance(other, _HashableIndex) and self._content_key() == other._content_key()
+
+    def __hash__(self):
+        return hash(self._content_key())
+
+
 def _same_sparsity_pattern(a, b) -> bool:
     """Check whether two index arrays describe the same sparsity pattern.
 
@@ -94,6 +115,10 @@ class SparseMatrix:
 
     __hash__ = None  # type: ignore[assignment]
 
+    # Tell numpy to defer binary operations (including ufunc-backed operators
+    # such as ``np.ndarray @ sparse``) to the reflected methods defined here.
+    __array_ufunc__ = None
+
     def __init__(
         self,
         args: tuple[Array, ...],
@@ -130,8 +155,8 @@ class SparseMatrix:
         return self.transpose()
 
     def block_until_ready(self):
-        for arg in self.tree_flatten()[0]:
-            arg.block_until_ready()
+        import jax
+        jax.block_until_ready(self.tree_flatten()[0])
         return self
 
     def tree_flatten(self):

--- a/saiunit/fft/_fft_change_unit.py
+++ b/saiunit/fft/_fft_change_unit.py
@@ -25,7 +25,7 @@ from saiunit._backend import get_backend
 from saiunit._base_dimension import get_or_create_dimension
 from saiunit._base_unit import Unit
 from saiunit._base_quantity import Quantity
-from saiunit._misc import set_module_as
+from saiunit._misc import set_module_as, maybe_custom_array
 from saiunit._unit_common import second
 from saiunit.math._fun_change_unit import _fun_change_unit_unary
 
@@ -457,8 +457,6 @@ def fftn(
     input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u * (second ** n)
-    # TODO: may cause computation overhead?
-    fftn._unit_change_fun = _unit_change_fun
     return _fun_change_unit_unary('fft.fftn',
                                   _unit_change_fun,
                                   a, s=s, axes=axes, norm=norm, **kwargs)
@@ -511,8 +509,6 @@ def rfftn(
     input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u * (second ** n)
-    # TODO: may cause computation overhead?
-    rfftn._unit_change_fun = _unit_change_fun
     return _fun_change_unit_unary('fft.rfftn',
                                   _unit_change_fun,
                                   a, s=s, axes=axes, norm=norm, **kwargs)
@@ -670,8 +666,6 @@ def ifftn(
     input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u / (second ** n)
-    # TODO: may cause computation overhead?
-    ifftn._unit_change_fun = _unit_change_fun
     return _fun_change_unit_unary('fft.ifftn',
                                   _unit_change_fun,
                                   a, s=s, axes=axes, norm=norm, **kwargs)
@@ -726,8 +720,6 @@ def irfftn(
     input_ndim = a.ndim if hasattr(a, 'ndim') else np.asarray(a).ndim
     n = _calculate_fftn_dimension(input_ndim, s=s, axes=axes)
     _unit_change_fun = lambda u: u / (second ** n)
-    # TODO: may cause computation overhead?
-    irfftn._unit_change_fun = _unit_change_fun
     return _fun_change_unit_unary('fft.irfftn',
                                   _unit_change_fun,
                                   a, s=s, axes=axes, norm=norm, **kwargs)
@@ -825,6 +817,10 @@ def fftfreq(
         >>> import saiunit.fft as sufft
         >>> freqs = sufft.fftfreq(4, 1.0 * u.second)
     """
+    d = maybe_custom_array(d)
+    if isinstance(d, Quantity) and d.dim.is_dimensionless:
+        # dimensionless Quantities behave like plain numbers (scale folded in)
+        d = d.to_decimal()
     if isinstance(d, Quantity):
         _validate_time_spacing(d)
         time_scale = _find_closest_scale(d.unit.scale)
@@ -836,7 +832,9 @@ def fftfreq(
             freq_unit = Unit.create(get_or_create_dimension(s=-1),
                                     name=f'10^{freq_unit_scale} hertz',
                                     dispname=f'10^{freq_unit_scale} Hz',
-                                    scale=freq_unit_scale, )
+                                    scale=freq_unit_scale,
+                                    base=d.unit.base,
+                                    factor=1.0 / d.unit.factor)
         d_value = d.to_decimal(time_unit)
         xp = get_backend(d_value)
         extra = _fftfreq_extra_kwargs(xp, dtype)
@@ -885,6 +883,10 @@ def rfftfreq(
         >>> import saiunit.fft as sufft
         >>> freqs = sufft.rfftfreq(4, 1.0 * u.second)
     """
+    d = maybe_custom_array(d)
+    if isinstance(d, Quantity) and d.dim.is_dimensionless:
+        # dimensionless Quantities behave like plain numbers (scale folded in)
+        d = d.to_decimal()
     if isinstance(d, Quantity):
         _validate_time_spacing(d)
         time_scale = _find_closest_scale(d.unit.scale)
@@ -896,7 +898,9 @@ def rfftfreq(
             freq_unit = Unit.create(get_or_create_dimension(s=-1),
                                     name=f'10^{freq_unit_scale} hertz',
                                     dispname=f'10^{freq_unit_scale} Hz',
-                                    scale=freq_unit_scale, )
+                                    scale=freq_unit_scale,
+                                    base=d.unit.base,
+                                    factor=1.0 / d.unit.factor)
         d_value = d.to_decimal(time_unit)
         xp = get_backend(d_value)
         extra = _fftfreq_extra_kwargs(xp, dtype)

--- a/saiunit/fft/_fft_change_unit_test.py
+++ b/saiunit/fft/_fft_change_unit_test.py
@@ -158,6 +158,11 @@ class TestFftChangeUnitWithArrayCustomArray(parameterized.TestCase):
         for ufft_fun, jnpfft_fun in zip(ufft_fun_list, jnpfft_fun_list):
             print(f'fun: {ufft_fun.__name__}')
 
+            if ufft_fun.__name__ in ('fftn', 'rfftn'):
+                expected_unit = unit * (second ** len(axes))
+            else:
+                expected_unit = unit / (second ** len(axes))
+
             result = ufft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
             expected = jnpfft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
             assert_quantity(result, expected)
@@ -169,17 +174,17 @@ class TestFftChangeUnitWithArrayCustomArray(parameterized.TestCase):
             q = jnp.array(value) * unit
             result = ufft_fun(q, s=s, axes=axes, norm=norm)
             expected = jnpfft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
-            assert_quantity(result, expected, unit=ufft_fun._unit_change_fun(unit))
+            assert_quantity(result, expected, unit=expected_unit)
 
             array_result = Array(result)
             assert isinstance(array_result, u.CustomArray)
-            assert_quantity(array_result.data, expected, unit=ufft_fun._unit_change_fun(unit))
+            assert_quantity(array_result.data, expected, unit=expected_unit)
 
             array_input = Array(q)
             result = ufft_fun(array_input.data, s=s, axes=axes, norm=norm)
             array_result = Array(result)
             assert isinstance(array_result, u.CustomArray)
-            assert_quantity(array_result.data, expected, unit=ufft_fun._unit_change_fun(unit))
+            assert_quantity(array_result.data, expected, unit=expected_unit)
 
     @parameterized.product(
         size=[9, 10, 101, 102],
@@ -318,7 +323,7 @@ class TestFftChangeUnitWithArrayCustomArray(parameterized.TestCase):
         
         # Compare with direct computation
         direct_result = ufft.fftn(data, axes=(0, 1))
-        assert_quantity(result_array.data, direct_result.mantissa, unit=ufft.fftn._unit_change_fun(second))
+        assert_quantity(result_array.data, direct_result.mantissa, unit=second * (second ** 2))
 
 
 class TestFftChangeUnit(parameterized.TestCase):
@@ -437,6 +442,11 @@ class TestFftChangeUnit(parameterized.TestCase):
         for ufft_fun, jnpfft_fun in zip(ufft_fun_list, jnpfft_fun_list):
             print(f'fun: {ufft_fun.__name__}')
 
+            if ufft_fun.__name__ in ('fftn', 'rfftn'):
+                expected_unit = unit * (second ** len(axes))
+            else:
+                expected_unit = unit / (second ** len(axes))
+
             result = ufft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
             expected = jnpfft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
             assert_quantity(result, expected)
@@ -444,7 +454,7 @@ class TestFftChangeUnit(parameterized.TestCase):
             q = value * unit
             result = ufft_fun(q, s=s, axes=axes, norm=norm)
             expected = ufft_fun(jnp.array(value), s=s, axes=axes, norm=norm)
-            assert_quantity(result, expected, unit=ufft_fun._unit_change_fun(unit))
+            assert_quantity(result, expected, unit=expected_unit)
 
     @parameterized.product(
         size=[9, 10, 101, 102],
@@ -540,3 +550,72 @@ def test_fft_numpy_backend():
     # fft of unitless returns either a raw numpy ndarray or a Quantity on the numpy backend
     arr = r.mantissa if hasattr(r, "mantissa") else r
     assert isinstance(arr, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests
+# ---------------------------------------------------------------------------
+
+def test_fft_unknown_kwarg_raises_typeerror():
+    """Unknown kwargs must raise instead of being silently dropped."""
+    x2d = jnp.array([[1.0, 2.0], [3.0, 4.0]]) * meter
+    # 'axes' is not an fft kwarg ('axis' is) -- silently dropping it would
+    # transform the default axis instead of the requested one.
+    with pytest.raises(TypeError, match='axes'):
+        ufft.fft(x2d, axes=0)
+    x = jnp.array([1.0, 2.0, 3.0, 4.0]) * meter
+    # typo of 'norm' must not be silently ignored
+    with pytest.raises(TypeError, match='nrm'):
+        ufft.fft(x, nrm='ortho')
+    # valid kwargs still work
+    result = ufft.fft(x, n=4, axis=-1, norm='ortho')
+    expected = jnpfft.fft(jnp.array([1.0, 2.0, 3.0, 4.0]), n=4, axis=-1, norm='ortho')
+    assert_quantity(result, expected, unit=meter * second)
+
+
+def test_fftfreq_out_of_range_scale_keeps_factor():
+    """fftfreq/rfftfreq must keep d's unit factor in the fallback branch."""
+    import numpy as np
+    tdim = get_or_create_dimension(s=1)
+    ub = Unit.create(tdim, "u30f6", "u30f6", scale=30, factor=6.0)  # 1 ub = 6e30 s
+    q = ufft.fftfreq(4, 1.0 * ub)
+    assert np.isclose(float(q[1].to_decimal(u.hertz)), 1 / (4 * 6e30), rtol=1e-6, atol=0.0)
+    q = ufft.rfftfreq(4, 1.0 * ub)
+    assert np.isclose(float(q[1].to_decimal(u.hertz)), 1 / (4 * 6e30), rtol=1e-6, atol=0.0)
+
+
+def test_fftfreq_accepts_custom_array_d():
+    """A CustomArray wrapping a time Quantity must behave like the Quantity."""
+    d = 0.5 * second
+    expected = ufft.fftfreq(8, d)
+    result = ufft.fftfreq(8, Array(d))
+    assert isinstance(result, u.Quantity)
+    assert result.unit == expected.unit
+    assert jnp.allclose(result.mantissa, expected.mantissa)
+
+    expected = ufft.rfftfreq(8, d)
+    result = ufft.rfftfreq(8, Array(d))
+    assert isinstance(result, u.Quantity)
+    assert result.unit == expected.unit
+    assert jnp.allclose(result.mantissa, expected.mantissa)
+
+
+def test_fftn_funcs_do_not_mutate_unit_change_fun():
+    """Calling the n-d transforms must not attach per-call state to the function."""
+    x = jnp.ones((2, 4)) * meter
+    for fn in (ufft.fftn, ufft.rfftn, ufft.ifftn, ufft.irfftn):
+        fn(x)
+        assert not hasattr(fn, '_unit_change_fun')
+
+
+def test_fftfreq_dimensionless_quantity_d():
+    """A dimensionless Quantity d behaves like a plain number."""
+    expected = ufft.fftfreq(4, 0.5)
+    result = ufft.fftfreq(4, u.Quantity(0.5))
+    assert not isinstance(result, u.Quantity)
+    assert jnp.array_equal(result, expected)
+
+    expected = ufft.rfftfreq(4, 0.5)
+    result = ufft.rfftfreq(4, u.Quantity(0.5))
+    assert not isinstance(result, u.Quantity)
+    assert jnp.array_equal(result, expected)

--- a/saiunit/lax/_lax_accept_unitless.py
+++ b/saiunit/lax/_lax_accept_unitless.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 from typing import Union, Optional, Callable, Sequence
 
 import jax
+import jax.numpy as jnp
 from jax import lax
 
 from saiunit._base_unit import Unit
+from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
-from saiunit._misc import set_module_as
+from saiunit._misc import set_module_as, maybe_custom_array
 from saiunit.math._fun_accept_unitless import _fun_accept_unitless_unary, _fun_accept_unitless_binary, _fun_unitless_binary
 from saiunit._typing import Array, ArrayLike
 
@@ -47,9 +49,6 @@ __all__ = [
 
     # fft
     'fft',
-
-    # misc
-    'collapse',
 ]
 
 
@@ -212,7 +211,7 @@ def collapse(
     stop_dimension: Optional[int] = None,
     unit_to_scale: Optional[Unit] = None,
     **kwargs,
-) -> Array:
+) -> Union[Quantity, Array]:
     """Collapses dimensions of an array into a single dimension.
 
     For example, if ``operand`` is an array with shape ``[2, 3, 4]``,
@@ -220,23 +219,41 @@ def collapse(
     dimension are laid out major-to-minor, i.e., with the lowest-numbered
     dimension as the slowest varying dimension.
 
+    Since collapsing is a pure reshape, the unit of a ``Quantity`` input is
+    preserved by default.
+
     Args:
-        x: an input array.
+        x: an input array or Quantity.
         start_dimension: the start of the dimensions to collapse (inclusive).
         stop_dimension: the end of the dimensions to collapse (exclusive). Pass None
           to collapse all the dimensions after start.
-        unit_to_scale: the unit to scale the input to. If None, the input should be
-            dimensionless.
+        unit_to_scale: if provided, a ``Quantity`` input is converted to this unit
+            and the result is returned as a plain array (legacy behavior). If None,
+            the unit of ``x`` is preserved.
 
     Returns:
-        An array where dimensions ``[start_dimension, stop_dimension)`` have been
-        collapsed (raveled) into a single dimension.
+        An array (or Quantity with the unit of ``x``) where dimensions
+        ``[start_dimension, stop_dimension)`` have been collapsed (raveled) into a
+        single dimension.
     """
-    return _fun_accept_unitless_unary(lax.collapse,
-                                      x,
-                                      start_dimension=start_dimension,
-                                      stop_dimension=stop_dimension,
-                                      unit_to_scale=unit_to_scale, **kwargs)
+    x = maybe_custom_array(x)
+    if isinstance(x, Quantity):
+        if unit_to_scale is not None:
+            if not isinstance(unit_to_scale, Unit):
+                raise TypeError(f'unit_to_scale should be a Unit instance. Got {unit_to_scale}')
+            return lax.collapse(jnp.asarray(x.to_decimal(unit_to_scale)),
+                                start_dimension, stop_dimension, **kwargs)
+        return maybe_decimal(
+            Quantity(lax.collapse(jnp.asarray(x.mantissa), start_dimension, stop_dimension, **kwargs),
+                     unit=x.unit)
+        )
+    if unit_to_scale is not None:
+        raise TypeError(
+            f'collapse received "unit_to_scale" but input "x" is not a Quantity '
+            f'(got type {type(x).__name__}). '
+            f'Remove "unit_to_scale" or pass a Quantity input.'
+        )
+    return lax.collapse(jnp.asarray(x), start_dimension, stop_dimension, **kwargs)
 
 
 @set_module_as('saiunit.lax')
@@ -692,6 +709,11 @@ def _fun_accept_unitless_nary(
 ):
     if not isinstance(quantity_num, int):
         raise TypeError(f'quantity_num should be an integer. Got {quantity_num}')
+    if unit_to_scale is not None and not any(isinstance(arg, Quantity) for arg in args):
+        raise TypeError(
+            f'{func.__name__} received "unit_to_scale" but none of the inputs is a Quantity. '
+            f'Remove "unit_to_scale" or pass a Quantity input.'
+        )
     new_args = []
     for arg in args:
         if isinstance(arg, Quantity):

--- a/saiunit/lax/_lax_accept_unitless_test.py
+++ b/saiunit/lax/_lax_accept_unitless_test.py
@@ -187,8 +187,10 @@ class TestLaxAcceptUnitless(parameterized.TestCase):
         expected = lax_fun(q1.to_decimal(u.dametre), value2)
         assert_quantity(result, expected)
 
-        with pytest.raises(TypeError):
-            result = bulax_fun(q1, value2)
+        # collapse is a pure reshape: without unit_to_scale the unit is kept.
+        result = bulax_fun(q1, value2)
+        expected = lax_fun(jnp.asarray(value1, dtype=q1.dtype), value2)
+        assert_quantity(result, expected, unit=meter)
 
         with pytest.raises(u.UnitMismatchError):
             result = bulax_fun(q1, value2, unit_to_scale=u.second)
@@ -224,5 +226,50 @@ class TestLaxAcceptUnitlessDocstringExamples:
     def test_betainc_unitless(self):
         """Docstring example: betainc on unitless arrays."""
         result = bulax.betainc(jnp.array([1.0]), jnp.array([1.0]), jnp.array([0.5]))
+        expected = lax.betainc(jnp.array([1.0]), jnp.array([1.0]), jnp.array([0.5]))
+        assert_quantity(result, expected)
+
+
+class TestLaxAcceptUnitlessRegressions:
+    """Regression tests for audited bugs in accept-unitless lax functions."""
+
+    def test_all_has_no_duplicate_collapse(self):
+        # LXB-8: 'collapse' was listed twice in __all__.
+        import saiunit.lax
+        assert saiunit.lax.__all__.count('collapse') == 1
+
+    def test_collapse_preserves_unit(self):
+        # LXB-9: collapse is a pure reshape and must keep the unit.
+        q = jnp.ones((2, 3, 4)) * u.mV
+        result = bulax.collapse(q, 0, 2)
+        assert isinstance(result, u.Quantity)
+        expected = lax.collapse(jnp.ones((2, 3, 4)), 0, 2)
+        assert result.shape == (6, 4)
+        assert_quantity(result, expected, unit=u.mV)
+
+    def test_collapse_unit_to_scale_returns_plain(self):
+        # LXB-9: the legacy unit_to_scale escape hatch still returns a plain array.
+        q = jnp.ones((2, 3, 4)) * u.mV
+        result = bulax.collapse(q, 0, 2, unit_to_scale=u.mV)
+        assert not isinstance(result, u.Quantity)
+        expected = lax.collapse(jnp.ones((2, 3, 4)), 0, 2)
+        assert_quantity(result, expected)
+
+    def test_collapse_plain_input_stays_plain(self):
+        x = jnp.ones((2, 3, 4))
+        result = bulax.collapse(x, 0, 2)
+        assert not isinstance(result, u.Quantity)
+        assert_quantity(result, lax.collapse(x, 0, 2))
+
+    def test_betainc_unit_to_scale_without_quantity_raises(self):
+        # LXB-10: unit_to_scale with all-plain inputs must raise, not be ignored.
+        with pytest.raises(TypeError):
+            bulax.betainc(jnp.array([1.0]), jnp.array([1.0]), jnp.array([0.5]),
+                          unit_to_scale=u.mV)
+
+    def test_betainc_unit_to_scale_with_quantity_still_works(self):
+        # LXB-10: with at least one Quantity input, unit_to_scale keeps working.
+        a = jnp.array([1.0]) * u.mV
+        result = bulax.betainc(a, jnp.array([1.0]), jnp.array([0.5]), unit_to_scale=u.mV)
         expected = lax.betainc(jnp.array([1.0]), jnp.array([1.0]), jnp.array([0.5]))
         assert_quantity(result, expected)

--- a/saiunit/lax/_lax_array_creation.py
+++ b/saiunit/lax/_lax_array_creation.py
@@ -178,15 +178,11 @@ def broadcasted_iota(
         Array([[0., 1., 2.],
                [0., 1., 2.]], dtype=float32)
     """
+    if _sharding is not None:
+        kwargs['out_sharding'] = _sharding
     if unit is not None:
         if not isinstance(unit, Unit):
             raise TypeError('unit must be an instance of Unit.')
-        try:
-            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs) * unit  # type: ignore[arg-type,misc,return-value]
-        except TypeError:
-            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs) * unit  # type: ignore[arg-type,return-value]
+        return lax.broadcasted_iota(dtype, shape, dimension, **kwargs) * unit  # type: ignore[arg-type,return-value]
     else:
-        try:
-            return lax.broadcasted_iota(dtype, shape, dimension, _sharding, **kwargs)  # type: ignore[arg-type,misc]
-        except TypeError:
-            return lax.broadcasted_iota(dtype, shape, dimension, **kwargs)  # type: ignore[arg-type]
+        return lax.broadcasted_iota(dtype, shape, dimension, **kwargs)  # type: ignore[arg-type]

--- a/saiunit/lax/_lax_array_creation_test.py
+++ b/saiunit/lax/_lax_array_creation_test.py
@@ -16,6 +16,7 @@
 
 import jax.lax as lax
 import jax.numpy as jnp
+import pytest
 from absl.testing import parameterized
 
 import saiunit.lax as bulax
@@ -99,3 +100,20 @@ class TestLaxArrayCreationDocstringExamples:
         result = bulax.broadcasted_iota(float, (2, 3), 1, unit=meter)
         expected = lax.broadcasted_iota(float, (2, 3), 1)
         assert_quantity(result, expected, unit=meter)
+
+
+class TestLaxArrayCreationRegressions:
+    """Regression tests for audited bugs in array-creation lax functions."""
+
+    def test_broadcasted_iota_invalid_sharding_raises(self):
+        # LXB-5: an invalid _sharding must propagate the backend error, not be ignored.
+        with pytest.raises(TypeError):
+            bulax.broadcasted_iota(float, (2, 3), 1, _sharding='GARBAGE')
+        with pytest.raises(TypeError):
+            bulax.broadcasted_iota(float, (2, 3), 1, _sharding='GARBAGE', unit=meter)
+
+    def test_broadcasted_iota_default_call_works(self):
+        # LXB-5: the default call (no _sharding) keeps working, with unit attached.
+        result = bulax.broadcasted_iota(float, (2, 3), 1, unit=second)
+        expected = lax.broadcasted_iota(float, (2, 3), 1)
+        assert_quantity(result, expected, unit=second)

--- a/saiunit/lax/_lax_change_unit.py
+++ b/saiunit/lax/_lax_change_unit.py
@@ -19,7 +19,6 @@ from typing import Callable, Union, Sequence
 import jax
 from jax import lax
 
-from saiunit._base_unit import UNITLESS
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
@@ -277,16 +276,12 @@ def dot_general(
         by the ``lhs`` non-contracting/non-batch dimensions, and finally the ``rhs``
         non-contracting/non-batch dimensions.
     """
-    try:
-        return _fun_change_unit_binary(lax.dot_general,
-                                       lambda x, y: x * y,
-                                       x, y,
-                                       dimension_numbers, precision, preferred_element_type, out_type, **kwargs)
-    except TypeError:
-        return _fun_change_unit_binary(lax.dot_general,
-                                       lambda x, y: x * y,
-                                       x, y,
-                                       dimension_numbers, precision, preferred_element_type, **kwargs)
+    if out_type is not None:
+        kwargs['out_sharding'] = out_type
+    return _fun_change_unit_binary(lax.dot_general,
+                                   lambda x, y: x * y,
+                                   x, y,
+                                   dimension_numbers, precision, preferred_element_type, **kwargs)
 
 
 @set_module_as('saiunit.lax')
@@ -336,10 +331,9 @@ def pow(
             y = y.mantissa
         return maybe_decimal(Quantity(jax.lax.pow(x.mantissa, y, **kwargs), unit=x.unit ** y))
     elif isinstance(y, Quantity):
-        if not y.is_unitless:
-            raise TypeError(f'{jax.lax.power.__name__} only supports scalar exponent')  # type: ignore[attr-defined]
-        y = y.mantissa
-        return maybe_decimal(Quantity(jax.lax.pow(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
+        if not y.dim.is_dimensionless:
+            raise TypeError(f'{jax.lax.pow.__name__} requires a dimensionless exponent, but got {y}')
+        return jax.lax.pow(x, y.to_decimal(), **kwargs)
     else:
         return jax.lax.pow(x, y, **kwargs)
 
@@ -391,10 +385,9 @@ def integer_pow(
             y = y.mantissa
         return maybe_decimal(Quantity(jax.lax.integer_pow(x.mantissa, y, **kwargs), unit=x.unit ** y))  # type: ignore[arg-type]
     elif isinstance(y, Quantity):
-        if not y.is_unitless:
-            raise TypeError(f'{jax.lax.integer_power.__name__} only supports scalar exponent')  # type: ignore[attr-defined]
-        y = y.mantissa
-        return maybe_decimal(Quantity(jax.lax.integer_pow(x, y, **kwargs), unit=x ** y))  # type: ignore[arg-type]
+        if not y.dim.is_dimensionless:
+            raise TypeError(f'{jax.lax.integer_pow.__name__} requires a dimensionless exponent, but got {y}')
+        return jax.lax.integer_pow(x, y.to_decimal(), **kwargs)  # type: ignore[arg-type]
     else:
         return jax.lax.integer_pow(x, y, **kwargs)  # type: ignore[arg-type]
 
@@ -461,7 +454,13 @@ def rem(
     elif isinstance(x, Quantity):
         return maybe_decimal(Quantity(lax.rem(x.mantissa, y, **kwargs), unit=x.unit))  # type: ignore[arg-type]
     elif isinstance(y, Quantity):
-        return maybe_decimal(Quantity(lax.rem(x, y.mantissa, **kwargs), unit=UNITLESS))
+        if not y.dim.is_dimensionless:
+            raise TypeError(
+                f'Expected "y" to be dimensionless when "x" is a plain array, '
+                f'but got y with unit={y.unit}. '
+                f'Either pass a Quantity for x with matching units, or strip the unit from y.'
+            )
+        return lax.rem(x, y.to_decimal(), **kwargs)
     else:
         return lax.rem(x, y, **kwargs)
 

--- a/saiunit/lax/_lax_change_unit_test.py
+++ b/saiunit/lax/_lax_change_unit_test.py
@@ -19,6 +19,7 @@ import itertools
 import jax.lax as lax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from absl.testing import parameterized
 
 import saiunit as u
@@ -475,3 +476,60 @@ class TestLaxChangeUnitDocstringExamples:
         result = bulax.pow(q, jnp.float32(2.0))
         expected = lax.pow(jnp.array([2.0, 3.0]), jnp.float32(2.0))
         assert_quantity(result, expected, unit=meter ** 2)
+
+
+class TestLaxChangeUnitRegressions:
+    """Regression tests for audited bugs in change-unit lax functions."""
+
+    def test_pow_plain_base_unitless_quantity_exponent(self):
+        # LXB-1: plain base with a unitless Quantity exponent must return a plain array.
+        result = bulax.pow(jnp.array([2.0, 3.0]), u.Quantity(2.0))
+        assert not isinstance(result, u.Quantity)
+        expected = lax.pow(jnp.array([2.0, 3.0]), 2.0)
+        assert_quantity(result, expected)
+
+    def test_pow_plain_base_dimensioned_exponent_raises(self):
+        # LXB-1: a dimensioned exponent must raise TypeError, not AttributeError.
+        with pytest.raises(TypeError, match='dimensionless'):
+            bulax.pow(jnp.array([2.0]), 3.0 * u.mV)
+
+    def test_integer_pow_plain_base_unitless_quantity_exponent(self):
+        # LXB-2: plain base with a unitless Quantity exponent must return a plain array.
+        result = bulax.integer_pow(jnp.array([2.0, 3.0]), u.Quantity(2))
+        assert not isinstance(result, u.Quantity)
+        expected = lax.integer_pow(jnp.array([2.0, 3.0]), 2)
+        assert_quantity(result, expected)
+
+    def test_integer_pow_plain_base_dimensioned_exponent_raises(self):
+        # LXB-2: a dimensioned exponent must raise TypeError, not AttributeError.
+        with pytest.raises(TypeError, match='dimensionless'):
+            bulax.integer_pow(jnp.array([2.0]), u.Quantity(3, unit=u.mV))
+
+    def test_rem_plain_dividend_dimensioned_divisor_raises(self):
+        # LXB-3: a dimensioned divisor with a plain dividend must raise, not drop the unit.
+        with pytest.raises(TypeError, match='dimensionless'):
+            bulax.rem(jnp.array([5.0]), jnp.array([3.0]) * u.mV)
+
+    def test_rem_plain_dividend_scaled_dimensionless_divisor(self):
+        # LXB-3: a scaled-dimensionless divisor must have its scale folded in.
+        result = bulax.rem(jnp.array([5.0]), u.Quantity(3000.0, unit=u.mV / volt))
+        assert not isinstance(result, u.Quantity)
+        assert_quantity(result, jnp.array([2.0]))
+
+    def test_dot_general_invalid_out_type_raises(self):
+        # LXB-4: an invalid out_type must propagate the backend error, not be ignored.
+        a = jnp.ones((2, 3))
+        b = jnp.ones((3, 4))
+        dn = (((1,), (0,)), ((), ()))
+        with pytest.raises(TypeError):
+            bulax.dot_general(a, b, dn, out_type='GARBAGE')
+
+    def test_dot_general_default_call_works(self):
+        # LXB-4: the default call must keep working for plain and Quantity operands.
+        a = jnp.ones((2, 3))
+        b = jnp.ones((3, 4))
+        dn = (((1,), (0,)), ((), ()))
+        expected = lax.dot_general(a, b, dn)
+        assert_quantity(bulax.dot_general(a, b, dn), expected)
+        result = bulax.dot_general(a * meter, b * volt, dn)
+        assert_quantity(result, expected, unit=meter * volt)

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -26,7 +26,7 @@ from saiunit._typing import Array, ArrayLike, DTypeLike
 # Used purely for type-hint clarity in this module.
 Shape = Sequence[Union[int, Any]]
 
-from saiunit._base_getters import has_same_unit, maybe_decimal
+from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._jax_guard import require_jax_backend
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
@@ -977,21 +977,19 @@ def _fun_lax_scatter(
     dimension_numbers,
     indices_are_sorted,
     unique_indices,
-    mode
+    mode,
+    **kwargs,
 ) -> Union[Quantity, Array]:
     fun_name = getattr(fun, "__name__", "scatter")
     require_jax_backend(f"saiunit.lax.{fun_name}", operand, updates)
     operand = maybe_custom_array(operand)
     updates = maybe_custom_array(updates)
     if isinstance(operand, Quantity) and isinstance(updates, Quantity):
-        if not has_same_unit(operand, updates):
-            raise TypeError(
-                f'operand(unit:{operand.unit}) and updates(unit:{updates.unit}) must have the same unit.'
-            )
+        updates = updates.in_unit(operand.unit)
         return maybe_decimal(Quantity(fun(operand.mantissa, scatter_indices, updates.mantissa, dimension_numbers,
                                           indices_are_sorted=indices_are_sorted,
                                           unique_indices=unique_indices,
-                                          mode=mode), unit=operand.unit))
+                                          mode=mode, **kwargs), unit=operand.unit))
     elif isinstance(operand, Quantity) or isinstance(updates, Quantity):
         raise TypeError(
             f'operand and updates should both be `Quantity` or Array, now we got {type(operand)} and {type(updates)}')
@@ -999,7 +997,7 @@ def _fun_lax_scatter(
         return fun(operand, scatter_indices, updates, dimension_numbers,
                    indices_are_sorted=indices_are_sorted,
                    unique_indices=unique_indices,
-                   mode=mode)
+                   mode=mode, **kwargs)
 
 
 @set_module_as('saiunit.math')
@@ -1231,10 +1229,29 @@ def scatter_mul(
               implementation-defined.
 
     Returns:
-        An array containing the sum of `operand` and the scattered updates.
+        An array containing the product of `operand` and the scattered updates.
     """
-    return _fun_lax_scatter(lax.scatter_mul, operand, scatter_indices, updates, dimension_numbers, indices_are_sorted,
-                            unique_indices, mode, **kwargs)
+    require_jax_backend("saiunit.lax.scatter_mul", operand, updates)
+    operand = maybe_custom_array(operand)
+    updates = maybe_custom_array(updates)
+    # ``new = old * update`` keeps the operand's unit only if the updates are
+    # dimensionless, so dimensioned updates are rejected.
+    if isinstance(updates, Quantity):
+        if not updates.is_unitless:
+            raise TypeError(
+                f'scatter_mul multiplies updates into the operand, so updates must be '
+                f'dimensionless, but got unit {updates.unit}.'
+            )
+        updates = updates.to_decimal()
+    if isinstance(operand, Quantity):
+        return maybe_decimal(Quantity(lax.scatter_mul(operand.mantissa, scatter_indices, updates, dimension_numbers,
+                                                      indices_are_sorted=indices_are_sorted,
+                                                      unique_indices=unique_indices,
+                                                      mode=mode, **kwargs), unit=operand.unit))
+    return lax.scatter_mul(operand, scatter_indices, updates, dimension_numbers,
+                           indices_are_sorted=indices_are_sorted,
+                           unique_indices=unique_indices,
+                           mode=mode, **kwargs)
 
 
 @set_module_as('saiunit.math')
@@ -1594,6 +1611,11 @@ def clamp(
     min = maybe_custom_array(min)
     x = maybe_custom_array(x)
     max = maybe_custom_array(max)
+    # Dimensionless Quantities are equivalent to plain arrays; fold their
+    # scale so they can be mixed freely with plain inputs.
+    min = min.to_decimal() if isinstance(min, Quantity) and min.is_unitless else min
+    x = x.to_decimal() if isinstance(x, Quantity) and x.is_unitless else x
+    max = max.to_decimal() if isinstance(max, Quantity) and max.is_unitless else max
     if all(isinstance(i, Quantity) for i in (min, x, max)):
         unit = min.unit  # type: ignore[union-attr]
         return maybe_decimal(Quantity(lax.clamp(min.mantissa, x.to_decimal(unit), max.to_decimal(unit), **kwargs), unit=unit))  # type: ignore[union-attr]
@@ -1601,7 +1623,8 @@ def clamp(
              (min, x, max)):
         return lax.clamp(min, x, max, **kwargs)  # type: ignore[arg-type]
     else:
-        raise TypeError('All inputs must be Quantity or ArrayLike')
+        raise TypeError('Mixing dimensioned Quantities with plain arrays is not allowed in clamp; '
+                        'min, x and max must either all carry units or all be plain arrays.')
 
 
 # math funcs keep unit (return Quantity and index)

--- a/saiunit/lax/_lax_keep_unit_test.py
+++ b/saiunit/lax/_lax_keep_unit_test.py
@@ -1019,3 +1019,90 @@ def test_lax_entry_raises_on_numpy_quantity(call):
     q = u.Quantity(np.arange(4.0), unit=meter)
     with pytest.raises(u.BackendError, match="requires the jax backend"):
         call(q)
+
+
+# --- Regression tests for audited findings ---
+
+
+def _scatter_1d_dnums():
+    return lax.ScatterDimensionNumbers(
+        update_window_dims=(), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))
+
+
+def test_scatter_mul_plain_updates_on_quantity_operand():
+    """Regression LXA-7: scatter_mul takes dimensionless updates and keeps the operand unit."""
+    values = jnp.array([1.0, 2.0, 3.0])
+    indices = jnp.array([[0], [2]])
+    updates = jnp.array([2.0, 10.0])
+    dnums = _scatter_1d_dnums()
+    expected = lax.scatter_mul(values, indices, updates, dimension_numbers=dnums)
+
+    result = ulax.scatter_mul(values * u.mV, indices, updates, dimension_numbers=dnums)
+    assert_quantity(result, expected, u.mV)
+
+    # Scale-consistent with the volt-equivalent call.
+    result_v = ulax.scatter_mul((values * u.mV).in_unit(u.volt), indices, updates,
+                                dimension_numbers=dnums)
+    assert jnp.allclose(result_v.to_decimal(u.mV), result.to_decimal(u.mV))
+
+
+def test_scatter_mul_unitless_quantity_updates():
+    """Regression LXA-7: dimensionless-Quantity updates are accepted."""
+    values = jnp.array([1.0, 2.0, 3.0])
+    indices = jnp.array([[0], [2]])
+    updates = jnp.array([2.0, 10.0])
+    dnums = _scatter_1d_dnums()
+    expected = lax.scatter_mul(values, indices, updates, dimension_numbers=dnums)
+
+    result = ulax.scatter_mul(values * u.mV, indices, updates * u.UNITLESS,
+                              dimension_numbers=dnums)
+    assert_quantity(result, expected, u.mV)
+
+
+def test_scatter_mul_rejects_dimensioned_updates():
+    """Regression LXA-7: dimensioned updates are dimensionally wrong for scatter_mul."""
+    values = jnp.array([1.0, 2.0, 3.0])
+    indices = jnp.array([[0], [2]])
+    updates = jnp.array([2.0, 10.0])
+    dnums = _scatter_1d_dnums()
+
+    with pytest.raises(TypeError):
+        ulax.scatter_mul(values * u.mV, indices, updates * u.mV, dimension_numbers=dnums)
+
+    with pytest.raises(TypeError):
+        ulax.scatter_mul(values, indices, updates * u.mV, dimension_numbers=dnums)
+
+
+def test_scatter_add_converts_compatible_units():
+    """Regression LXA-8: volt updates are converted into the mV operand's unit."""
+    operand = jnp.array([1.0, 2.0, 3.0]) * u.mV
+    indices = jnp.array([[1]])
+    updates = jnp.array([0.001]) * u.volt
+    dnums = _scatter_1d_dnums()
+
+    result = ulax.scatter_add(operand, indices, updates, dimension_numbers=dnums)
+    assert_quantity(result, jnp.array([1.0, 3.0, 3.0]), u.mV)
+
+
+def test_scatter_add_forwards_kwargs():
+    """Regression LXA-9: kwargs reach the underlying lax.scatter* call."""
+    operand = jnp.array([1.0, 2.0, 3.0]) * u.mV
+    indices = jnp.array([[1]])
+    updates = jnp.array([1.0]) * u.mV
+    dnums = _scatter_1d_dnums()
+
+    result = ulax.scatter_add(operand, indices, updates, dimension_numbers=dnums,
+                              indices_are_sorted=True)
+    assert_quantity(result, jnp.array([1.0, 3.0, 3.0]), u.mV)
+
+    # An unknown kwarg must produce jax's own TypeError, not _fun_lax_scatter's.
+    with pytest.raises(TypeError, match="scatter_add"):
+        ulax.scatter_add(operand, indices, updates, dimension_numbers=dnums,
+                         not_a_real_kwarg=True)
+
+
+def test_clamp_unitless_quantity_with_plain_bounds():
+    """Regression LXA-12: plain bounds with a dimensionless-Quantity operand work."""
+    result = ulax.clamp(0.0, jnp.array([-0.5, 0.5, 3.0]) * u.UNITLESS, 2.0)
+    assert jnp.allclose(result, jnp.array([0.0, 0.5, 2.0]))

--- a/saiunit/lax/_lax_linalg.py
+++ b/saiunit/lax/_lax_linalg.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 from typing import Union, Callable, Any
 
 import jax
+import jax.numpy as jnp
 from jax import lax, Array
 
 from saiunit.lax._lax_change_unit import unit_change
-from saiunit._base_getters import fail_for_unit_mismatch, maybe_decimal
+from saiunit._base_getters import get_unit, maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array, maybe_custom_array_tree
 from saiunit.math._fun_change_unit import _fun_change_unit_unary
@@ -96,7 +97,8 @@ def cholesky(
 def eig(
     x: Union[Quantity, ArrayLike],
     compute_left_eigenvectors: bool = True,
-    compute_right_eigenvectors: bool = True
+    compute_right_eigenvectors: bool = True,
+    **kwargs,
 ) -> tuple[Array | Quantity, Array, Array] | list[Array] | tuple[Array | Quantity, Array] | tuple[Array | Quantity]:
     """Eigendecomposition of a general matrix.
 
@@ -145,36 +147,36 @@ def eig(
     if compute_left_eigenvectors and compute_right_eigenvectors:
         if isinstance(x, Quantity):
             w, vl, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
-                                       compute_right_eigenvectors=compute_right_eigenvectors)
+                                       compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
             return maybe_decimal(Quantity(w, unit=x.unit)), vl, vr
         else:
             return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
-                                  compute_right_eigenvectors=compute_right_eigenvectors)
+                                  compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
     elif compute_left_eigenvectors:
         if isinstance(x, Quantity):
             w, vl = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
-                                   compute_right_eigenvectors=compute_right_eigenvectors)
+                                   compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
             return maybe_decimal(Quantity(w, unit=x.unit)), vl
         else:
             return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
-                                  compute_right_eigenvectors=compute_right_eigenvectors)
+                                  compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
 
     elif compute_right_eigenvectors:
         if isinstance(x, Quantity):
             w, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
-                                   compute_right_eigenvectors=compute_right_eigenvectors)
+                                   compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
             return maybe_decimal(Quantity(w, unit=x.unit)), vr
         else:
             return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
-                                  compute_right_eigenvectors=compute_right_eigenvectors)
+                                  compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
     else:
         if isinstance(x, Quantity):
             (w,) = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
-                                  compute_right_eigenvectors=compute_right_eigenvectors)
+                                  compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
             return (maybe_decimal(Quantity(w, unit=x.unit)),)
         else:
             return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
-                                  compute_right_eigenvectors=compute_right_eigenvectors)
+                                  compute_right_eigenvectors=compute_right_eigenvectors, **kwargs)
 
 
 @set_module_as('saiunit.lax')
@@ -184,6 +186,7 @@ def eigh(
     symmetrize_input: bool = True,
     sort_eigenvalues: bool = True,
     subset_by_index: tuple[int, int] | None = None,
+    **kwargs,
 ) -> tuple[Quantity | Array, Array]:
     r"""Eigendecomposition of a Hermitian matrix.
 
@@ -232,11 +235,11 @@ def eigh(
     x = maybe_custom_array(x)
     if isinstance(x, Quantity):
         v, w = lax.linalg.eigh(x.mantissa, lower=lower, symmetrize_input=symmetrize_input,  # type: ignore[arg-type]
-                               sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index)
+                               sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index, **kwargs)
         return v, maybe_decimal(Quantity(w, unit=x.unit))
     else:
         return lax.linalg.eigh(x, lower=lower, symmetrize_input=symmetrize_input,  # type: ignore[arg-type]
-                               sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index)
+                               sort_eigenvalues=sort_eigenvalues, subset_by_index=subset_by_index, **kwargs)
 
 
 @set_module_as('saiunit.lax')
@@ -394,6 +397,7 @@ def householder_product(
 @set_module_as('saiunit.lax')
 def qdwh(
     x: Union[Quantity, ArrayLike],
+    **kwargs,
 ) -> tuple[Array, Quantity | Array, int, bool]:
     r"""Polar decomposition via QR-based dynamically weighted Halley iteration.
 
@@ -432,16 +436,20 @@ def qdwh(
     """
     x = maybe_custom_array(x)
     if isinstance(x, Quantity):
-        u, h, num_iters, is_converged = lax.linalg.qdwh(x.mantissa)
+        u, h, num_iters, is_converged = lax.linalg.qdwh(x.mantissa, **kwargs)
         return u, maybe_decimal(Quantity(h, unit=x.unit)), num_iters, is_converged
     else:
-        return lax.linalg.qdwh(x)
+        return lax.linalg.qdwh(x, **kwargs)
 
 
 @set_module_as('saiunit.lax')
 def qr(
     x: Union[Quantity, ArrayLike],
-) -> tuple[Array, Quantity | Array]:
+    *,
+    pivoting: bool = False,
+    full_matrices: bool = True,
+    use_magma: bool | None = None,
+) -> tuple[Array, Quantity | Array] | tuple[Array, Quantity | Array, Array]:
     r"""QR decomposition.
 
     Compute the QR decomposition :math:`A = Q \cdot R` where :math:`Q` is
@@ -451,14 +459,28 @@ def qr(
     ----------
     x : array_like or Quantity
         A batch of matrices with shape ``[..., m, n]``.
+    pivoting : bool, optional
+        If ``True``, compute a column-pivoted decomposition
+        :math:`A[:, P] = Q \cdot R` and additionally return the pivot
+        indices ``p``. Default is ``False``.
+    full_matrices : bool, optional
+        If ``True``, compute the full-size ``q`` and ``r``; if ``False``,
+        only the leading ``min(m, n)`` columns of ``q`` are returned.
+        Default is ``True``.
+    use_magma : bool or None, optional
+        Whether to use MAGMA for the pivoted decomposition on GPU.
+        Default is ``None``.
 
     Returns
     -------
     q : Array
-        The unitary factor (unitless) with shape ``[..., m, min(m, n)]``.
+        The unitary factor (unitless).
     r : Array or Quantity
         The upper-triangular factor with shape ``[..., min(m, n), n]``.
         If ``x`` has a unit, ``r`` preserves that unit.
+    p : Array
+        Column pivot indices (plain integers).  Only returned when
+        ``pivoting`` is ``True``.
 
     Examples
     --------
@@ -474,10 +496,13 @@ def qr(
     """
     x = maybe_custom_array(x)
     if isinstance(x, Quantity):
-        q, r = lax.linalg.qr(x.mantissa)
+        q, r, *rest = lax.linalg.qr(x.mantissa, pivoting=pivoting, full_matrices=full_matrices,
+                                    use_magma=use_magma)
+        if pivoting:
+            return q, maybe_decimal(Quantity(r, unit=x.unit)), rest[0]
         return q, maybe_decimal(Quantity(r, unit=x.unit))
     else:
-        return lax.linalg.qr(x)
+        return lax.linalg.qr(x, pivoting=pivoting, full_matrices=full_matrices, use_magma=use_magma)
 
 
 @set_module_as('saiunit.lax')
@@ -486,7 +511,7 @@ def schur(
     compute_schur_vectors: bool = True,
     sort_eig_vals: bool = False,
     select_callable: Callable[..., Any] | None = None
-) -> tuple[Array, Quantity | Array]:
+) -> tuple[Quantity | Array, Array] | list[Array] | tuple[Quantity | Array]:
     r"""Schur decomposition.
 
     Compute the Schur decomposition :math:`A = Q \cdot T \cdot Q^H` where
@@ -507,10 +532,11 @@ def schur(
 
     Returns
     -------
-    t : Array
-        The Schur form (unitless).
-    q : Array or Quantity
-        The Schur vectors.  If ``x`` has a unit, ``q`` preserves that unit.
+    t : Array or Quantity
+        The Schur form.  If ``x`` has a unit, ``t`` preserves that unit.
+    q : Array
+        The Schur vectors (unitless).  Only returned when
+        ``compute_schur_vectors`` is ``True``.
 
     Examples
     --------
@@ -521,14 +547,20 @@ def schur(
         >>> import saiunit.lax as sulax
         >>> A = jnp.array([[1.0, 2.0], [3.0, 4.0]]) * u.second
         >>> t, q = sulax.schur(A)
-        >>> u.get_unit(q) == u.second
+        >>> u.get_unit(t) == u.second
         True
     """
     x = maybe_custom_array(x)
     if isinstance(x, Quantity):
-        t, q = lax.linalg.schur(x.mantissa, compute_schur_vectors=compute_schur_vectors,
-                                sort_eig_vals=sort_eig_vals, select_callable=select_callable)
-        return t, maybe_decimal(Quantity(q, unit=x.unit))
+        if compute_schur_vectors:
+            t, q = lax.linalg.schur(x.mantissa, compute_schur_vectors=compute_schur_vectors,
+                                    sort_eig_vals=sort_eig_vals, select_callable=select_callable)
+            return maybe_decimal(Quantity(t, unit=x.unit)), q
+        else:
+            # jax returns a one-element sequence when the Schur vectors are off.
+            t = lax.linalg.schur(x.mantissa, compute_schur_vectors=compute_schur_vectors,
+                                 sort_eig_vals=sort_eig_vals, select_callable=select_callable)[0]
+            return (maybe_decimal(Quantity(t, unit=x.unit)),)
     else:
         return lax.linalg.schur(x, compute_schur_vectors=compute_schur_vectors,
                                 sort_eig_vals=sort_eig_vals, select_callable=select_callable)
@@ -639,8 +671,9 @@ def triangular_solve(
     Returns
     -------
     X : Array or Quantity
-        The solution with the same shape and dtype as ``b``.  If ``b``
-        carries a unit, ``X`` preserves that unit.
+        The solution with the same shape and dtype as ``b``.  The result
+        unit is ``unit(b) / unit(a)``; the result is a plain array when
+        neither input carries a unit.
 
     Examples
     --------
@@ -657,24 +690,14 @@ def triangular_solve(
     """
     a = maybe_custom_array(a)
     b = maybe_custom_array(b)
-    if isinstance(a, Quantity) and isinstance(b, Quantity):
-        return maybe_decimal(Quantity(lax.linalg.triangular_solve(a.mantissa, b.mantissa, left_side=left_side,
-                                                                  lower=lower, transpose_a=transpose_a,
-                                                                  conjugate_a=conjugate_a,
-                                                                  unit_diagonal=unit_diagonal), unit=b.unit))
-    elif isinstance(a, Quantity):
-        return lax.linalg.triangular_solve(a.mantissa, b, left_side=left_side,  # type: ignore[arg-type]
-                                           lower=lower, transpose_a=transpose_a, conjugate_a=conjugate_a,
-                                           unit_diagonal=unit_diagonal)
-    elif isinstance(b, Quantity):
-        return maybe_decimal(Quantity(lax.linalg.triangular_solve(a, b.mantissa, left_side=left_side,
-                                                                  lower=lower, transpose_a=transpose_a,
-                                                                  conjugate_a=conjugate_a,
-                                                                  unit_diagonal=unit_diagonal), unit=b.unit))
-    else:
-        return lax.linalg.triangular_solve(a, b, left_side=left_side,
-                                           lower=lower, transpose_a=transpose_a, conjugate_a=conjugate_a,
-                                           unit_diagonal=unit_diagonal)
+    a_mantissa = a.mantissa if isinstance(a, Quantity) else a
+    b_mantissa = b.mantissa if isinstance(b, Quantity) else b
+    r = lax.linalg.triangular_solve(a_mantissa, b_mantissa, left_side=left_side,
+                                    lower=lower, transpose_a=transpose_a, conjugate_a=conjugate_a,
+                                    unit_diagonal=unit_diagonal)
+    if isinstance(a, Quantity) or isinstance(b, Quantity):
+        return maybe_decimal(Quantity(r, unit=get_unit(b) / get_unit(a)))
+    return r
 
 
 @set_module_as('saiunit.lax')
@@ -737,6 +760,7 @@ def tridiagonal_solve(
     d: Union[Quantity, ArrayLike],
     du: Union[Quantity, ArrayLike],
     b: Union[Quantity, ArrayLike],
+    **kwargs,
 ) -> Quantity | Array:
     r"""Solve a tridiagonal linear system.
 
@@ -749,27 +773,28 @@ def tridiagonal_solve(
     dl : array_like or Quantity
         Lower diagonal with shape ``[..., m]``.
         ``dl[i] = A[i, i-1]``; ``dl[0]`` is unused.  Must have the same
-        unit as ``d`` and ``du``.
+        dimension as ``d`` and ``du``.
     d : array_like or Quantity
         Main diagonal with shape ``[..., m]``.
         ``d[i] = A[i, i]``.
     du : array_like or Quantity
         Upper diagonal with shape ``[..., m]``.
         ``du[i] = A[i, i+1]``; ``du[m-1]`` is unused.  Must have the same
-        unit as ``dl`` and ``d``.
+        dimension as ``dl`` and ``d``.
     b : array_like or Quantity
         Right-hand-side matrix.
 
     Returns
     -------
     X : Array or Quantity
-        The solution of the tridiagonal system.  If ``b`` has a unit, ``X``
-        preserves that unit.
+        The solution of the tridiagonal system.  The result unit is
+        ``unit(b) / unit(d)``; the result is a plain array when no input
+        carries a unit.
 
     Raises
     ------
-    saiunit.DimensionMismatchError
-        If ``dl``, ``d``, and ``du`` do not share the same unit.
+    saiunit.UnitMismatchError
+        If ``dl``, ``d``, and ``du`` do not share the same dimension.
 
     Examples
     --------
@@ -790,16 +815,15 @@ def tridiagonal_solve(
     d = maybe_custom_array(d)
     du = maybe_custom_array(du)
     b = maybe_custom_array(b)
-    fail_for_unit_mismatch(dl, d)
-    fail_for_unit_mismatch(dl, du)
-    if isinstance(b, Quantity):
-        try:
-            return maybe_decimal(
-                Quantity(lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b.mantissa), unit=b.unit))  # type: ignore[arg-type,union-attr]
-        except:
-            return Quantity(lax.linalg.tridiagonal_solve(dl, d, du, b.mantissa), unit=b.unit)  # type: ignore[arg-type]
-    else:
-        try:
-            return lax.linalg.tridiagonal_solve(dl.mantissa, d.mantissa, du.mantissa, b)  # type: ignore[arg-type,union-attr]
-        except:
-            return lax.linalg.tridiagonal_solve(dl, d, du, b)  # type: ignore[arg-type]
+    # Express both off-diagonals in the main diagonal's unit; ``in_unit``
+    # raises on a true dimension mismatch.
+    ref_unit = get_unit(d)
+    dl_mantissa = dl.in_unit(ref_unit).mantissa if isinstance(dl, Quantity) else dl
+    d_mantissa = d.mantissa if isinstance(d, Quantity) else d
+    du_mantissa = du.in_unit(ref_unit).mantissa if isinstance(du, Quantity) else du
+    b_mantissa = b.mantissa if isinstance(b, Quantity) else b
+    r = lax.linalg.tridiagonal_solve(jnp.asarray(dl_mantissa), jnp.asarray(d_mantissa),
+                                     jnp.asarray(du_mantissa), jnp.asarray(b_mantissa), **kwargs)
+    if any(isinstance(i, Quantity) for i in (dl, d, du, b)):
+        return maybe_decimal(Quantity(r, unit=get_unit(b) / ref_unit))
+    return r

--- a/saiunit/lax/_lax_linalg_test.py
+++ b/saiunit/lax/_lax_linalg_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import jax.numpy as jnp
+import pytest
 from absl.testing import parameterized
 from jax import lax
 
@@ -191,8 +192,8 @@ class TestLaxLinalg(parameterized.TestCase):
 
         x = x * u.second
         t, q = ulax.schur(x)
-        assert_quantity(t, t_e)
-        assert_quantity(q, q_e, u.second)
+        assert_quantity(t, t_e, u.second)
+        assert_quantity(q, q_e)
 
     def test_svd(self):
         x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
@@ -262,10 +263,10 @@ class TestLaxLinalg(parameterized.TestCase):
 
         a = a * u.second
         result_q = ulax.triangular_solve(a, b)
-        assert_quantity(result_q, expected)
+        assert_quantity(result_q, expected, u.second ** -1)
         b = b * u.second
         result_q = ulax.triangular_solve(a, b)
-        assert_quantity(result_q, expected, u.second)
+        assert_quantity(result_q, expected)
 
     def test_tridiagonal_solve(self):
         dl = jnp.array([0.0, 1.0, 1.0])
@@ -343,10 +344,10 @@ def test_docstring_example_qr():
 
 
 def test_docstring_example_schur():
-    """Verify schur docstring: Schur vectors preserve unit."""
+    """Verify schur docstring: the Schur form preserves the input unit."""
     A = jnp.array([[1.0, 2.0], [3.0, 4.0]]) * u.second
     t, q = ulax.schur(A)
-    assert u.get_unit(q) == u.second
+    assert u.get_unit(t) == u.second
 
 
 def test_docstring_example_svd():
@@ -379,3 +380,171 @@ def test_docstring_example_tridiagonal_solve():
     b = jnp.array([[1.0], [2.0], [3.0]]) * u.meter
     X = ulax.tridiagonal_solve(dl, d, du, b)
     assert u.get_unit(X) == u.meter
+
+
+# --- Regression tests for audited findings ---
+
+
+def test_schur_unit_on_t_not_q():
+    """Regression LXA-1: A = Q.T.Q^H, so T carries A's unit and Q is plain."""
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    t_e, q_e = lax.linalg.schur(x)
+
+    t, q = ulax.schur(x * u.second)
+    assert isinstance(t, u.Quantity)
+    assert_quantity(t, t_e, u.second)
+    assert not isinstance(q, u.Quantity)
+    assert_quantity(q, q_e)
+    # Q is orthogonal (unitary), hence dimensionless
+    assert jnp.allclose(q @ q.T, jnp.eye(2), atol=1e-5)
+
+
+def test_schur_no_vectors_quantity():
+    """Regression LXA-2: compute_schur_vectors=False must not crash for Quantity."""
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    (t_e,) = lax.linalg.schur(x, compute_schur_vectors=False)
+
+    (t,) = ulax.schur(x * u.second, compute_schur_vectors=False)
+    assert_quantity(t, t_e, u.second)
+
+
+def test_triangular_solve_unit_ratio():
+    """Regression LXA-3: result unit is unit(b) / unit(a)."""
+    a = jnp.array([[2.0, 0.0], [1.0, 3.0]])
+    b = jnp.array([[4.0], [7.0]])
+    expected = lax.linalg.triangular_solve(a, b, left_side=True, lower=True)
+
+    x = ulax.triangular_solve(a * u.ohm, b * u.volt, left_side=True, lower=True)
+    assert u.get_unit(x).dim == (u.volt / u.ohm).dim
+    assert_quantity(x, expected, u.volt / u.ohm)
+
+    # The same physical system expressed in kohm gives a physically equal result.
+    x_k = ulax.triangular_solve((a * u.ohm).in_unit(u.kohm), b * u.volt,
+                                left_side=True, lower=True)
+    assert jnp.allclose(x_k.to_decimal(u.amp), x.to_decimal(u.amp))
+
+
+def test_triangular_solve_a_only_quantity():
+    """Regression LXA-3: a-only Quantity must not drop the unit."""
+    a = jnp.array([[2.0, 0.0], [1.0, 3.0]])
+    b = jnp.array([[4.0], [7.0]])
+    expected = lax.linalg.triangular_solve(a, b, left_side=True, lower=True)
+
+    x = ulax.triangular_solve(a * u.ohm, b, left_side=True, lower=True)
+    assert isinstance(x, u.Quantity)
+    assert_quantity(x, expected, u.ohm ** -1)
+
+
+def test_tridiagonal_solve_mixed_scale_diagonals():
+    """Regression LXA-4: mV main diagonal with volt off-diagonals must agree with all-volt."""
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]])
+    expected = lax.linalg.tridiagonal_solve(dl, d, du, b)
+
+    x = ulax.tridiagonal_solve(dl * u.volt, (d * u.volt).in_unit(u.mV),
+                               du * u.volt, b * u.meter)
+    assert jnp.allclose(x.to_decimal(u.meter / u.volt), expected, atol=1e-6)
+
+    x_all_volt = ulax.tridiagonal_solve(dl * u.volt, d * u.volt, du * u.volt, b * u.meter)
+    assert jnp.allclose(x_all_volt.to_decimal(u.meter / u.volt), expected, atol=1e-6)
+
+
+def test_tridiagonal_solve_unit_ratio():
+    """Regression LXA-5: result unit is unit(b) / unit(d)."""
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]])
+    expected = lax.linalg.tridiagonal_solve(dl, d, du, b)
+
+    x = ulax.tridiagonal_solve(dl * u.ohm, d * u.ohm, du * u.ohm, b * u.volt)
+    assert u.get_unit(x).dim == (u.volt / u.ohm).dim
+    assert_quantity(x, expected, u.volt / u.ohm)
+
+
+def test_tridiagonal_solve_quantity_diagonals_plain_b():
+    """Regression LXA-5: plain b with Quantity diagonals returns unit 1 / unit(d)."""
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]])
+    expected = lax.linalg.tridiagonal_solve(dl, d, du, b)
+
+    x = ulax.tridiagonal_solve(dl * u.ohm, d * u.ohm, du * u.ohm, b)
+    assert isinstance(x, u.Quantity)
+    assert_quantity(x, expected, u.ohm ** -1)
+
+
+def test_tridiagonal_solve_unitless_quantity_dl():
+    """Regression LXA-6: UNITLESS-Quantity dl with plain d/du must work."""
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]])
+    expected = lax.linalg.tridiagonal_solve(dl, d, du, b)
+
+    x = ulax.tridiagonal_solve(dl * u.UNITLESS, d, du, b)
+    assert_quantity(x, expected)
+
+
+def test_tridiagonal_solve_dimension_mismatch_raises():
+    """Regression LXA-4/6: a true dimension mismatch among diagonals raises."""
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]])
+    with pytest.raises(u.UnitMismatchError):
+        ulax.tridiagonal_solve(dl * u.meter, d * u.volt, du * u.volt, b)
+
+
+def test_qr_full_matrices_false():
+    """Regression LXA-10: full_matrices must be forwarded."""
+    x = jnp.arange(6.0).reshape(3, 2)
+    q_e, r_e = lax.linalg.qr(x, full_matrices=False)
+
+    q, r = ulax.qr(x * u.meter, full_matrices=False)
+    assert q.shape == q_e.shape
+    assert_quantity(q, q_e)
+    assert_quantity(r, r_e, u.meter)
+
+
+def test_qr_pivoting():
+    """Regression LXA-10: pivoting=True returns (q, r, p) with p plain ints."""
+    x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    q_e, r_e, p_e = lax.linalg.qr(x, pivoting=True)
+
+    q, r, p = ulax.qr(x * u.meter, pivoting=True)
+    assert not isinstance(q, u.Quantity)
+    assert not isinstance(p, u.Quantity)
+    assert jnp.issubdtype(p.dtype, jnp.integer)
+    assert_quantity(q, q_e)
+    assert_quantity(r, r_e, u.meter)
+    assert_quantity(p, p_e)
+
+    q2, r2, p2 = ulax.qr(x, pivoting=True)
+    assert_quantity(r2, r_e)
+    assert_quantity(p2, p_e)
+
+
+def test_linalg_kwargs_forwarding():
+    """Regression LXA-11: extra jax kwargs are forwarded by the wrappers."""
+    A = jnp.array([[1.0, 2.0], [3.0, 4.0]]) * u.second
+    H = jnp.array([[2.0, 1.0], [1.0, 3.0]]) * u.second
+
+    u_mat, h, num_iters, is_converged = ulax.qdwh(A, is_hermitian=False)
+    assert u.get_unit(h) == u.second
+
+    w, vl, vr = ulax.eig(A, implementation=None)
+    assert u.get_unit(w) == u.second
+
+    v, w2 = ulax.eigh(H, implementation=None)
+    assert u.get_unit(w2) == u.second
+
+    dl = jnp.array([0.0, 1.0, 1.0])
+    d = jnp.array([2.0, 2.0, 2.0])
+    du = jnp.array([1.0, 1.0, 0.0])
+    b = jnp.array([[1.0], [2.0], [3.0]]) * u.meter
+    x = ulax.tridiagonal_solve(dl, d, du, b, perturb_singular=True)
+    assert u.get_unit(x) == u.meter

--- a/saiunit/lax/_misc.py
+++ b/saiunit/lax/_misc.py
@@ -21,6 +21,7 @@ from jax import lax
 
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
+from saiunit._base_unit import UNITLESS
 from saiunit._misc import set_module_as, maybe_custom_array
 from saiunit._typing import Array, ArrayLike
 
@@ -73,7 +74,12 @@ def reduce(
         :class:`~saiunit.CustomArray`, its ``.data`` attribute is unwrapped.
     init_values : array_like or Quantity
         The initial value(s) for the reduction.  Must be an identity element
-        of ``computation``.  Accepts the same types as ``operands``.
+        of ``computation``.  Accepts the same types as ``operands``.  If a
+        :class:`~saiunit.Quantity`, it is converted into the unit of
+        ``operands`` before its mantissa is extracted (raising
+        :class:`~saiunit.UnitMismatchError` if the dimensions are
+        incompatible, or if ``init_values`` carries a dimension while
+        ``operands`` is a plain array).
     computation : callable
         A binary function used to combine elements (e.g. ``jax.lax.add``).
     dimensions : sequence of int
@@ -131,15 +137,23 @@ def reduce(
     """
     operands = maybe_custom_array(operands)
     init_values = maybe_custom_array(init_values)
+    if isinstance(operands, Quantity):
+        op_unit = operands.unit
+        operands = operands.mantissa
+    else:
+        op_unit = UNITLESS
+    if isinstance(init_values, Quantity):
+        init_values = init_values.in_unit(op_unit).mantissa
     return lax.reduce(operands, init_values, computation, dimensions, **kwargs)
 
 
+@set_module_as('saiunit.lax')
 def reduce_precision(
     operand: Union[ArrayLike, Quantity, float],
     exponent_bits: int,
     mantissa_bits: int,
     **kwargs,
-) -> ArrayLike:
+) -> Union[Quantity, ArrayLike]:
     """Reduce the precision of array elements.
 
     Wraps XLA's `ReducePrecision
@@ -147,15 +161,15 @@ def reduce_precision(
     operator.
 
     When the input is a :class:`~saiunit.Quantity`, the precision reduction
-    is applied to the mantissa and the result is returned as a plain
-    :class:`Array` (the unit is stripped).
+    is applied to the mantissa and the result is a ``Quantity`` with the
+    same unit.
 
     Parameters
     ----------
     operand : array_like, Quantity, or float
         The input values whose precision will be reduced.  If a
         :class:`~saiunit.Quantity`, the precision reduction is applied to its
-        mantissa and the result is a plain array.  If a
+        mantissa and the unit is preserved.  If a
         :class:`~saiunit.CustomArray`, its ``.data`` attribute is unwrapped
         first.
     exponent_bits : int
@@ -165,9 +179,9 @@ def reduce_precision(
 
     Returns
     -------
-    result : Array
-        Array with reduced-precision values.  Unit information from a
-        :class:`~saiunit.Quantity` input is not preserved.
+    result : Array or Quantity
+        Array with reduced-precision values.  A :class:`~saiunit.Quantity`
+        input yields a ``Quantity`` with the same unit.
 
     See Also
     --------
@@ -196,7 +210,7 @@ def reduce_precision(
         >>> sulax.reduce_precision(x, exponent_bits=5, mantissa_bits=10)
         Array([1.123047, 2.123047], dtype=float32)
 
-    Reducing precision of a ``Quantity`` (mantissa is extracted, unit is stripped):
+    Reducing precision of a ``Quantity`` (mantissa is reduced, unit is kept):
 
     .. code-block:: python
 
@@ -204,12 +218,18 @@ def reduce_precision(
         >>> import saiunit.lax as sulax
         >>> import jax.numpy as jnp
         >>> q = jnp.array([1.123456, 2.123456], dtype=jnp.float32) * u.meter
-        >>> sulax.reduce_precision(q, exponent_bits=5, mantissa_bits=10)
+        >>> result = sulax.reduce_precision(q, exponent_bits=5, mantissa_bits=10)
+        >>> result.mantissa
         Array([1.123047, 2.123047], dtype=float32)
+        >>> result.unit
+        meter
     """
     operand = maybe_custom_array(operand)
     if isinstance(operand, Quantity):
-        return maybe_decimal(lax.reduce_precision(operand.mantissa, exponent_bits, mantissa_bits, **kwargs))
+        return maybe_decimal(
+            Quantity(lax.reduce_precision(operand.mantissa, exponent_bits, mantissa_bits, **kwargs),
+                     unit=operand.unit)
+        )
     return lax.reduce_precision(operand, exponent_bits, mantissa_bits, **kwargs)
 
 

--- a/saiunit/lax/_misc_test.py
+++ b/saiunit/lax/_misc_test.py
@@ -16,6 +16,7 @@
 
 import jax.lax as lax
 import jax.numpy as jnp
+import pytest
 from absl.testing import parameterized
 
 import saiunit as u
@@ -165,10 +166,47 @@ def test_docstring_example_reduce_precision():
     expected = lax.reduce_precision(x, exponent_bits=5, mantissa_bits=10)
     assert jnp.allclose(result, expected)
 
-    # Example 2: Quantity input (mantissa extracted, unit stripped)
+    # Example 2: Quantity input (precision reduced on the mantissa, unit kept)
     q = jnp.array([1.123456, 2.123456], dtype=jnp.float32) * u.meter
     result_q = sulax.reduce_precision(q, exponent_bits=5, mantissa_bits=10)
-    assert jnp.allclose(result_q, expected)
+    assert_quantity(result_q, expected, unit=u.meter)
+
+
+# --- Regression tests for audited bugs ---
+
+
+def test_reduce_quantity_init_converted_to_operand_unit():
+    # LXB-6: a Quantity init is converted into the operand's unit before reducing.
+    q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+    result = ulax.reduce(q, jnp.float32(0) * u.volt, lax.add, [0])
+    assert not isinstance(result, u.Quantity)
+    assert float(result) == 6.0
+
+
+def test_reduce_quantity_operand_plain_init():
+    # LXB-6: a dimensioned operand with a plain init must not crash.
+    q = jnp.array([1.0, 2.0, 3.0]) * meter
+    result = ulax.reduce(q, jnp.float32(0), lax.add, [0])
+    assert not isinstance(result, u.Quantity)
+    assert float(result) == 6.0
+
+
+def test_reduce_init_dimension_mismatch_raises():
+    # LXB-6: a dimensioned init incompatible with the operand must raise.
+    q = jnp.array([1.0, 2.0, 3.0]) * u.mV
+    with pytest.raises(u.UnitMismatchError):
+        ulax.reduce(q, jnp.float32(0) * meter, lax.add, [0])
+    with pytest.raises(u.UnitMismatchError):
+        ulax.reduce(jnp.array([1.0, 2.0, 3.0]), jnp.float32(0) * meter, lax.add, [0])
+
+
+def test_reduce_precision_preserves_unit():
+    # LXB-7: reduce_precision is a mantissa-only transformation; the unit survives.
+    q = jnp.array([1.123456, 2.123456], dtype=jnp.float32) * meter
+    result = ulax.reduce_precision(q, exponent_bits=5, mantissa_bits=10)
+    assert isinstance(result, u.Quantity)
+    expected = lax.reduce_precision(jnp.array([1.123456, 2.123456], dtype=jnp.float32), 5, 10)
+    assert_quantity(result, expected, unit=meter)
 
 
 def test_docstring_example_broadcast_shapes():

--- a/saiunit/linalg/_linalg_change_unit.py
+++ b/saiunit/linalg/_linalg_change_unit.py
@@ -114,11 +114,26 @@ def cholesky(
         >>> u.math.allclose(x, L @ L.T)
         Array(True, dtype=bool)
     """
+    a = maybe_custom_array(a)
+    mantissa = a.mantissa if isinstance(a, Quantity) else a
+    xp = get_backend(mantissa)
+    extra: dict = {}
+    if symmetrize_input:
+        # ``np.linalg.cholesky`` (and other array-API backends) lack jax's
+        # ``symmetrize_input`` kwarg, so symmetrize here instead of
+        # forwarding it; jax's own (default) symmetrization is idempotent
+        # on the already-Hermitian result.
+        m = xp.asarray(mantissa)
+        m = (m + xp.conj(xp.matrix_transpose(m))) / 2
+        a = Quantity(m, unit=a.unit) if isinstance(a, Quantity) else m
+    elif xp is jnp:
+        # jax defaults to ``symmetrize_input=True``; forward the opt-out.
+        extra['symmetrize_input'] = False
     return _fun_change_unit_unary('linalg.cholesky',
                                   lambda u: u ** 0.5,
                                   a,
                                   upper=upper,
-                                  symmetrize_input=symmetrize_input, **kwargs)
+                                  **extra, **kwargs)
 
 
 @unit_change(lambda x, y: y / x)
@@ -255,7 +270,7 @@ def lstsq(
     *,
     numpy_resid: bool = False,
     **kwargs,
-) -> tuple[Union[ArrayLike, Quantity], Array, Array, Array]:
+) -> tuple[Union[ArrayLike, Quantity], Union[Array, Quantity], Array, Union[Array, Quantity]]:
     """
     Return the least-squares solution to a linear equation.
 
@@ -285,12 +300,14 @@ def lstsq(
     x : ndarray or Quantity
         Least-squares solution of shape ``(N,)`` or ``(N, K)``. The
         resulting unit is ``b.unit / a.unit``.
-    residuals : ndarray
-        Sum of squared residuals of shape ``()`` or ``(K,)``.
+    residuals : ndarray or Quantity
+        Sum of squared residuals of shape ``()`` or ``(K,)``. Carries
+        ``b.unit ** 2`` when ``b`` is a Quantity.
     rank : ndarray
         Effective rank of ``a``.
-    s : ndarray
-        Singular values of ``a``.
+    s : ndarray or Quantity
+        Singular values of ``a``. Carries ``a.unit`` when ``a`` is a
+        Quantity.
 
     See Also
     --------
@@ -318,12 +335,16 @@ def lstsq(
     extra = {'numpy_resid': numpy_resid} if xp is jnp else {}
     r = xp.linalg.lstsq(a_mantissa, b_mantissa, rcond=rcond, **extra, **kwargs)
     if isinstance(a, Quantity) and isinstance(b, Quantity):
-        return maybe_decimal(Quantity(r[0], unit=b.unit / a.unit)), r[1], r[2], r[3]
-    if isinstance(a, Quantity):
-        return maybe_decimal(Quantity(r[0], unit=UNITLESS / a.unit)), r[1], r[2], r[3]
-    if isinstance(b, Quantity):
-        return maybe_decimal(Quantity(r[0], unit=b.unit)), r[1], r[2], r[3]
-    return r
+        solution = maybe_decimal(Quantity(r[0], unit=b.unit / a.unit))
+    elif isinstance(a, Quantity):
+        solution = maybe_decimal(Quantity(r[0], unit=UNITLESS / a.unit))
+    elif isinstance(b, Quantity):
+        solution = maybe_decimal(Quantity(r[0], unit=b.unit))
+    else:
+        return r
+    residuals = maybe_decimal(Quantity(r[1], unit=b.unit ** 2)) if isinstance(b, Quantity) else r[1]
+    s = maybe_decimal(Quantity(r[3], unit=a.unit)) if isinstance(a, Quantity) else r[3]
+    return solution, residuals, r[2], s
 
 
 @unit_change(lambda u: u ** -1)

--- a/saiunit/linalg/_linalg_change_unit_test.py
+++ b/saiunit/linalg/_linalg_change_unit_test.py
@@ -626,3 +626,58 @@ def test_docstring_example_det():
     assert result.unit == u.meter ** 2
     expected = jnp.linalg.det(jnp.array([[1., 2.], [3., 4.]]))
     assert jnp.allclose(result.mantissa, expected)
+
+
+def test_lstsq_residuals_and_s_carry_units():
+    """Regression: lstsq must wrap residuals (b.unit**2) and s (a.unit)."""
+    a_v = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
+    b_v = jnp.array([1., 2., 4.])
+    x1, res1, rank1, s1 = bulinalg.lstsq(a_v * u.ms, b_v * u.mV)
+    assert isinstance(res1, u.Quantity) and res1.unit.dim == (u.mV ** 2).dim
+    assert isinstance(s1, u.Quantity) and s1.unit.dim == u.ms.dim
+    assert not isinstance(rank1, u.Quantity)
+    # the same physical system expressed in different display units
+    x2, res2, rank2, s2 = bulinalg.lstsq(
+        u.Quantity(a_v / 1000.0, unit=u.second),
+        u.Quantity(b_v / 1000.0, unit=u.volt),
+    )
+    assert u.math.allclose(x1, x2, rtol=1e-3)
+    assert u.math.allclose(res1, res2, rtol=1e-3)
+    assert u.math.allclose(s1, s2, rtol=1e-3)
+    assert int(rank1) == int(rank2)
+    # one-sided branches
+    x3, res3, rank3, s3 = bulinalg.lstsq(a_v * u.ms, b_v)
+    assert isinstance(s3, u.Quantity) and s3.unit.dim == u.ms.dim
+    assert not isinstance(res3, u.Quantity)
+    x4, res4, rank4, s4 = bulinalg.lstsq(a_v, b_v * u.mV)
+    assert isinstance(res4, u.Quantity) and res4.unit.dim == (u.mV ** 2).dim
+    assert not isinstance(s4, u.Quantity)
+
+
+def test_cholesky_symmetrize_input_consistent_across_backends():
+    """Regression: numpy backend must symmetrize like jax instead of silently
+    dropping ``symmetrize_input``."""
+    import numpy as np
+    a_v = np.array([[4.0, 2.0], [0.0, 3.0]])  # asymmetric input
+    expected = jnp.linalg.cholesky((jnp.asarray(a_v) + jnp.asarray(a_v).T) / 2)
+    r_jax = u.linalg.cholesky(jnp.asarray(a_v) * u.meter2)
+    r_np = u.linalg.cholesky(u.Quantity(a_v, unit=u.meter2))
+    assert r_jax.unit == meter
+    assert r_np.unit == meter
+    np.testing.assert_allclose(np.asarray(r_jax.mantissa), np.asarray(expected), rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(r_np.mantissa), np.asarray(expected), rtol=1e-6)
+
+
+def test_cholesky_symmetrize_input_false():
+    """``symmetrize_input=False`` keeps jax semantics and must not crash numpy."""
+    import numpy as np
+    a_v = jnp.array([[4.0, 2.0], [0.0, 3.0]])
+    expected = jnp.linalg.cholesky(a_v, symmetrize_input=False)
+    r_jax = u.linalg.cholesky(a_v * u.meter2, symmetrize_input=False)
+    np.testing.assert_allclose(np.asarray(r_jax.mantissa), np.asarray(expected),
+                               rtol=1e-6, equal_nan=True)
+    # numpy backend: the kwarg must not be forwarded (np.linalg.cholesky lacks it)
+    sym = np.array([[4.0, 1.0], [1.0, 3.0]])
+    r_np = u.linalg.cholesky(u.Quantity(sym, unit=u.meter2), symmetrize_input=False)
+    np.testing.assert_allclose(np.asarray(r_np.mantissa),
+                               np.linalg.cholesky(sym), rtol=1e-6)

--- a/saiunit/linalg/_linalg_keep_unit.py
+++ b/saiunit/linalg/_linalg_keep_unit.py
@@ -18,21 +18,35 @@ from __future__ import annotations
 from typing import Union
 
 from saiunit._jax_compat import HAS_JAX, jax, jnp, require_jax
-from saiunit._typing import Array, ArrayLike
+from saiunit._typing import Array, ArrayLike, DTypeLike
 
 from saiunit._backend import get_backend
 from saiunit._base_getters import maybe_decimal
 from saiunit._base_quantity import Quantity
 from saiunit._misc import set_module_as, maybe_custom_array
-from saiunit.math._fun_keep_unit import (
-    _fun_keep_unit_unary, trace, diagonal
-)
+from saiunit.math._fun_keep_unit import _fun_keep_unit_unary
 
 
 def _lax_linalg():
     require_jax("saiunit.linalg.svd / eig / eigh")
     from saiunit.lax import _lax_linalg as _m
     return _m
+
+
+def _promote_to_inexact(x):
+    """Promote integer/bool inputs to a floating-point dtype.
+
+    ``lax.linalg`` primitives reject non-inexact dtypes whereas
+    ``jnp.linalg`` promotes them; match the ``jnp.linalg`` behaviour.
+    """
+    mantissa = x.mantissa if isinstance(x, Quantity) else x
+    mantissa = jnp.asarray(mantissa)
+    if jnp.issubdtype(mantissa.dtype, jnp.inexact):
+        return x
+    mantissa = mantissa.astype(jnp.promote_types(mantissa.dtype, jnp.float32))
+    if isinstance(x, Quantity):
+        return Quantity(mantissa, unit=x.unit)
+    return mantissa
 
 __all__ = [
     # Decompositions
@@ -88,7 +102,8 @@ def norm(
     * ``ord=None`` (default) -- 2-norm
     * ``ord=inf`` -- ``max(abs(x))``
     * ``ord=-inf`` -- ``min(abs(x))``
-    * ``ord=0`` -- ``sum(x != 0)``
+    * ``ord=0`` -- ``sum(x != 0)`` (a dimensionless count, returned
+      without a unit)
     * other numeric -- ``sum(abs(x)**ord)**(1/ord)``
 
     For **matrix norms** (two-axis reduction):
@@ -125,6 +140,12 @@ def norm(
         >>> u.linalg.norm(m)
         10.198039 * meter
     """
+    if ord == 0:
+        # ``ord=0`` counts nonzero entries — a dimensionless count — so
+        # the input unit must not be attached to the result.
+        x = maybe_custom_array(x)
+        if isinstance(x, Quantity):
+            x = x.mantissa
     return _fun_keep_unit_unary('linalg.norm', x, ord=ord, axis=axis, keepdims=keepdims, **kwargs)
 
 
@@ -226,6 +247,12 @@ def vector_norm(
         >>> u.linalg.vector_norm(x, axis=1)
         ArrayImpl([3.7416575, 9.48683262], dtype=float32) * meter
     """
+    if ord == 0:
+        # ``ord=0`` counts nonzero entries — a dimensionless count — so
+        # the input unit must not be attached to the result.
+        x = maybe_custom_array(x)
+        if isinstance(x, Quantity):
+            x = x.mantissa
     return _fun_keep_unit_unary('linalg.vector_norm',
                                 x,
                                 axis=axis,
@@ -238,7 +265,7 @@ def qr(
     a: Union[Quantity, ArrayLike],
     mode: str = "reduced",
     **kwargs,
-) -> Array | Quantity:
+) -> Array | Quantity | tuple[Array | Quantity, ...]:
     """Compute the QR decomposition of a matrix.
 
     SaiUnit implementation of :func:`numpy.linalg.qr`.
@@ -265,6 +292,9 @@ def qr(
         * ``"complete"`` -- *Q* has shape ``(..., M, M)``, *R* has shape
           ``(..., M, N)``.
         * ``"r"`` -- only *R* is returned.
+        * ``"raw"`` -- returns ``(h, tau)`` where the unit of *a* is
+          carried by *h*; the Householder scalars *tau* are
+          dimensionless.
 
     Returns
     -------
@@ -293,11 +323,23 @@ def qr(
     xp = get_backend(mantissa)
     result = xp.linalg.qr(mantissa, mode=mode, **kwargs)
     if not isinstance(a, Quantity):
-        return result  # type: ignore[return-value]
+        return result
     if mode == "r":
         return maybe_decimal(Quantity(result, unit=a.unit))
+    if mode == "raw":
+        # The backend returns ``(h, tau)``: the unit is carried by ``h``
+        # while the Householder scalars ``tau`` stay dimensionless.
+        h, tau = result
+        h = maybe_decimal(Quantity(h, unit=a.unit))
+        if hasattr(result, '_fields'):
+            return type(result)(h, tau)
+        return h, tau
     Q, R = result
-    return Q, maybe_decimal(Quantity(R, unit=a.unit))  # type: ignore[return-value]
+    R = maybe_decimal(Quantity(R, unit=a.unit))
+    # Preserve the backend's container type (e.g. ``QRResult``).
+    if hasattr(result, '_fields'):
+        return type(result)(Q, R)
+    return Q, R
 
 
 @set_module_as('saiunit.linalg')
@@ -383,10 +425,16 @@ def svd(
             return result
         if compute_uv:
             u, s, vh = result
-            return u, maybe_decimal(Quantity(s, unit=x.unit)), vh
+            s = maybe_decimal(Quantity(s, unit=x.unit))
+            # Preserve the backend's container type (e.g. ``SVDResult``).
+            if hasattr(result, '_fields'):
+                return type(result)(u, s, vh)
+            return u, s, vh
         return maybe_decimal(Quantity(result, unit=x.unit))
 
-    return _lax_linalg().svd(
+    lax_linalg = _lax_linalg()
+    x = _promote_to_inexact(x)
+    return lax_linalg.svd(
         x,
         full_matrices=full_matrices,
         compute_uv=compute_uv,
@@ -468,7 +516,11 @@ def eig(
         ArrayImpl([ 3.+0.j, -1.+0.j], dtype=complex64) * meter
     """
     a = maybe_custom_array(a)
-    return _lax_linalg().eig(a, compute_left_eigenvectors=False, **kwargs)
+    lax_linalg = _lax_linalg()
+    a = _promote_to_inexact(a)
+    # ``lax.linalg.eig`` returns a list for plain inputs; normalise both
+    # the plain and the Quantity path to a plain tuple.
+    return tuple(lax_linalg.eig(a, compute_left_eigenvectors=False, **kwargs))
 
 
 @set_module_as('saiunit.linalg')
@@ -638,3 +690,91 @@ def matrix_transpose(
                    [3, 6]], dtype=int32) * meter
     """
     return _fun_keep_unit_unary('linalg.matrix_transpose', x, **kwargs)
+
+
+@set_module_as('saiunit.linalg')
+def trace(
+    x: Union[ArrayLike, Quantity],
+    *,
+    offset: int = 0,
+    dtype: DTypeLike | None = None,
+    **kwargs,
+) -> Union[Array, Quantity]:
+    """Compute the trace of a matrix or stack of matrices.
+
+    SaiUnit implementation of :func:`numpy.linalg.trace`.
+
+    Unlike :func:`saiunit.math.trace` (which follows :func:`numpy.trace`
+    and sums over the *first* two axes by default), this function follows
+    ``linalg`` semantics and sums along the diagonals of the *last* two
+    axes.
+
+    Parameters
+    ----------
+    x : array_like or Quantity
+        Input of shape ``(..., M, N)``.
+    offset : int, optional
+        Offset of the diagonal from the main diagonal (default: 0).
+    dtype : dtype, optional
+        Data type of the returned array.
+
+    Returns
+    -------
+    out : ndarray or Quantity
+        Trace of shape ``x.shape[:-2]``.  Carries the same unit as *x*.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
+        >>> x = jnp.arange(18.).reshape(2, 3, 3) * u.meter
+        >>> u.linalg.trace(x)
+        ArrayImpl([12., 39.], dtype=float32) * meter
+    """
+    return _fun_keep_unit_unary('linalg.trace', x, offset=offset, dtype=dtype, **kwargs)
+
+
+@set_module_as('saiunit.linalg')
+def diagonal(
+    x: Union[ArrayLike, Quantity],
+    *,
+    offset: int = 0,
+    **kwargs,
+) -> Union[Array, Quantity]:
+    """Extract the diagonals of a matrix or stack of matrices.
+
+    SaiUnit implementation of :func:`numpy.linalg.diagonal`.
+
+    Unlike :func:`saiunit.math.diagonal` (which follows
+    :func:`numpy.diagonal` and uses the *first* two axes by default),
+    this function follows ``linalg`` semantics and extracts the diagonal
+    of the *last* two axes.
+
+    Parameters
+    ----------
+    x : array_like or Quantity
+        Input of shape ``(..., M, N)``.
+    offset : int, optional
+        Offset of the diagonal from the main diagonal (default: 0).
+
+    Returns
+    -------
+    out : ndarray or Quantity
+        Diagonals of shape ``x.shape[:-2] + (K,)`` with
+        ``K = min(M, N)`` for ``offset=0``.  Carries the same unit
+        as *x*.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import saiunit as u
+        >>> import jax.numpy as jnp
+        >>> x = jnp.arange(18.).reshape(2, 3, 3) * u.meter
+        >>> u.linalg.diagonal(x)
+        ArrayImpl([[ 0.,  4.,  8.],
+                   [ 9., 13., 17.]], dtype=float32) * meter
+    """
+    return _fun_keep_unit_unary('linalg.diagonal', x, offset=offset, **kwargs)

--- a/saiunit/linalg/_linalg_keep_unit_test.py
+++ b/saiunit/linalg/_linalg_keep_unit_test.py
@@ -267,3 +267,114 @@ def test_eigvals_keeps_unit():
     ev_ref = jnp.linalg.eigvals(a)
     assert_quantity(bulinalg.eigvals(a), ev_ref)
     assert_quantity(bulinalg.eigvals(a * meter), ev_ref, meter)
+
+
+def test_linalg_trace_uses_last_two_axes():
+    """Regression: linalg.trace must reduce the last two axes (jnp.linalg semantics)."""
+    x = jnp.arange(18.0).reshape(2, 3, 3)
+    expected = jnp.linalg.trace(x)
+    assert_quantity(bulinalg.trace(x), expected)
+    assert_quantity(bulinalg.trace(x * meter), expected, unit=meter)
+    expected_off = jnp.linalg.trace(x, offset=1)
+    assert_quantity(bulinalg.trace(x, offset=1), expected_off)
+
+
+def test_linalg_diagonal_uses_last_two_axes():
+    """Regression: linalg.diagonal must take the last two axes (jnp.linalg semantics)."""
+    x = jnp.arange(18.0).reshape(2, 3, 3)
+    expected = jnp.linalg.diagonal(x)
+    assert_quantity(bulinalg.diagonal(x), expected)
+    assert_quantity(bulinalg.diagonal(x * meter), expected, unit=meter)
+    expected_off = jnp.linalg.diagonal(x, offset=1)
+    assert_quantity(bulinalg.diagonal(x, offset=1), expected_off)
+
+
+def test_norm_ord0_is_dimensionless_count():
+    """Regression: ord=0 counts nonzeros, so the result must not carry a unit."""
+    x = jnp.array([0.0, 1.0, 2.0, 0.0])
+    expected = jnp.linalg.norm(x, ord=0)
+    r = bulinalg.norm(x * meter, ord=0)
+    assert not isinstance(r, u.Quantity)
+    assert_quantity(r, expected)
+    # same physical vector in a different display unit gives the same count
+    r2 = bulinalg.norm(u.Quantity(x / 1000.0, unit=u.kmeter), ord=0)
+    assert not isinstance(r2, u.Quantity)
+    assert_quantity(r2, expected)
+
+
+def test_vector_norm_ord0_is_dimensionless_count():
+    """Regression: vector_norm(ord=0) must not carry a unit."""
+    x = jnp.array([0.0, 1.0, 2.0, 0.0])
+    expected = jnp.linalg.vector_norm(x, ord=0)
+    r = bulinalg.vector_norm(x * meter, ord=0)
+    assert not isinstance(r, u.Quantity)
+    assert_quantity(r, expected)
+
+
+def test_eig_eigvals_integer_input():
+    """Regression: integer inputs must be promoted like jnp.linalg.eig."""
+    a = jnp.array([[1, 2], [2, 1]], dtype=jnp.int32)
+    w_exp, v_exp = jnp.linalg.eig(a)
+    w, v = bulinalg.eig(a)
+    assert_quantity(w, w_exp)
+    assert_quantity(v, v_exp)
+    w_q, v_q = bulinalg.eig(a * meter)
+    assert_quantity(w_q, w_exp, unit=meter)
+    assert_quantity(bulinalg.eigvals(a), w_exp)
+    assert_quantity(bulinalg.eigvals(a * meter), w_exp, unit=meter)
+
+
+def test_svd_svdvals_integer_input():
+    """Regression: integer inputs must be promoted like jnp.linalg.svd."""
+    m = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=jnp.int32)
+    u_exp, s_exp, vh_exp = jnp.linalg.svd(m)
+    u_res, s_res, vh_res = bulinalg.svd(m)
+    assert_quantity(u_res, u_exp)
+    assert_quantity(s_res, s_exp)
+    assert_quantity(vh_res, vh_exp)
+    u_res, s_res, vh_res = bulinalg.svd(m * meter)
+    assert_quantity(s_res, s_exp, unit=meter)
+    assert_quantity(bulinalg.svdvals(m), jnp.linalg.svdvals(m))
+    assert_quantity(bulinalg.svdvals(m * meter), jnp.linalg.svdvals(m), unit=meter)
+
+
+def test_qr_raw_mode_unit_on_h():
+    """Regression: for mode='raw' the unit belongs to h, and tau stays plain."""
+    x = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
+    h_exp, tau_exp = jnp.linalg.qr(x, mode='raw')
+    h, tau = bulinalg.qr(x * meter, mode='raw')
+    assert isinstance(h, u.Quantity)
+    assert h.unit == meter
+    assert not isinstance(tau, u.Quantity)
+    assert_quantity(h, h_exp, unit=meter)
+    assert_quantity(tau, tau_exp)
+
+
+def test_qr_container_type_matches_plain():
+    """Regression: qr must return the same container type for plain and Quantity."""
+    x = jnp.array([[1., 2.], [3., 4.]])
+    plain = bulinalg.qr(x)
+    q = bulinalg.qr(x * meter)
+    assert type(q) is type(plain)
+    if hasattr(plain, '_fields'):
+        assert q.R.unit == meter
+        assert not isinstance(q.Q, u.Quantity)
+
+
+def test_eig_container_is_tuple():
+    """Regression: eig must return a plain tuple for plain and Quantity inputs."""
+    a = jnp.array([[1., 2.], [2., 1.]])
+    assert type(bulinalg.eig(a)) is tuple
+    assert type(bulinalg.eig(a * meter)) is tuple
+
+
+def test_eigh_and_hermitian_svd_container_types_match():
+    """Regression: container type must not depend on unit-ness."""
+    a = jnp.array([[3., 1.], [1., 3.]])
+    assert type(bulinalg.eigh(a)) is type(bulinalg.eigh(a * meter))
+    plain = bulinalg.svd(a, hermitian=True)
+    q = bulinalg.svd(a * meter, hermitian=True)
+    assert type(q) is type(plain)
+    if hasattr(plain, '_fields'):
+        assert q.S.unit == meter
+        assert not isinstance(q.U, u.Quantity)

--- a/saiunit/math/_fun_change_unit.py
+++ b/saiunit/math/_fun_change_unit.py
@@ -1696,7 +1696,7 @@ def det(
             msg = "Argument to _det() must have shape [..., n, n], got {}"
             raise ValueError(msg.format(a_shape))
         xp = get_backend(a.mantissa)
-        return Quantity(_resolve_op('linalg.det', xp)(a.mantissa, **kwargs), unit=new_unit)
+        return maybe_decimal(Quantity(_resolve_op('linalg.det', xp)(a.mantissa, **kwargs), unit=new_unit))
     else:
         xp = get_backend(a)
         return _resolve_op('linalg.det', xp)(a, **kwargs)

--- a/saiunit/math/_fun_change_unit_test.py
+++ b/saiunit/math/_fun_change_unit_test.py
@@ -809,3 +809,10 @@ def test_power_scaled_dimensionless_base_array_exponent():
     scaled = u.Quantity(jnp.array([2.0, 3.0]), unit=u.kmeter / u.meter)
     r = um.power(scaled, jnp.array([1.0, 2.0]))
     assert_quantity(r, jnp.array([2000.0, 9000000.0]))
+
+
+def test_det_dimensionless_quantity_returns_plain():
+    """Regression: det of a unitless Quantity must unwrap to a plain array."""
+    r = u.linalg.det(u.Quantity(jnp.array([[2.0, 1.0], [1.0, 2.0]])))
+    assert not isinstance(r, u.Quantity)
+    assert_quantity(r, 3.0)

--- a/saiunit/math/_fun_keep_unit.py
+++ b/saiunit/math/_fun_keep_unit.py
@@ -184,16 +184,24 @@ def _accepted_kwargs(fn) -> Optional[frozenset]:
 
 
 def _filter_unsupported_kwargs(fn, kwargs):
-    """Drop kwargs the backend ``fn`` doesn't accept.
+    """Reject kwargs the backend ``fn`` doesn't accept.
 
-    Best-effort: returns ``kwargs`` unchanged when ``fn``'s signature
-    can't be introspected (C-extensions such as torch's bindings). Pair
-    with :func:`_safe_call` to also handle the un-introspectable case.
+    Raises :class:`TypeError` when ``fn``'s signature does not accept a
+    kwarg — silently dropping it would change semantics (e.g. a typo'd
+    ``axes=`` instead of ``axis=`` would transform the default axis).
+    Returns ``kwargs`` unchanged when ``fn``'s signature can't be
+    introspected (C-extensions such as torch's bindings); pair with
+    :func:`_safe_call` to also handle the un-introspectable case.
     """
     accepted = _accepted_kwargs(fn)
     if accepted is None:
         return kwargs
-    return {k: v for k, v in kwargs.items() if k in accepted}
+    for k in kwargs:
+        if k not in accepted:
+            raise TypeError(
+                f"{getattr(fn, '__name__', fn)!r} got an unexpected keyword argument {k!r}"
+            )
+    return kwargs
 
 
 _UNEXPECTED_KW_RE = re.compile(

--- a/saiunit/math/_fun_keep_unit_test.py
+++ b/saiunit/math/_fun_keep_unit_test.py
@@ -1549,3 +1549,22 @@ def test_nan_to_num_plain_array_quantity_replacement_raises():
         u.math.nan_to_num(x, posinf=1 * u.meter)
     with pytest.raises(TypeError, match='nan_to_num'):
         u.math.nan_to_num(x, neginf=1 * u.meter)
+
+
+def test_filter_unsupported_kwargs_raises_on_unknown():
+    """Unknown kwargs must raise, not be silently dropped."""
+    from saiunit.math._fun_keep_unit import _filter_unsupported_kwargs
+
+    def fn(a, axis=-1):
+        return a
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'axes'"):
+        _filter_unsupported_kwargs(fn, {'axes': 0})
+    # accepted kwargs pass through unchanged
+    assert _filter_unsupported_kwargs(fn, {'axis': 0}) == {'axis': 0}
+
+    def fn_varkw(a, **kw):
+        return a
+
+    # **kwargs / un-introspectable functions are left for _safe_call
+    assert _filter_unsupported_kwargs(fn_varkw, {'whatever': 1}) == {'whatever': 1}

--- a/saiunit/sparse/_coo.py
+++ b/saiunit/sparse/_coo.py
@@ -35,7 +35,7 @@ from saiunit._base_getters import (
 from saiunit._typing import Array, ArrayLike, DTypeLike
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
-from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
+from saiunit._sparse_base import SparseMatrix, _HashableIndex, _same_sparsity_pattern
 from saiunit.math._fun_array_creation import asarray
 from saiunit.math._fun_keep_unit import promote_dtypes
 
@@ -107,6 +107,11 @@ class COO(SparseMatrix):
     :class:`jax.experimental.sparse.BCOO`. Additionally, there are known
     failures when ``nse`` is larger than the true number of non-zeros in the
     represented matrix.
+
+    Element-wise operations (``+``, ``-``, ``*``, ``/``, ``%`` and their
+    reflected variants) apply ONLY to the explicitly stored entries;
+    implicit zeros are unaffected. For example, ``coo + 2`` does NOT add 2
+    to absent entries, unlike dense arrays.
 
     Examples
     --------
@@ -317,8 +322,8 @@ class COO(SparseMatrix):
         Tuple[Array | Quantity,], dict[str, Any]
     ]:
         aux = self._info._asdict()
-        aux['row'] = self.row
-        aux['col'] = self.col
+        aux['row'] = _HashableIndex(self.row)
+        aux['col'] = _HashableIndex(self.col)
         return (self.data,), aux
 
     @classmethod
@@ -330,8 +335,8 @@ class COO(SparseMatrix):
         obj.shape = aux_data['shape']
         obj._rows_sorted = aux_data['rows_sorted']
         obj._cols_sorted = aux_data['cols_sorted']
-        obj.row = aux_data['row']
-        obj.col = aux_data['col']
+        obj.row = aux_data['row'].value
+        obj.col = aux_data['col'].value
         return obj
 
     def __abs__(self):
@@ -359,7 +364,10 @@ class COO(SparseMatrix):
         )
 
     def _binary_op(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, COO):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.row, other.row) and _same_sparsity_pattern(self.col, other.col):
                 return COO(
                     (
@@ -376,6 +384,7 @@ class COO(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return COO(
                 (
                     op(self.data, other),
@@ -402,7 +411,10 @@ class COO(SparseMatrix):
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, COO):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.row, other.row) and _same_sparsity_pattern(self.col, other.col):
                 return COO(
                     (
@@ -419,6 +431,7 @@ class COO(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return COO(
                 (
                     op(other, self.data),
@@ -596,6 +609,8 @@ def coo_fromdense(
         Array([[1., 0., 0.],
                [0., 2., 3.]], dtype=float32)
     """
+    from saiunit._jax_guard import require_jax_backend
+    require_jax_backend("coo_fromdense", mat)
     if nse is None:
         nse = int((get_mantissa(mat) != 0).sum())
     nse_int = concrete_or_error(operator.index, nse, "coo_fromdense nse argument")

--- a/saiunit/sparse/_coo_test.py
+++ b/saiunit/sparse/_coo_test.py
@@ -388,3 +388,94 @@ class TestCOODocstringExamples(unittest.TestCase):
         dense = jnp.array([[1., 0.], [0., 2.]])
         coo = susparse.COO.fromdense(dense)
         self.assertIsInstance(coo, susparse.SparseMatrix)
+
+
+def test_coo_jit_repeated_calls():
+    import jax.numpy as jnp
+
+    @jax.jit
+    def f(sp, x):
+        return sp @ x
+
+    x = jnp.ones(3)
+    dense1 = jnp.array([[1., 0., 2.], [0., 3., 0.]]) * u.mV
+    dense2 = jnp.array([[4., 0., 5.], [0., 6., 0.]]) * u.mV
+    dense3 = jnp.array([[0., 7., 0.], [8., 0., 9.]]) * u.mV
+
+    coo1 = u.sparse.COO.fromdense(dense1)
+    # Same unit and same sparsity pattern, different values.
+    coo2 = u.sparse.COO.fromdense(dense2)
+    # Different sparsity pattern.
+    coo3 = u.sparse.COO.fromdense(dense3)
+
+    assert u.math.allclose(f(coo1, x), dense1 @ x)
+    assert u.math.allclose(f(coo2, x), dense2 @ x)  # crashed before fix
+    assert u.math.allclose(f(coo1, x), dense1 @ x)  # cache hit
+    assert u.math.allclose(f(coo3, x), dense3 @ x)  # recompile
+
+
+def test_coo_binary_op_with_1x1_operand():
+    import jax.numpy as jnp
+
+    dense = jnp.array([[1., 0., 2.], [0., 3., 0.]])
+    coo = u.sparse.COO.fromdense(dense)
+
+    out = coo * jnp.array([[3.0]])
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = jnp.array([[3.0]]) * coo
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = coo * (jnp.array([[3.0]]) * u.mV)
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * (3.0 * u.mV))
+
+
+def test_coo_add_shape_mismatch_raises():
+    import jax.numpy as jnp
+    import pytest
+
+    c1 = u.sparse.COO.fromdense(jnp.array([[1., 2., 3.]]))
+    c2 = u.sparse.COO.fromdense(jnp.array([[1., 2., 3., 0.]]))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 + c2
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 - c2
+
+
+def test_numpy_left_operands_defer_to_coo():
+    import jax.numpy as jnp
+    import numpy as np
+
+    dense = jnp.array([[1., 0., 2.], [0., 3., 0.]])
+    coo = u.sparse.COO.fromdense(dense)
+
+    expected = jnp.ones(2) @ coo
+    out = np.ones(2) @ coo
+    assert u.math.allclose(out, expected)
+
+    out = np.float64(3.0) * coo
+    assert isinstance(out, u.sparse.COO)
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+
+def test_coo_block_until_ready_with_quantity():
+    import jax.numpy as jnp
+
+    dense = jnp.array([[1., 0.], [0., 2.]]) * u.mV
+    coo = u.sparse.COO.fromdense(dense)
+    assert coo.block_until_ready() is coo
+
+
+def test_coo_fromdense_raises_on_numpy_quantity():
+    import numpy as np
+    import pytest
+    from saiunit import meter
+
+    q = u.Quantity(np.array([[1.0, 0.0], [0.0, 2.0]]), unit=meter)
+    with pytest.raises(u.BackendError, match="requires the jax backend"):
+        u.sparse.COO.fromdense(q)
+    with pytest.raises(u.BackendError, match="requires the jax backend"):
+        u.sparse.coo_fromdense(q)

--- a/saiunit/sparse/_csr.py
+++ b/saiunit/sparse/_csr.py
@@ -31,7 +31,7 @@ from saiunit._base_getters import (
 )
 from saiunit._base_quantity import Quantity
 from saiunit._compatible_import import concrete_or_error
-from saiunit._sparse_base import SparseMatrix, _same_sparsity_pattern
+from saiunit._sparse_base import SparseMatrix, _HashableIndex, _same_sparsity_pattern
 from saiunit._typing import Array, DTypeLike
 from saiunit.math._fun_array_creation import asarray
 from saiunit.math._fun_keep_unit import promote_dtypes
@@ -87,6 +87,13 @@ class CSR(SparseMatrix):
     csr_fromdense : Create a CSR matrix from a dense array.
     csr_todense : Convert a CSR matrix to a dense array.
 
+    Notes
+    -----
+    Element-wise operations (``+``, ``-``, ``*``, ``/``, ``%`` and their
+    reflected variants) apply ONLY to the explicitly stored entries;
+    implicit zeros are unaffected. For example, ``csr + 2`` does NOT add 2
+    to absent entries, unlike dense arrays.
+
     Examples
     --------
     .. code-block:: python
@@ -116,8 +123,6 @@ class CSR(SparseMatrix):
 
     @classmethod
     def fromdense(cls, mat, *, nse=None, index_dtype=np.int32):
-        from saiunit._jax_guard import require_jax_backend
-        require_jax_backend("CSR.fromdense", mat)
         if nse is None:
             nse = (get_mantissa(mat) != 0).sum()
         return csr_fromdense(mat, nse=nse, index_dtype=index_dtype)
@@ -233,7 +238,10 @@ class CSR(SparseMatrix):
         return CSR((self.data.__pos__(), self.indices, self.indptr), shape=self.shape)
 
     def _binary_op(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, CSR):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSR(
                     (op(self.data, other.data),
@@ -246,6 +254,7 @@ class CSR(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return CSR(
                 (op(self.data, other), self.indices, self.indptr),
                 shape=self.shape
@@ -263,7 +272,10 @@ class CSR(SparseMatrix):
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, CSR):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSR(
                     (op(other.data, self.data),
@@ -276,6 +288,7 @@ class CSR(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return CSR(
                 (op(other, self.data),
                  self.indices,
@@ -383,7 +396,11 @@ class CSR(SparseMatrix):
             raise NotImplementedError(f"matmul with object of shape {other.shape}")
 
     def tree_flatten(self):
-        return (self.data,), {"shape": self.shape, "indices": self.indices, "indptr": self.indptr}
+        return (self.data,), {
+            "shape": self.shape,
+            "indices": _HashableIndex(self.indices),
+            "indptr": _HashableIndex(self.indptr),
+        }
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
@@ -392,8 +409,8 @@ class CSR(SparseMatrix):
         if aux_data.keys() != {'shape', 'indices', 'indptr'}:
             raise ValueError(f"CSR.tree_unflatten: invalid {aux_data=}")
         obj.shape = aux_data['shape']
-        obj.indices = aux_data['indices']
-        obj.indptr = aux_data['indptr']
+        obj.indices = aux_data['indices'].value
+        obj.indptr = aux_data['indptr'].value
         return obj
 
 
@@ -434,6 +451,13 @@ class CSC(SparseMatrix):
     CSR : Unit-aware Compressed Sparse Row matrix.
     csc_fromdense : Create a CSC matrix from a dense array.
     csc_todense : Convert a CSC matrix to a dense array.
+
+    Notes
+    -----
+    Element-wise operations (``+``, ``-``, ``*``, ``/``, ``%`` and their
+    reflected variants) apply ONLY to the explicitly stored entries;
+    implicit zeros are unaffected. For example, ``csc + 2`` does NOT add 2
+    to absent entries, unlike dense arrays.
 
     Examples
     --------
@@ -577,7 +601,10 @@ class CSC(SparseMatrix):
         return CSC((self.data.__pos__(), self.indices, self.indptr), shape=self.shape)
 
     def _binary_op(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, CSC):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSC(
                     (op(self.data, other.data),
@@ -590,6 +617,7 @@ class CSC(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return CSC(
                 (op(self.data, other),
                  self.indices,
@@ -609,7 +637,10 @@ class CSC(SparseMatrix):
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        """Apply ``op`` to the explicitly stored entries only (see class Notes)."""
         if isinstance(other, CSC):
+            if self.shape != other.shape:
+                raise ValueError(f"shape mismatch: {self.shape} vs {other.shape}")
             if _same_sparsity_pattern(self.indices, other.indices) and _same_sparsity_pattern(self.indptr, other.indptr):
                 return CSC(
                     (op(other.data, self.data),
@@ -622,6 +653,7 @@ class CSC(SparseMatrix):
 
         other = asarray(other)
         if other.size == 1:
+            other = other.reshape(())
             return CSC(
                 (op(other, self.data),
                  self.indices,
@@ -730,7 +762,11 @@ class CSC(SparseMatrix):
             raise NotImplementedError(f"matmul with object of shape {other.shape}")
 
     def tree_flatten(self):
-        return (self.data,), {"shape": self.shape, "indices": self.indices, "indptr": self.indptr}
+        return (self.data,), {
+            "shape": self.shape,
+            "indices": _HashableIndex(self.indices),
+            "indptr": _HashableIndex(self.indptr),
+        }
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
@@ -739,8 +775,8 @@ class CSC(SparseMatrix):
         if aux_data.keys() != {'shape', 'indices', 'indptr'}:
             raise ValueError(f"CSC.tree_unflatten: invalid {aux_data=}")
         obj.shape = aux_data['shape']
-        obj.indices = aux_data['indices']
-        obj.indptr = aux_data['indptr']
+        obj.indices = aux_data['indices'].value
+        obj.indptr = aux_data['indptr'].value
         return obj
 
 
@@ -787,6 +823,8 @@ def csr_fromdense(
         Array([[1., 0., 0.],
                [0., 2., 3.]], dtype=float32)
     """
+    from saiunit._jax_guard import require_jax_backend
+    require_jax_backend("csr_fromdense", mat)
     if nse is None:
         nse = int((get_mantissa(mat) != 0).sum())
     nse_int = concrete_or_error(operator.index, nse, "csr_fromdense nse argument")
@@ -906,6 +944,8 @@ def csc_fromdense(
         Array([[1., 0., 0.],
                [0., 2., 3.]], dtype=float32)
     """
+    from saiunit._jax_guard import require_jax_backend
+    require_jax_backend("csc_fromdense", mat)
     if nse is not None:
         nse = concrete_or_error(operator.index, nse, "csc_fromdense nse argument")
     return CSC.fromdense(mat, nse=nse, index_dtype=index_dtype)

--- a/saiunit/sparse/_csr_test.py
+++ b/saiunit/sparse/_csr_test.py
@@ -769,11 +769,157 @@ def test_csr_fromdense_raises_on_numpy_quantity():
         u.sparse.CSR.fromdense(q)
 
 
-def test_csr_fromdense_raises_on_numpy_quantity():  # type: ignore[no-redef]
+def test_csr_fromdense_function_raises_on_numpy_quantity():
     import numpy as np
     import pytest
     import saiunit as u
     from saiunit import meter
     q = u.Quantity(np.array([[1.0, 0.0], [0.0, 2.0]]), unit=meter)
     with pytest.raises(u.BackendError, match="requires the jax backend"):
-        u.sparse.CSR.fromdense(q)
+        u.sparse.csr_fromdense(q)
+
+
+def test_csc_fromdense_raises_on_numpy_quantity():
+    import numpy as np
+    import pytest
+    import saiunit as u
+    from saiunit import meter
+    q = u.Quantity(np.array([[1.0, 0.0], [0.0, 2.0]]), unit=meter)
+    with pytest.raises(u.BackendError, match="requires the jax backend"):
+        u.sparse.CSC.fromdense(q)
+    with pytest.raises(u.BackendError, match="requires the jax backend"):
+        u.sparse.csc_fromdense(q)
+
+
+def test_csr_jit_repeated_calls():
+    import jax.numpy as jnp
+
+    @jax.jit
+    def f(sp, x):
+        return sp @ x
+
+    x = jnp.ones(3)
+    dense1 = jnp.array([[1., 0., 2.], [0., 3., 0.]]) * u.mV
+    dense2 = jnp.array([[4., 0., 5.], [0., 6., 0.]]) * u.mV
+    dense3 = jnp.array([[0., 7., 0.], [8., 0., 9.]]) * u.mV
+
+    csr1 = u.sparse.CSR.fromdense(dense1)
+    # Same unit and same sparsity pattern, different values.
+    csr2 = u.sparse.CSR.fromdense(dense2)
+    # Different sparsity pattern.
+    csr3 = u.sparse.CSR.fromdense(dense3)
+
+    assert u.math.allclose(f(csr1, x), dense1 @ x)
+    assert u.math.allclose(f(csr2, x), dense2 @ x)  # crashed before fix
+    assert u.math.allclose(f(csr1, x), dense1 @ x)  # cache hit
+    assert u.math.allclose(f(csr3, x), dense3 @ x)  # recompile
+
+
+def test_csc_jit_repeated_calls():
+    import jax.numpy as jnp
+
+    @jax.jit
+    def f(sp, x):
+        return sp @ x
+
+    x = jnp.ones(3)
+    dense1 = jnp.array([[1., 0., 2.], [0., 3., 0.]]) * u.mV
+    dense2 = jnp.array([[4., 0., 5.], [0., 6., 0.]]) * u.mV
+    dense3 = jnp.array([[0., 7., 0.], [8., 0., 9.]]) * u.mV
+
+    csc1 = u.sparse.CSC.fromdense(dense1)
+    # Same unit and same sparsity pattern, different values.
+    csc2 = u.sparse.CSC.fromdense(dense2)
+    # Different sparsity pattern.
+    csc3 = u.sparse.CSC.fromdense(dense3)
+
+    assert u.math.allclose(f(csc1, x), dense1 @ x)
+    assert u.math.allclose(f(csc2, x), dense2 @ x)  # crashed before fix
+    assert u.math.allclose(f(csc1, x), dense1 @ x)  # cache hit
+    assert u.math.allclose(f(csc3, x), dense3 @ x)  # recompile
+
+
+def test_csr_binary_op_with_1x1_operand():
+    import jax.numpy as jnp
+
+    dense = jnp.array([[1., 0., 2.], [0., 3., 0.]])
+    csr = u.sparse.CSR.fromdense(dense)
+
+    out = csr * jnp.array([[3.0]])
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = jnp.array([[3.0]]) * csr
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = csr * (jnp.array([[3.0]]) * u.mV)
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * (3.0 * u.mV))
+
+
+def test_csc_binary_op_with_1x1_operand():
+    import jax.numpy as jnp
+
+    dense = jnp.array([[1., 0., 2.], [0., 3., 0.]])
+    csc = u.sparse.CSC.fromdense(dense)
+
+    out = csc * jnp.array([[3.0]])
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = jnp.array([[3.0]]) * csc
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+    out = csc * (jnp.array([[3.0]]) * u.mV)
+    assert out.data.ndim == 1
+    assert u.math.allclose(out.todense(), dense * (3.0 * u.mV))
+
+
+def test_csr_add_shape_mismatch_raises():
+    import jax.numpy as jnp
+    import pytest
+
+    c1 = u.sparse.CSR.fromdense(jnp.array([[1., 2., 3.]]))
+    c2 = u.sparse.CSR.fromdense(jnp.array([[1., 2., 3., 0.]]))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 + c2
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 - c2
+
+
+def test_csc_add_shape_mismatch_raises():
+    import jax.numpy as jnp
+    import pytest
+
+    c1 = u.sparse.CSC.fromdense(jnp.array([[1.], [2.], [3.]]))
+    c2 = u.sparse.CSC.fromdense(jnp.array([[1.], [2.], [3.], [0.]]))
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 + c2
+    with pytest.raises(ValueError, match="shape mismatch"):
+        c1 - c2
+
+
+def test_numpy_left_operands_defer_to_csr():
+    import jax.numpy as jnp
+    import numpy as np
+
+    dense = jnp.array([[1., 0., 2.], [0., 3., 0.]])
+    csr = u.sparse.CSR.fromdense(dense)
+
+    expected = jnp.ones(2) @ csr
+    out = np.ones(2) @ csr
+    assert u.math.allclose(out, expected)
+
+    out = np.float64(3.0) * csr
+    assert isinstance(out, u.sparse.CSR)
+    assert u.math.allclose(out.todense(), dense * 3.0)
+
+
+def test_csr_block_until_ready_with_quantity():
+    import jax.numpy as jnp
+
+    dense = jnp.array([[1., 0.], [0., 2.]]) * u.mV
+    csr = u.sparse.CSR.fromdense(dense)
+    assert csr.block_until_ready() is csr


### PR DESCRIPTION
## Summary

A line-by-line audit of `saiunit.lax`, `saiunit.fft`, `saiunit.linalg`, and `saiunit.sparse` (every finding runtime-verified with a reproduction before fixing) surfaced **42 bugs**: silently-wrong unit algebra, crashes, swallowed errors, and API-surface defects. This PR fixes all of them, each with a regression test that failed before the fix.

### Highlights (silently wrong results)

- **`lax.triangular_solve` / `lax.tridiagonal_solve`** ignored the coefficient unit: solving `(A: Ω) x = (b: V)` returned volts instead of amps, and the same physical system expressed in kΩ gave answers 1000× apart. Mixed-scale diagonals (volt + mV) solved on raw mantissas. Result units are now `unit(b)/unit(a)` resp. `unit(b)/unit(d)`, with off-diagonals scale-unified.
- **`lax.schur`** attached the unit to the unitary Q instead of the Schur form T (and crashed with `compute_schur_vectors=False`).
- **`linalg.trace`/`linalg.diagonal`** used `np.trace` axis semantics (first two axes) instead of linalg semantics (last two): batched `(k,n,n)` inputs reduced across the batch axis.
- **`lax.scatter_mul`** demanded same-unit updates — dimensionally wrong for a product and scale-dependent; it now requires dimensionless updates.
- **Silent kwarg dropping**: `u.fft.fft(x2d, axes=0)` (typo for `axis=`) used to silently transform the default axis. The shared dispatch now raises `TypeError` like the backends themselves; torch's un-introspectable bindings keep the lenient `_safe_call` path.
- **`sparse` + `jax.jit`** crashed on the second call with any sparse argument (jax `Array`s in pytree aux_data); index arrays are now wrapped content-hashably for CSR/CSC/COO.

### Everything else

- `lax`: `pow`/`integer_pow` crashes on plain-base/Quantity-exponent; `rem` unit stripping; dead try/excepts silently discarding `dot_general(out_type=)` and `broadcasted_iota(_sharding=)`; `lax.reduce` pytree crash; `reduce_precision` unit loss; `collapse` now keeps units; scatter family scale-conversion + kwargs forwarding; `clamp` unitless-Quantity interop; missing kwargs on `qr`/`qdwh`/`eig`/`eigh`/`tridiagonal_solve`; duplicate `__all__` entry; `betainc` validation.
- `linalg`: `lstsq` residuals/singular-values units; `norm(ord=0)` dimensionless count; integer-input promotion for `eig`/`svd` family; `qr(mode="raw")` output labeling; container types no longer depend on unit-ness; `det` dimensionless unwrap; `cholesky` pre-symmetrizes instead of forwarding `symmetrize_input` to backends that reject it.
- `sparse`: `(1,1)` operand data corruption; shape-ignoring sparse+sparse ops; numpy-left operand crashes (`__array_ufunc__ = None`); `block_until_ready` with Quantity data; consistent jax-backend guard; documented stored-entries-only semantics.
- `fft`: `fftfreq`/`rfftfreq` dropped the unit `factor` in the out-of-range-scale branch; CustomArray `d` unwrap; dimensionless `d` accepted; per-call function-attribute mutation removed.

## Test plan

- [x] Full suite in this branch: **3859 passed, 0 failed, 183 skipped** (baseline on main: 3785 passed) — includes numpy/torch/dask/ndonnx backend tests
- [x] ~74 new regression tests, each confirmed red before its fix (TDD)
- [x] `mypy saiunit/` exits 0
- [x] All original audit reproductions re-verified fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)