### PR TITLE
fix(docs): correct stale unit examples in array_creation notebook

### DIFF
--- a/docs/unit_operations/array_creation.ipynb
+++ b/docs/unit_operations/array_creation.ipynb
@@ -13,22 +13,30 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "The functions listed below are designed to create `array` or `Quantity` with specific properties, such as filled with a certain value, identity matrices, or arrays with ones on the diagonal. These functions are part of the `saiunit.math` module and are tailored to handle both numerical `array` and `Quantity` with units."
+   "source": [
+    "The functions listed below are designed to create `array` or `Quantity` with specific properties, such as filled with a certain value, identity matrices, or arrays with ones on the diagonal. These functions are part of the `saiunit.math` module and are tailored to handle both numerical `array` and `Quantity` with units."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:31.388017800Z",
      "start_time": "2026-03-04T15:10:30.451361100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:14.078188Z",
+     "iopub.status.busy": "2026-06-14T09:17:14.078021Z",
+     "iopub.status.idle": "2026-06-14T09:17:15.364895Z",
+     "shell.execute_reply": "2026-06-14T09:17:15.364108Z"
     }
    },
+   "outputs": [],
    "source": [
     "import saiunit as u\n",
     "import jax.numpy as jnp"
-   ],
-   "outputs": [],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "markdown",
@@ -45,15 +53,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:31.992977100Z",
      "start_time": "2026-03-04T15:10:31.406532700Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:15.367148Z",
+     "iopub.status.busy": "2026-06-14T09:17:15.366802Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.427162Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.426313Z"
     }
    },
-   "source": [
-    "u.math.asarray([1, 2, 3])                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -66,24 +78,30 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 2
+   "source": [
+    "u.math.asarray([1, 2, 3])                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.261432Z",
      "start_time": "2026-03-04T15:10:32.090526600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.460363Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.459999Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.524733Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.523787Z"
     }
    },
-   "source": [
-    "u.math.asarray([1, 2, 3], unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Array([1, 2, 3], dtype=int32)"
+       "Quantity([1. 2.], \"s\")"
       ]
      },
      "execution_count": 3,
@@ -91,20 +109,26 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 3
+   "source": [
+    "# same dimension, different magnitude -> converted to the provided unit\n",
+    "u.math.asarray([1000 * u.ms, 2000 * u.ms], unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.366911800Z",
      "start_time": "2026-03-04T15:10:32.263434200Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.526657Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.526429Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.579478Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.578447Z"
     }
    },
-   "source": [
-    "# check if the input has the same unit as the provided unit\n",
-    "u.math.asarray([1 * u.second, 2 * u.second], unit=u.second)"
-   ],
    "outputs": [
     {
      "data": {
@@ -117,23 +141,26 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 4
+   "source": [
+    "# check if the input has the same unit as the provided unit\n",
+    "u.math.asarray([1 * u.second, 2 * u.second], unit=u.second)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.437720200Z",
      "start_time": "2026-03-04T15:10:32.370083Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.581216Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.580960Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.586206Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.585554Z"
     }
    },
-   "source": [
-    "# fails because the input has a different unit\n",
-    "try:\n",
-    "    u.math.asarray([1 * u.second, 2 * u.second], unit=u.ampere)\n",
-    "except Exception as e:\n",
-    "    print(e)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -143,7 +170,13 @@
      ]
     }
    ],
-   "execution_count": 5
+   "source": [
+    "# fails because the input has a different unit\n",
+    "try:\n",
+    "    u.math.asarray([1 * u.second, 2 * u.second], unit=u.ampere)\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -155,15 +188,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.515230900Z",
      "start_time": "2026-03-04T15:10:32.463641300Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.588133Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.587909Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.630040Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.629110Z"
     }
    },
-   "source": [
-    "u.math.arange(5)                                    # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -176,19 +213,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 6
+   "source": [
+    "u.math.arange(5)                                    # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.582604Z",
      "start_time": "2026-03-04T15:10:32.516238100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.631862Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.631633Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.746255Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.745367Z"
     }
    },
-   "source": [
-    "u.math.arange(5 * u.second, step=1 * u.second) # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -201,19 +244,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 7
+   "source": [
+    "u.math.arange(5 * u.second, step=1 * u.second) # return a Quantity"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.615306100Z",
      "start_time": "2026-03-04T15:10:32.583708900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.747790Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.747636Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.839206Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.838350Z"
     }
    },
-   "source": [
-    "u.math.arange(3, 9, 1)                                          # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -226,19 +275,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 8
+   "source": [
+    "u.math.arange(3, 9, 1)                                          # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.683835600Z",
      "start_time": "2026-03-04T15:10:32.615306100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.840816Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.840654Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.870405Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.869650Z"
     }
    },
-   "source": [
-    "u.math.arange(3 * u.second, 9 * u.second, 1 * u.second)   # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -251,7 +306,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 9
+   "source": [
+    "u.math.arange(3 * u.second, 9 * u.second, 1 * u.second)   # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -263,17 +320,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.773784800Z",
      "start_time": "2026-03-04T15:10:32.686941100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.872435Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.872195Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.945741Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.945011Z"
     }
    },
-   "source": [
-    "a = jnp.arange(9)\n",
-    "\n",
-    "u.math.array_split(a, 3)      # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -288,21 +347,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 10
+   "source": [
+    "a = jnp.arange(9)\n",
+    "\n",
+    "u.math.array_split(a, 3)      # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:32.824553800Z",
      "start_time": "2026-03-04T15:10:32.774820Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.947760Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.947552Z",
+     "iopub.status.idle": "2026-06-14T09:17:17.978727Z",
+     "shell.execute_reply": "2026-06-14T09:17:17.978072Z"
     }
    },
-   "source": [
-    "q = jnp.arange(9) * u.second\n",
-    "\n",
-    "u.math.array_split(q, 3)   # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -315,7 +380,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 11
+   "source": [
+    "q = jnp.arange(9) * u.second\n",
+    "\n",
+    "u.math.array_split(q, 3)   # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -327,15 +396,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.062212900Z",
      "start_time": "2026-03-04T15:10:32.825625100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:17.980328Z",
+     "iopub.status.busy": "2026-06-14T09:17:17.980140Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.124813Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.124050Z"
     }
    },
-   "source": [
-    "u.math.linspace(0, 10, 5)                               # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -348,19 +421,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 12
+   "source": [
+    "u.math.linspace(0, 10, 5)                               # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.179765100Z",
      "start_time": "2026-03-04T15:10:33.085363600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.126554Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.126359Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.158155Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.157515Z"
     }
    },
-   "source": [
-    "u.math.linspace(0 * u.second, 10 * u.second, 5)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -373,7 +452,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 13
+   "source": [
+    "u.math.linspace(0 * u.second, 10 * u.second, 5)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -385,15 +466,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.431479100Z",
      "start_time": "2026-03-04T15:10:33.223035300Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.159773Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.159611Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.203291Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.202581Z"
     }
    },
-   "source": [
-    "u.math.logspace(0, 10, 5)                               # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -407,32 +492,41 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 14
+   "source": [
+    "u.math.logspace(0, 10, 5)                               # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.561577300Z",
      "start_time": "2026-03-04T15:10:33.456551400Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.204920Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.204729Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.209198Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.208524Z"
     }
    },
-   "source": [
-    "u.math.logspace(0 * u.second, 10 * u.second, 5)    # return a Quantity"
-   ],
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Quantity([1.0000000e+00 3.1622775e+02 1.0000000e+05 3.1622776e+07 1.0000000e+10], \"s\")"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "logspace requires dimensionless `start`, got unit Unit(\"s\"). `base ** x` is intrinsically dimensionless; pass a plain scalar/array instead. (unit is s).\n"
+     ]
     }
    ],
-   "execution_count": 15
+   "source": [
+    "# logspace is intrinsically dimensionless (base ** x), so units are not allowed\n",
+    "try:\n",
+    "    u.math.logspace(0 * u.second, 10 * u.second, 5)\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -444,18 +538,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.737786300Z",
      "start_time": "2026-03-04T15:10:33.570692700Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.210916Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.210738Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.292582Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.292035Z"
     }
    },
-   "source": [
-    "x = jnp.array([1, 2, 3])\n",
-    "y = jnp.array([4, 5])\n",
-    "\n",
-    "u.math.meshgrid(x, y)           # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -471,22 +566,28 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 16
+   "source": [
+    "x = jnp.array([1, 2, 3])\n",
+    "y = jnp.array([4, 5])\n",
+    "\n",
+    "u.math.meshgrid(x, y)           # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:33.969708300Z",
      "start_time": "2026-03-04T15:10:33.761812Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.294819Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.294574Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.341076Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.340431Z"
     }
    },
-   "source": [
-    "x_q = jnp.array([1, 2, 3]) * u.second\n",
-    "y_q = jnp.array([4, 5]) * u.second\n",
-    "\n",
-    "u.math.meshgrid(x_q, y_q)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -502,7 +603,12 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 17
+   "source": [
+    "x_q = jnp.array([1, 2, 3]) * u.second\n",
+    "y_q = jnp.array([4, 5]) * u.second\n",
+    "\n",
+    "u.math.meshgrid(x_q, y_q)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -517,17 +623,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.079169700Z",
      "start_time": "2026-03-04T15:10:34.000515600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.343473Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.343217Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.399018Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.398006Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.vander(a)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -542,7 +650,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 18
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.vander(a)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -563,15 +675,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.140831700Z",
      "start_time": "2026-03-04T15:10:34.079169700Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.401099Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.400918Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.441057Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.440130Z"
     }
    },
-   "source": [
-    "u.math.full(3, 4)                   # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -584,19 +700,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 19
+   "source": [
+    "u.math.full(3, 4)                   # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.201697300Z",
      "start_time": "2026-03-04T15:10:34.141831400Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.443094Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.442881Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.487422Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.486529Z"
     }
    },
-   "source": [
-    "u.math.full(3, 4 * u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -609,7 +731,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 20
+   "source": [
+    "u.math.full(3, 4 * u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -621,15 +745,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.270603600Z",
      "start_time": "2026-03-04T15:10:34.204732600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.489453Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.489258Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.527005Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.526094Z"
     }
    },
-   "source": [
-    "u.math.empty((2, 2))                    # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -643,19 +771,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 21
+   "source": [
+    "u.math.empty((2, 2))                    # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.329150900Z",
      "start_time": "2026-03-04T15:10:34.272586500Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.528572Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.528430Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.570172Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.569159Z"
     }
    },
-   "source": [
-    "u.math.empty((2, 2), unit=u.second) # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -669,7 +803,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 22
+   "source": [
+    "u.math.empty((2, 2), unit=u.second) # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -681,15 +817,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.343505600Z",
      "start_time": "2026-03-04T15:10:34.330542100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.572534Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.572193Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.578097Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.577391Z"
     }
    },
-   "source": [
-    "u.math.ones((2, 2))                     # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -703,19 +843,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "source": [
+    "u.math.ones((2, 2))                     # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.357404400Z",
      "start_time": "2026-03-04T15:10:34.343505600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.579913Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.579636Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.586326Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.585523Z"
     }
    },
-   "source": [
-    "u.math.ones((2, 2), unit=u.second)  # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -729,7 +875,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 24
+   "source": [
+    "u.math.ones((2, 2), unit=u.second)  # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -741,15 +889,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.370243400Z",
      "start_time": "2026-03-04T15:10:34.357404400Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.588389Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.588197Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.594262Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.593477Z"
     }
    },
-   "source": [
-    "u.math.zeros((2, 2))                    # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -763,19 +915,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 25
+   "source": [
+    "u.math.zeros((2, 2))                    # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.384978100Z",
      "start_time": "2026-03-04T15:10:34.370243400Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.596568Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.596298Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.601716Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.601036Z"
     }
    },
-   "source": [
-    "u.math.zeros((2, 2), unit=u.second) # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -789,7 +947,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 26
+   "source": [
+    "u.math.zeros((2, 2), unit=u.second) # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -801,17 +961,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.430959600Z",
      "start_time": "2026-03-04T15:10:34.384978100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.603509Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.603347Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.646990Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.646344Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.full_like(a, 4)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -824,21 +986,26 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 27
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.full_like(a, 4)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "try:\n",
-    "    u.math.full_like(a, 4 * u.second)         # return a Quantity\n",
-    "except Exception as e:\n",
-    "    print(e)"
-   ],
+   "execution_count": 28,
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.442427300Z",
      "start_time": "2026-03-04T15:10:34.430959600Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.648458Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.648321Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.651536Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.650771Z"
     }
    },
    "outputs": [
@@ -850,7 +1017,12 @@
      ]
     }
    ],
-   "execution_count": 28
+   "source": [
+    "try:\n",
+    "    u.math.full_like(a, 4 * u.second)         # return a Quantity\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -862,17 +1034,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.456820700Z",
      "start_time": "2026-03-04T15:10:34.443476Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.653417Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.653175Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.658584Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.657673Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.empty_like(a)       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -885,21 +1059,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 29
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.empty_like(a)       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.474343300Z",
      "start_time": "2026-03-04T15:10:34.458282600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.660214Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.660086Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.665660Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.664942Z"
     }
    },
-   "source": [
-    "q = jnp.array([1, 2, 3]) * u.second\n",
-    "\n",
-    "u.math.empty_like(q)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -912,7 +1092,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 30
+   "source": [
+    "q = jnp.array([1, 2, 3]) * u.second\n",
+    "\n",
+    "u.math.empty_like(q)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -924,17 +1108,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 31,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.584606100Z",
      "start_time": "2026-03-04T15:10:34.510794500Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.667124Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.666995Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.672338Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.671494Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.ones_like(a)       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -947,21 +1133,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 31
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.ones_like(a)       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 32,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:34.606396100Z",
      "start_time": "2026-03-04T15:10:34.586050900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.674345Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.674042Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.681713Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.680918Z"
     }
    },
-   "source": [
-    "q = jnp.array([1, 2, 3]) * u.second\n",
-    "\n",
-    "u.math.ones_like(q)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -974,7 +1166,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 32
+   "source": [
+    "q = jnp.array([1, 2, 3]) * u.second\n",
+    "\n",
+    "u.math.ones_like(q)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -986,17 +1182,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 33,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:35.017005400Z",
      "start_time": "2026-03-04T15:10:34.673237600Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.683796Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.683571Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.690062Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.688994Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.zeros_like(a)       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1009,21 +1207,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 33
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.zeros_like(a)       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 34,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:35.229875600Z",
      "start_time": "2026-03-04T15:10:35.075363900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.692493Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.692221Z",
+     "iopub.status.idle": "2026-06-14T09:17:18.700098Z",
+     "shell.execute_reply": "2026-06-14T09:17:18.699128Z"
     }
    },
-   "source": [
-    "q = jnp.array([1, 2, 3]) * u.second\n",
-    "\n",
-    "u.math.zeros_like(q)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1036,7 +1240,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 34
+   "source": [
+    "q = jnp.array([1, 2, 3]) * u.second\n",
+    "\n",
+    "u.math.zeros_like(q)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1048,17 +1256,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 35,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:35.598787Z",
      "start_time": "2026-03-04T15:10:35.258585900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:18.703863Z",
+     "iopub.status.busy": "2026-06-14T09:17:18.703465Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.033335Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.032363Z"
     }
    },
-   "source": [
-    "a = jnp.zeros((3, 3))\n",
-    "\n",
-    "u.math.fill_diagonal(a, 4)      # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1073,21 +1283,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 35
+   "source": [
+    "a = jnp.zeros((3, 3))\n",
+    "\n",
+    "u.math.fill_diagonal(a, 4)      # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 36,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:35.681172800Z",
      "start_time": "2026-03-04T15:10:35.599294700Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.036372Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.036132Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.070791Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.069972Z"
     }
    },
-   "source": [
-    "q = jnp.zeros((3, 3)) * u.second\n",
-    "\n",
-    "u.math.fill_diagonal(q, 4 * u.second)   # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1102,7 +1318,11 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 36
+   "source": [
+    "q = jnp.zeros((3, 3)) * u.second\n",
+    "\n",
+    "u.math.fill_diagonal(q, 4 * u.second)   # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1123,15 +1343,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 37,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:35.938555200Z",
      "start_time": "2026-03-04T15:10:35.684617Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.072633Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.072395Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.218429Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.217770Z"
     }
    },
-   "source": [
-    "u.math.eye(3)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1146,19 +1370,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 37
+   "source": [
+    "u.math.eye(3)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 38,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.053545400Z",
      "start_time": "2026-03-04T15:10:35.942874100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.219992Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.219833Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.226526Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.225716Z"
     }
    },
-   "source": [
-    "u.math.eye(3, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1173,7 +1403,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 38
+   "source": [
+    "u.math.eye(3, unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1185,15 +1417,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 39,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.087742400Z",
      "start_time": "2026-03-04T15:10:36.056066300Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.228461Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.228290Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.234582Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.233706Z"
     }
    },
-   "source": [
-    "u.math.identity(3)                  # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1208,19 +1444,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 39
+   "source": [
+    "u.math.identity(3)                  # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 40,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.175455300Z",
      "start_time": "2026-03-04T15:10:36.114283200Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.236461Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.236312Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.243537Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.242591Z"
     }
    },
-   "source": [
-    "u.math.identity(3, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1235,7 +1477,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 40
+   "source": [
+    "u.math.identity(3, unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1247,16 +1491,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 41,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.273780900Z",
      "start_time": "2026-03-04T15:10:36.177465100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.246109Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.245908Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.323566Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.322661Z"
     }
    },
-   "source": [
-    "u.math.tri(3)                       # return a jax.Array"
-   ],
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/d/codes/projects/saiunit/.claude/worktrees/fix-doc-notebooks/saiunit/math/_fun_array_creation.py:290: UserWarning: Explicitly requested dtype float64 requested in tri is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/jax-ml/jax#current-gotchas for more.\n",
+      "  arr = xp.tri(N, M, k, dtype=dtype)\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -1270,19 +1526,25 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 41
+   "source": [
+    "u.math.tri(3)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 42,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.298065500Z",
      "start_time": "2026-03-04T15:10:36.275779900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.325789Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.325558Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.332356Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.331748Z"
     }
    },
-   "source": [
-    "u.math.tri(3, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1297,7 +1559,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 42
+   "source": [
+    "u.math.tri(3, unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1309,17 +1573,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 43,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.355291300Z",
      "start_time": "2026-03-04T15:10:36.300065900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.335233Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.334889Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.374255Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.373202Z"
     }
    },
-   "source": [
-    "a = jnp.array([1, 2, 3])\n",
-    "\n",
-    "u.math.diag(a)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1334,19 +1600,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 43
+   "source": [
+    "a = jnp.array([1, 2, 3])\n",
+    "\n",
+    "u.math.diag(a)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 44,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.412976300Z",
      "start_time": "2026-03-04T15:10:36.356729500Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.376390Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.376136Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.409199Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.408430Z"
     }
    },
-   "source": [
-    "u.math.diag(a, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1361,7 +1635,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 44
+   "source": [
+    "u.math.diag(a, unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1376,17 +1652,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 45,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.468278100Z",
      "start_time": "2026-03-04T15:10:36.413977200Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.410898Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.410742Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.453031Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.452265Z"
     }
    },
-   "source": [
-    "a = jnp.ones((3, 3))\n",
-    "\n",
-    "u.math.diag(a)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1399,19 +1677,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 45
+   "source": [
+    "a = jnp.ones((3, 3))\n",
+    "\n",
+    "u.math.diag(a)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 46,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.508031900Z",
      "start_time": "2026-03-04T15:10:36.469279800Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.455240Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.455051Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.485726Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.484911Z"
     }
    },
-   "source": [
-    "u.math.diag(a, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1424,7 +1710,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 46
+   "source": [
+    "u.math.diag(a, unit=u.second)    # return a Quantity"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1439,17 +1727,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 47,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.557376100Z",
      "start_time": "2026-03-04T15:10:36.509262100Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.487593Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.487397Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.523513Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.522451Z"
     }
    },
-   "source": [
-    "a = jnp.ones((3, 3))\n",
-    "\n",
-    "u.math.tril(a)                       # return a jax.Array"
-   ],
    "outputs": [
     {
      "data": {
@@ -1464,19 +1754,27 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 47
+   "source": [
+    "a = jnp.ones((3, 3))\n",
+    "\n",
+    "u.math.tril(a)                       # return a jax.Array"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 48,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2026-03-04T15:10:36.576482900Z",
      "start_time": "2026-03-04T15:10:36.558375900Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-06-14T09:17:19.525795Z",
+     "iopub.status.busy": "2026-06-14T09:17:19.525544Z",
+     "iopub.status.idle": "2026-06-14T09:17:19.532401Z",
+     "shell.execute_reply": "2026-06-14T09:17:19.531614Z"
     }
    },
-   "source": [
-    "u.math.tril(a, unit=u.second)    # return a Quantity"
-   ],
    "outputs": [
     {
      "data": {
@@ -1491,7 +1789,9 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 48
+   "source": [
+    "u.math.tril(a, unit=u.second)    # return a Quantity"
+   ]
   }
  ],
  "metadata": {
@@ -1510,7 +1810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Executed all 31 source notebooks under `docs/` (excluding `docs/_build/` build artifacts). Two cells in `docs/unit_operations/array_creation.ipynb` raised `UnitMismatchError` because they used examples inconsistent with saiunit's documented unit semantics. This fixes both so every notebook runs cleanly.

## Fixes

- **`asarray([1, 2, 3], unit=second)`** → a raw dimensionless list cannot be *converted* to seconds. `asarray` with an explicit `unit=` performs strict conversion — consistent with its docstring, the audit comment in `_fun_array_creation.py`, and the notebook's own markdown. The cell now converts a same-dimension quantity across magnitudes (`ms` → `s`), matching the surrounding prose ("same dimension but different magnitude → converted to the provided unit").
- **`logspace(0*s, 10*s, 5)`** → `logspace` computes `base ** x`, which is intrinsically dimensionless and rejects unitful `start`/`stop` (per its docstring). The cell now demonstrates that constraint via `try/except`, matching the notebook's existing idiom for showing expected errors.

No library code changed — both were stale documentation examples. Only `docs/unit_operations/array_creation.ipynb` is modified (2 source cells + re-executed outputs).

## Verification

```
==== SUMMARY ====
31 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update unit operations array creation documentation examples to align with saiunit’s unit semantics and ensure the notebook executes cleanly.

Bug Fixes:
- Correct asarray example to demonstrate conversion between quantities of the same dimension and magnitude scaling instead of converting a raw list to a unitful quantity.
- Adjust logspace example to illustrate that it only accepts dimensionless inputs by showing the expected error when units are provided.

Documentation:
- Refresh docs/unit_operations/array_creation.ipynb with corrected code cells and re-executed outputs so that all documented examples run successfully.