### PR TITLE
release: v0.5.0 — follow-up public API audit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,51 @@
 # Release Notes
 
+## Version 0.5.0
+
+### Highlights
+
+Version 0.5.0 is a focused follow-up to the library-wide correctness audit that
+landed in 0.4.0. A second, execution-verified pass over the entire public API —
+the core ``Quantity``, ``Unit``, and ``Dimension`` types together with every
+numerical subpackage (``saiunit.math``, ``saiunit.lax``, ``saiunit.linalg``,
+``saiunit.fft``, ``saiunit.sparse``, and ``saiunit.autograd``) — confirmed that
+those subpackages are already correct and surfaced a small number of remaining
+edge-case defects in the core and decorator layers, which this release fixes.
+The public API is unchanged, so 0.5.0 is a drop-in upgrade from 0.4.0.
+
+### Core: ``Quantity``
+
+- **Fix indexed ``.at[...]`` updates with a multi-dimensional value and
+  out-of-bounds indices on the NumPy/CuPy backends.** ``q.at[idx].set(value)``
+  (and the ``add``/``multiply``/``divide``/``min``/``max`` variants) no longer
+  raises a shape-mismatch error when ``value`` is multi-dimensional and ``idx``
+  contains out-of-bounds entries; the out-of-bounds rows are now dropped to match
+  JAX's scatter behaviour (#127).
+- **Make ``Quantity.itemsize`` and ``Quantity.nbytes`` consistent with
+  ``Quantity.dtype``.** For scalar (Python-number) mantissas the byte counts now
+  follow the canonicalized ``dtype`` (e.g. ``float32`` under x32) instead of
+  reporting NumPy's default ``float64`` width (#127).
+
+### Decorators and validation
+
+- **``assign_units`` no longer drops variadic positional arguments.** A function
+  decorated with ``@assign_units`` that declares ``*args`` now receives the
+  surplus positional arguments instead of having them silently discarded: the
+  unit-stripped declared parameters are forwarded positionally so the trailing
+  ``*args`` is preserved. ``without_result_units`` was corrected identically
+  (#127).
+- **Correct stale documentation on ``fail_for_dimension_mismatch`` and
+  ``fail_for_unit_mismatch``.** Removed an inherited note claiming ``0`` is
+  treated as having "any dimension"; these helpers compare ``0`` as a
+  dimensionless value (the 0-as-any-dimension convention applies only to
+  ``Quantity`` equality). The ``assign_units.without_result_units`` docstring
+  example was also fixed (#127).
+
+### ``saiunit.lax``
+
+- **Correct the ``lax.index_take`` docstring example**, which showed a transposed
+  result that did not match the function's (JAX-consistent) output (#127).
+
 ## Version 0.4.0
 
 ### Highlights

--- a/saiunit/_base_decorators.py
+++ b/saiunit/_base_decorators.py
@@ -639,8 +639,8 @@ def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[
 
     The decorated function has a 'without_result_units' attribute that
     returns the raw result without unit assignment:
-    >>> func = assign_units(result=volt)(lambda x: x)
-    >>> func(3*mV).without_result_units()
+    >>> func = assign_units(x=volt, result=volt)(lambda x: x)
+    >>> func.without_result_units(3*mV)
     0.003
 
     Notes
@@ -656,13 +656,15 @@ def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[
     if f is missing:
         return partial(assign_units, **au)
 
-    @wraps(f)
-    def new_f(*args, **kwds):
+    def _strip_units(args, kwds):
+        # Strip the declared-unit arguments while preserving the
+        # positional/keyword split, so any surplus positional arguments
+        # (absorbed by the wrapped function's ``*args``) are forwarded rather
+        # than silently dropped.
         arg_names = f.__code__.co_varnames[0: f.__code__.co_argcount]
-        newkeyset = kwds.copy()
-        for n, v in zip(arg_names, args[0: f.__code__.co_argcount]):
-            newkeyset[n] = v
-        for n, v in tuple(newkeyset.items()):
+        n_named = f.__code__.co_argcount
+
+        def convert(n, v):
             if n in au and v is not None:
                 specific_unit = au[n]
 
@@ -683,9 +685,18 @@ def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[
                     v,
                     is_leaf=_is_quantity
                 )
-            newkeyset[n] = v
+            return v
 
-        result = f(**newkeyset)
+        pos_args = [convert(arg_names[i], v) for i, v in enumerate(args[0:n_named])]
+        extra_args = list(args[n_named:])
+        new_kwds = {n: convert(n, v) for n, v in kwds.items()}
+        return pos_args, extra_args, new_kwds
+
+    @wraps(f)
+    def new_f(*args, **kwds):
+        pos_args, extra_args, new_kwds = _strip_units(args, kwds)
+
+        result = f(*pos_args, *extra_args, **new_kwds)
         if "result" in au:
             if isinstance(au["result"], Callable) and au["result"] != bool:
                 expected_result = au["result"](*[get_unit(a) for a in args])
@@ -716,33 +727,8 @@ def assign_units(f: Callable = missing, **au) -> CallableAssignUnit | Callable[[
         return result
 
     def without_result_units(*args, **kwds):
-        arg_names = f.__code__.co_varnames[0: f.__code__.co_argcount]
-        newkeyset = kwds.copy()
-        for n, v in zip(arg_names, args[0: f.__code__.co_argcount]):
-            newkeyset[n] = v
-        for n, v in tuple(newkeyset.items()):
-            if n in au and v is not None:
-                specific_unit = au[n]
-
-                if (
-                    _jtree.structure(specific_unit, is_leaf=_is_quantity)
-                    !=
-                    _jtree.structure(v, is_leaf=_is_quantity)
-                ):
-                    raise TypeError(
-                        f"For argument '{n}', we expect the input type {specific_unit} but got {v}"
-                    )
-
-                v = _jtree.map(
-                    partial(_remove_unit, f.__name__, n),
-                    specific_unit,
-                    v,
-                    is_leaf=_is_quantity
-                )
-            newkeyset[n] = v
-
-        result = f(**newkeyset)
-        return result
+        pos_args, extra_args, new_kwds = _strip_units(args, kwds)
+        return f(*pos_args, *extra_args, **new_kwds)
 
     new_f.without_result_units = without_result_units  # type: ignore[attr-defined]
 

--- a/saiunit/_base_getters.py
+++ b/saiunit/_base_getters.py
@@ -488,11 +488,6 @@ def fail_for_dimension_mismatch(
         If the dimensions of `obj1` and `obj2` do not match (or, if `obj2`
         is ``None``, when `obj1` is not dimensionless).
 
-    Notes
-    -----
-    Implements special checking for ``0``, treating it as having "any
-    dimensions".
-
     Examples
     --------
     .. code-block:: python
@@ -565,11 +560,6 @@ def fail_for_unit_mismatch(
     UnitMismatchError
         If the dimensions of `obj1` and `obj2` do not match (or, if `obj2`
         is ``None``, when `obj1` is not unitless).
-
-    Notes
-    -----
-    Implements special checking for ``0``, treating it as having "any
-    dimensions".
 
     Examples
     --------

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -1490,7 +1490,9 @@ class Quantity:
         if hasattr(m, "nbytes"):
             return m.nbytes
         _reject_lazy_materialization(m, "Quantity.nbytes")
-        return np.asarray(m).nbytes
+        # Stay consistent with ``dtype`` (which canonicalizes Python scalars,
+        # e.g. float -> float32 under x32) instead of ``np.asarray`` (float64).
+        return self.size * np.dtype(self.dtype).itemsize
 
     @property
     def itemsize(self) -> int:
@@ -1499,7 +1501,9 @@ class Quantity:
         if hasattr(m, "itemsize"):
             return m.itemsize
         _reject_lazy_materialization(m, "Quantity.itemsize")
-        return np.asarray(m).itemsize
+        # Stay consistent with ``dtype`` (which canonicalizes Python scalars,
+        # e.g. float -> float32 under x32) instead of ``np.asarray`` (float64).
+        return np.dtype(self.dtype).itemsize
 
     @property
     def strides(self):

--- a/saiunit/_scatter.py
+++ b/saiunit/_scatter.py
@@ -357,13 +357,16 @@ def _scatter_npy_like(xp, mantissa, index, value, op: str, *, mode, fill_value):
 
 
 def _take_masked(value, valid, xp):
-    """Subset ``value`` by ``valid`` if it's a 1D array of matching length."""
+    """Subset ``value`` along axis 0 by ``valid`` if its leading length matches."""
     if isinstance(value, (int, float, complex, np.number)):
         return value
     arr = xp.asarray(value)
     if arr.ndim == 0:
         return arr
-    if arr.ndim == 1 and arr.shape[0] == valid.shape[0]:
+    if arr.ndim >= 1 and arr.shape[0] == valid.shape[0]:
+        # Drop the rows whose scatter index was out of bounds. This must apply
+        # to multi-dimensional values too (e.g. a (n_index, k) block scattered
+        # into a (m, k) target), not just 1-D values.
         return arr[valid]
     # broadcast cases (e.g. value is scalar-like 0-D); return as-is
     return arr

--- a/saiunit/_version.py
+++ b/saiunit/_version.py
@@ -15,5 +15,5 @@
 
 """Project version information."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/saiunit/lax/_lax_keep_unit.py
+++ b/saiunit/lax/_lax_keep_unit.py
@@ -360,8 +360,8 @@ def index_take(
         >>> idx = jnp.array([0, 2])
         >>> result = sulax.index_take(x, (idx,), axes=(1,))
         >>> result.mantissa
-        Array([[1., 3.],
-               [4., 6.]], dtype=float32)
+        Array([[1., 4.],
+               [3., 6.]], dtype=float32)
     """
     require_jax_backend("saiunit.lax.index_take", src)
     return _fun_keep_unit_unary(lax.index_take, src, idxs, axes, **kwargs)


### PR DESCRIPTION
## Summary

Version 0.5.0 is a focused follow-up to the library-wide correctness audit that landed in **0.4.0** (150+ bugs). A second, **execution-verified** pass over the entire public API — the core `Quantity`/`Unit`/`Dimension` types plus every numerical subpackage (`saiunit.math`, `saiunit.lax`, `saiunit.linalg`, `saiunit.fft`, `saiunit.sparse`, `saiunit.autograd`) — re-confirmed those subpackages are already correct and surfaced a small number of remaining edge-case defects in the core and decorator layers, fixed here.

The public API is unchanged, so 0.5.0 is a drop-in upgrade from 0.4.0.

## Fixes

### Core: `Quantity`
- **Indexed `.at[...]` updates with a multi-dimensional value + out-of-bounds indices (NumPy/CuPy).** `q.at[idx].set(value)` (and `add`/`multiply`/`divide`/`min`/`max`) no longer raises a shape-mismatch error when `value` is multi-dimensional and `idx` contains out-of-bounds entries; the out-of-bounds rows are dropped, matching JAX's scatter semantics.
- **`Quantity.itemsize` / `Quantity.nbytes` now agree with `Quantity.dtype`** for scalar (Python-number) mantissas, instead of reporting NumPy's default `float64` width (upholds numpy's `itemsize == dtype.itemsize` invariant).

### Decorators and validation
- **`assign_units` no longer drops variadic positional (`*args`) arguments.** Surplus positional arguments are now forwarded (the unit-stripped declared parameters are passed positionally so trailing `*args` is preserved), matching `check_units`. `without_result_units` was corrected identically.
- **Docs:** removed an inherited, incorrect note claiming `fail_for_dimension_mismatch` / `fail_for_unit_mismatch` treat `0` as having "any dimension" (they compare `0` as dimensionless), and fixed the `assign_units.without_result_units` docstring example.

### `saiunit.lax`
- **Corrected the `lax.index_take` docstring example**, which showed a transposed result not matching the function's (JAX-consistent) output.

## Methodology

The full public API surface was audited by 12 focused, read-only agents (one per module group), each required to reproduce every candidate defect by execution against the local build and to cross-check against `numpy`/`jax` semantics and the existing test suite. Candidates that turned out to encode intentional, tested design choices (e.g. representation-invariant floor division) were rejected rather than "fixed".

## Verification
- `mypy saiunit/` → **Success: no issues found in 125 source files**
- `pytest saiunit/` → **3949 passed, 183 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)