### PR TITLE
fix: support jax<0.10 (argpartition + linalg kwargs test)

### DIFF
--- a/.github/workflows/CI-daily.yml
+++ b/.github/workflows/CI-daily.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-        jax-version: ["0.6.0", "0.7.2", "0.8.0", ""]
+        jax-version: ["0.7.0", "0.8.0", "0.9.0", ""]
 
     steps:
       - name: Cancel Previous Runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',

--- a/saiunit/custom_array.py
+++ b/saiunit/custom_array.py
@@ -455,14 +455,20 @@ class CustomArray:
 
     def argpartition(self, kth, axis: int = -1, kind: str = 'introselect', order=None):
         """Returns the indices that would partition this array."""
-        # JAX's ``argpartition`` accepts neither ``kind`` nor ``order``;
-        # forward them only when they deviate from numpy's defaults.
-        kwargs = {}
-        if kind != 'introselect':
-            kwargs['kind'] = kind
-        if order is not None:
-            kwargs['order'] = order
-        return self.data.argpartition(kth, axis, **kwargs)
+        if isinstance(self.data, np.ndarray):
+            # NumPy's ``argpartition`` accepts ``kind`` and ``order``; forward
+            # them only when they deviate from numpy's defaults.
+            kwargs: dict[str, Any] = {}
+            if kind != 'introselect':
+                kwargs['kind'] = kind
+            if order is not None:
+                kwargs['order'] = order
+            return self.data.argpartition(kth, axis, **kwargs)
+        # JAX's bound ``Array.argpartition`` method is broken in jax<0.10 (it
+        # references a removed internal symbol), so use the functional API,
+        # which works across versions. JAX accepts neither ``kind`` nor
+        # ``order``, so they are intentionally dropped.
+        return jnp.argpartition(self.data, kth, axis=axis)
 
     def argsort(self, axis=-1, kind=None, order=None):
         """Returns the indices that would sort this array."""

--- a/saiunit/lax/_lax_linalg_test.py
+++ b/saiunit/lax/_lax_linalg_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import jax
 import jax.numpy as jnp
 import pytest
 from absl.testing import parameterized
@@ -533,18 +534,24 @@ def test_linalg_kwargs_forwarding():
     A = jnp.array([[1.0, 2.0], [3.0, 4.0]]) * u.second
     H = jnp.array([[2.0, 1.0], [1.0, 3.0]]) * u.second
 
+    # ``is_hermitian`` is accepted by jax's qdwh across all supported versions.
     u_mat, h, num_iters, is_converged = ulax.qdwh(A, is_hermitian=False)
     assert u.get_unit(h) == u.second
 
-    w, vl, vr = ulax.eig(A, implementation=None)
+    # The kwargs below were introduced in later jax releases; forward each one
+    # only where the underlying jax function accepts it.
+    eig_kw = {'implementation': None} if jax.__version_info__ >= (0, 8, 0) else {}
+    w, vl, vr = ulax.eig(A, **eig_kw)
     assert u.get_unit(w) == u.second
 
-    v, w2 = ulax.eigh(H, implementation=None)
+    eigh_kw = {'implementation': None} if jax.__version_info__ >= (0, 9, 0) else {}
+    v, w2 = ulax.eigh(H, **eigh_kw)
     assert u.get_unit(w2) == u.second
 
     dl = jnp.array([0.0, 1.0, 1.0])
     d = jnp.array([2.0, 2.0, 2.0])
     du = jnp.array([1.0, 1.0, 0.0])
     b = jnp.array([[1.0], [2.0], [3.0]]) * u.meter
-    x = ulax.tridiagonal_solve(dl, d, du, b, perturb_singular=True)
+    ts_kw = {'perturb_singular': True} if jax.__version_info__ >= (0, 10, 0) else {}
+    x = ulax.tridiagonal_solve(dl, d, du, b, **ts_kw)
     assert u.get_unit(x) == u.meter


### PR DESCRIPTION
## Summary

The full test suite failed on jax<0.10 (verified locally against jax 0.7.0, 0.8.0, 0.9.0). Two failures, both now fixed; full suite is green on all three (3725 passed, 405 skipped each).

### Fixes

- **`custom_array.argpartition`** — JAX's bound `Array.argpartition` method is broken in jax<0.10 (it references the removed internal `lax_numpy.argpartition`). Now dispatches numpy arrays to the bound method (preserving `kind`/`order`) and jax arrays to the functional `jnp.argpartition`, which works across all jax versions. No behavior change on jax>=0.10.
- **`_lax_linalg_test.test_linalg_kwargs_forwarding`** — version-specific jax kwargs are gated behind `jax.__version_info__`:
  - `eig(implementation=...)` added in jax 0.8
  - `eigh(implementation=...)` added in jax 0.9
  - `tridiagonal_solve(perturb_singular=...)` added in jax 0.10

  `qdwh(is_hermitian=...)` (available on all versions) still exercises kwarg forwarding on every jax version.

### Housekeeping

- **CI-daily**: matrix now tests jax `0.7.0`, `0.8.0`, `0.9.0`, and latest.
- **pyproject**: drop the `Python :: 3.10` classifier.

## Verification

- `pytest saiunit/` → 3725 passed, 405 skipped on each of jax 0.7.0 / 0.8.0 / 0.9.0
- `mypy saiunit/` → no new errors (the single pre-existing `_compatible_import.py:56` note is a jax<0.10 environment artifact; CI type_check runs under jax>=0.10 where the symbol exists)

## Summary by Sourcery

Restore compatibility with older JAX versions and adjust tests and CI to match supported JAX/JAX/Python versions.

Bug Fixes:
- Route custom array argpartition to NumPy for ndarray inputs and to jnp.argpartition for JAX arrays to avoid failures on jax<0.10.
- Gate linalg kwarg forwarding tests on JAX version so they only pass kwargs supported by the underlying JAX APIs.

Build:
- Update CI daily workflow matrix to test JAX 0.7.0, 0.8.0, 0.9.0, and latest.

CI:
- Update CI daily workflow matrix to cover newer JAX 0.7.0–0.9.0 versions instead of older entries.

Tests:
- Relax linalg kwargs forwarding test to conditionally supply version-specific keyword arguments based on JAX version info.

Chores:
- Remove the Python 3.10 classifier from pyproject metadata.