### PR TITLE
release: v0.5.1 — harden pytree reconstruction + require Python 3.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## Version 0.5.1
+
+### Highlights
+
+Version 0.5.1 is a small maintenance release that hardens JAX pytree
+reconstruction for the core ``Quantity`` type and raises the minimum supported
+Python version to 3.11. The public API is unchanged, so 0.5.1 is a drop-in
+upgrade from 0.5.0.
+
+### Core: ``Quantity``
+
+- **Harden ``Quantity`` pytree reconstruction against non-array leaves.**
+  ``Quantity.tree_unflatten`` now rebuilds the instance directly rather than
+  routing through ``__init__``. JAX legitimately feeds non-array placeholders
+  through ``tree_unflatten`` when it inspects or renders tree structure — for
+  example, the ``ShapedArray.str_short()`` strings used to build ``custom_vjp``
+  structure-mismatch messages. Such placeholders previously tripped the
+  ``str``/``bytes`` guard that ``__init__`` applies to user input and raised a
+  spurious ``TypeError``. Reconstruction now round-trips any leaf the framework
+  supplies, while still enforcing the single-child invariant and normalising a
+  missing unit to ``UNITLESS`` (#131).
+
+### Packaging
+
+- **Raise the minimum supported Python to 3.11.** ``requires-python`` is now
+  ``>=3.11``; Python 3.10 is no longer tested or supported. The corresponding
+  ``Programming Language :: Python :: 3.10`` classifier had already been
+  dropped (#131).
+
+### Tests
+
+- Added comprehensive pytree round-trip coverage for ``Quantity`` and
+  ``CustomArray`` subclasses — including framework-supplied placeholder leaves
+  and the ``jit`` / ``grad`` / ``vmap`` / ``eval_shape`` / ``tree_map``
+  transform paths — and a regression test ensuring ``brainstate.State``-backed
+  ``CustomArray`` subclasses, whose reconstruction depends on ``__init__``
+  running, continue to round-trip correctly (#131).
+
 ## Version 0.5.0
 
 ### Highlights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ name = "saiunit"
 description = "Enabling Unit-aware Computations for AI-driven Scientific Computing."
 readme = 'README.md'
 license = 'Apache-2.0'
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 authors = [{ name = 'SAIUnit Developers', email = 'chao.brain@qq.com' }]
 classifiers = [
     'Natural Language :: English',

--- a/saiunit/_base_quantity.py
+++ b/saiunit/_base_quantity.py
@@ -3905,7 +3905,17 @@ class Quantity:
         Returns:
           The Quantity object.
         """
-        return cls(*values, unit=unit)  # type: ignore[misc]
+        # Pytree reconstruction must round-trip *any* leaf the framework supplies,
+        # including non-array placeholders that JAX passes purely to inspect or
+        # render tree structure (e.g. ShapedArray.str_short() strings fed through
+        # tree_unflatten when building custom_vjp structure-mismatch messages).
+        # Such placeholders must not trip the user-facing str/bytes guard in
+        # __init__; build the instance directly instead.
+        obj = object.__new__(cls)
+        mantissa, = values
+        obj._mantissa = mantissa
+        obj._unit = unit if unit is not None else UNITLESS
+        return obj
 
     def cuda(self, device=None) -> 'Quantity':
         from saiunit._jax_compat import device_put as _device_put, devices as _devices

--- a/saiunit/_base_quantity_test.py
+++ b/saiunit/_base_quantity_test.py
@@ -438,6 +438,130 @@ class TestQuantityPytree:
         assert jnp.allclose(result.mantissa, 6.0)
         assert result.unit == _metre
 
+    # -- tree_unflatten guard-bypass contract ------------------------------
+    # tree_unflatten reconstructs the instance directly (object.__new__) and
+    # must round-trip *any* leaf the framework supplies verbatim, without
+    # re-running __init__'s validation/coercion.
+
+    def test_tree_unflatten_string_leaf_bypasses_guard(self):
+        # JAX feeds non-array placeholders (e.g. ShapedArray.str_short()
+        # strings) through tree_unflatten when rendering tree structure. These
+        # must not trip the str/bytes guard that __init__ applies to user input.
+        q = Quantity.tree_unflatten(_metre, ("f32[3]",))
+        assert isinstance(q, Quantity)
+        assert q._mantissa == "f32[3]"
+        assert q._unit is _metre
+
+    def test_tree_unflatten_bytes_leaf_bypasses_guard(self):
+        q = Quantity.tree_unflatten(_metre, (b"placeholder",))
+        assert q._mantissa == b"placeholder"
+
+    def test_tree_unflatten_does_not_coerce_leaf(self):
+        # __init__ would convert a list mantissa into an array; tree_unflatten
+        # must store the supplied leaf by identity, proving __init__ is bypassed.
+        leaf = [1, 2, 3]
+        q = Quantity.tree_unflatten(_metre, (leaf,))
+        assert q._mantissa is leaf
+        assert isinstance(q._mantissa, list)
+
+    def test_tree_unflatten_preserves_arbitrary_leaf_identity(self):
+        sentinel = object()
+        q = Quantity.tree_unflatten(_metre, (sentinel,))
+        assert q._mantissa is sentinel
+
+    def test_tree_unflatten_none_unit_normalizes_to_unitless(self):
+        q = Quantity.tree_unflatten(None, (5.0,))
+        assert q._unit is UNITLESS
+
+    def test_tree_unflatten_preserves_unit_identity(self):
+        q = Quantity.tree_unflatten(_metre, (1.0,))
+        assert q._unit is _metre
+
+    def test_tree_unflatten_returns_quantity_instance(self):
+        assert isinstance(Quantity.tree_unflatten(_metre, (1.0,)), Quantity)
+
+    @pytest.mark.parametrize("values", [(), (1.0, 2.0)])
+    def test_tree_unflatten_requires_single_child(self, values):
+        # tree_flatten always emits exactly one child; a differently-shaped
+        # children tuple should raise loudly rather than mis-reconstruct.
+        with pytest.raises(ValueError):
+            Quantity.tree_unflatten(_metre, values)
+
+    # -- round-trip fidelity ----------------------------------------------
+
+    @pytest.mark.parametrize(
+        "mantissa,unit",
+        [
+            (3.0, _metre),
+            (jnp.array([1.0, 2.0, 3.0]), _metre),
+            (jnp.arange(6.0).reshape(2, 3), _second),
+            (1.0, UNITLESS),
+            (2.5, _metre / _second),
+        ],
+    )
+    def test_round_trip_preserves_value_and_unit(self, mantissa, unit):
+        q = Quantity(mantissa, unit=unit)
+        leaves, treedef = jax.tree.flatten(q)
+        q2 = treedef.unflatten(leaves)
+        assert jnp.allclose(q.mantissa, q2.mantissa)
+        assert q.unit == q2.unit
+
+    def test_round_trip_preserves_numpy_backend(self):
+        q = Quantity(np.array([1.0, 2.0, 3.0]), unit=_metre)
+        leaves, treedef = jax.tree.flatten(q)
+        q2 = treedef.unflatten(leaves)
+        assert isinstance(q2.mantissa, np.ndarray)
+
+    # -- high-level JAX transforms that exercise unflatten -----------------
+
+    def test_eval_shape_roundtrip(self):
+        # eval_shape reconstructs the output pytree from abstract leaves —
+        # the natural analogue of the placeholder-leaf path.
+        q = Quantity(jnp.array([1.0, 2.0, 3.0]), unit=_metre)
+        out = jax.eval_shape(lambda x: x * 2, q)
+        assert isinstance(out, Quantity)
+        assert out.unit == _metre
+        assert out.mantissa.shape == (3,)
+
+    def test_tree_map_roundtrip(self):
+        q = Quantity(jnp.array([1.0, 2.0]), unit=_metre)
+        q2 = jax.tree.map(lambda x: x + 1, q)
+        assert q2.unit == _metre
+        assert jnp.allclose(q2.mantissa, jnp.array([2.0, 3.0]))
+
+    def test_vmap_roundtrip(self):
+        q = Quantity(jnp.arange(6.0).reshape(3, 2), unit=_metre)
+        result = jax.vmap(lambda row: row * 2)(q)
+        assert result.unit == _metre
+        assert jnp.allclose(result.mantissa, q.mantissa * 2)
+
+    def test_grad_through_quantity(self):
+        q = Quantity(jnp.array([1.0, 2.0]), unit=_metre)
+        g = jax.grad(lambda x: (x / _metre).sum())(q)
+        assert isinstance(g, Quantity)
+
+    def test_custom_vjp_structure_mismatch_raises_jax_error(self):
+        # A bwd rule returning the wrong structure makes JAX render a
+        # structure-mismatch message. Reconstruction during that path must
+        # surface JAX's error, never saiunit's str/bytes guard.
+        @jax.custom_vjp
+        def f(x):
+            return x * 2.0
+
+        def f_fwd(x):
+            return f(x), None
+
+        def f_bwd(res, g):
+            return (g, g)  # two cotangents for one input
+
+        f.defvjp(f_fwd, f_bwd)
+
+        q = Quantity(jnp.array([1.0, 2.0, 3.0]), unit=_metre)
+        with pytest.raises(TypeError) as excinfo:
+            out, vjp = jax.vjp(f, q)
+            vjp(out)
+        assert "Cannot create a Quantity from a str" not in str(excinfo.value)
+
 
 # =========================================================================
 # Wrapping functions

--- a/saiunit/_version.py
+++ b/saiunit/_version.py
@@ -15,5 +15,5 @@
 
 """Project version information."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/saiunit/custom_array_test.py
+++ b/saiunit/custom_array_test.py
@@ -733,3 +733,103 @@ class TestCustomArrayBackendMethods:
         np.testing.assert_array_equal(
             np.asarray(r), np.array([1, 256], dtype=np.int32).byteswap()
         )
+
+
+# =========================================================================
+# CustomArray pytree reconstruction
+# =========================================================================
+
+@jax.tree_util.register_pytree_node_class
+class _PytreeArray(u.CustomArray):
+    """Registered plain CustomArray subclass for pytree round-trip tests."""
+
+    def __init__(self, value):
+        self.data = value
+
+
+class TestCustomArrayPytree:
+    """Pytree flatten/unflatten behaviour for CustomArray subclasses.
+
+    ``CustomArray`` is a generic base: its ``tree_unflatten`` routes through
+    the subclass ``__init__`` (via ``cls(*flat_contents)``) so that subclasses
+    whose construction is non-trivial are reconstructed correctly. The most
+    important such case is a ``brainstate.State``-backed subclass, whose
+    ``data`` is a property that requires ``State`` internals established in
+    ``__init__`` -- bypassing it with ``object.__new__`` would break the
+    setter. These tests lock in the generic round-trip (including
+    framework-supplied placeholder leaves) and the ``State``-backed path.
+    """
+
+    def test_tree_flatten_structure(self):
+        arr = _PytreeArray(jnp.array([1.0, 2.0, 3.0]))
+        children, aux = arr.tree_flatten()
+        assert aux is None
+        assert len(children) == 1
+
+    def test_flatten_unflatten_roundtrip(self):
+        arr = _PytreeArray(jnp.array([1.0, 2.0, 3.0]))
+        leaves, treedef = jax.tree_util.tree_flatten(arr)
+        arr2 = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert isinstance(arr2, _PytreeArray)
+        np.testing.assert_array_equal(arr2.data, arr.data)
+
+    def test_tree_unflatten_accepts_string_placeholder_leaf(self):
+        # JAX feeds non-array placeholders (e.g. ShapedArray.str_short()
+        # strings) through tree_unflatten when inspecting/rendering structure.
+        # A plain CustomArray subclass has no validation guard, so these must
+        # round-trip verbatim rather than raise.
+        arr = _PytreeArray.tree_unflatten(None, ("f32[3]",))
+        assert isinstance(arr, _PytreeArray)
+        assert arr.data == "f32[3]"
+
+    def test_tree_unflatten_returns_subclass_instance(self):
+        arr = _PytreeArray.tree_unflatten(None, (jnp.array([1.0]),))
+        assert isinstance(arr, _PytreeArray)
+
+    def test_jit_identity_preserves_type(self):
+        # A jitted function returning the pytree reconstructs the output via
+        # tree_unflatten.
+        arr = _PytreeArray(jnp.array([1.0, 2.0, 3.0]))
+        result = jax.jit(lambda x: x)(arr)
+        assert isinstance(result, _PytreeArray)
+        np.testing.assert_array_equal(result.data, arr.data)
+
+    def test_grad_roundtrip(self):
+        arr = _PytreeArray(jnp.array([1.0, 2.0, 3.0]))
+        g = jax.grad(lambda x: jnp.sum(x * x))(arr)
+        assert isinstance(g, _PytreeArray)
+        np.testing.assert_array_equal(g.data, jnp.array([2.0, 4.0, 6.0]))
+
+    def test_vmap_identity_roundtrip(self):
+        arr = _PytreeArray(jnp.arange(6.0).reshape(3, 2))
+        result = jax.vmap(lambda x: x)(arr)
+        assert isinstance(result, _PytreeArray)
+        np.testing.assert_array_equal(result.data, arr.data)
+
+    def test_eval_shape_roundtrip(self):
+        arr = _PytreeArray(jnp.array([1.0, 2.0, 3.0]))
+        out = jax.eval_shape(lambda x: x, arr)
+        assert isinstance(out, _PytreeArray)
+        assert out.data.shape == (3,)
+
+    def test_tree_map_roundtrip(self):
+        arr = _PytreeArray(jnp.array([1.0, 2.0]))
+        arr2 = jax.tree_util.tree_map(lambda x: x + 1, arr)
+        assert isinstance(arr2, _PytreeArray)
+        np.testing.assert_array_equal(arr2.data, jnp.array([2.0, 3.0]))
+
+    def test_brainstate_state_subclass_still_roundtrips(self):
+        # Regression: State-backed subclasses rely on __init__ running during
+        # reconstruction (the ``data`` property needs State internals). The
+        # base tree_unflatten must keep calling __init__ for them.
+        arr = Array(jnp.array([1.0, 2.0, 3.0]))
+        leaves, treedef = jax.tree_util.tree_flatten(arr)
+        arr2 = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert isinstance(arr2, Array)
+        np.testing.assert_array_equal(arr2.data, arr.data)
+
+    def test_brainstate_state_subclass_grad_roundtrips(self):
+        arr = Array(jnp.array([1.0, 2.0, 3.0]))
+        g = jax.grad(lambda x: jnp.sum(x * x))(arr)
+        assert isinstance(g, Array)
+        np.testing.assert_array_equal(g.data, jnp.array([2.0, 4.0, 6.0]))


### PR DESCRIPTION
## Summary

Maintenance release **v0.5.1**. Hardens JAX pytree reconstruction for the core `Quantity` type and raises the minimum supported Python to 3.11. The public API is unchanged — drop-in upgrade from 0.5.0.

## Changes

### Core: `Quantity`
- **Harden pytree reconstruction against non-array leaves.** `Quantity.tree_unflatten` now rebuilds the instance directly via `object.__new__` instead of routing through `__init__`. JAX legitimately feeds non-array placeholders through `tree_unflatten` when inspecting/rendering tree structure (e.g. the `ShapedArray.str_short()` strings used to build `custom_vjp` structure-mismatch messages); these previously tripped the `str`/`bytes` guard in `__init__` and raised a spurious `TypeError`. Reconstruction now round-trips any leaf, while preserving the single-child invariant and normalising a missing unit to `UNITLESS`.

### CustomArray (intentionally unchanged)
- `CustomArray.tree_unflatten` keeps calling `cls(*flat_contents)`. It is a **generic base**: subclasses — notably `brainstate.State`-backed ones, whose `data` is a property requiring `State` internals established in `__init__` — depend on `__init__` running during reconstruction. Bypassing it with `object.__new__` breaks them. The concrete sparse types (`COO`/`CSR`/`CSC`) already use the direct-construction pattern.

### Packaging
- Raise `requires-python` to `>=3.11`. The `Programming Language :: Python :: 3.10` classifier had already been dropped.
- Bump version to `0.5.1`.

### Tests
- Comprehensive pytree round-trip coverage for `Quantity` and `CustomArray` subclasses — placeholder leaves and `jit`/`grad`/`vmap`/`eval_shape`/`tree_map` paths — plus a `brainstate.State` regression lock.

## Verification
- `mypy saiunit/` → 0 errors
- `pytest saiunit/custom_array_test.py saiunit/_base_quantity_test.py` → 237 passed, 4 skipped

## Summary by Sourcery

Harden JAX pytree reconstruction for the core Quantity type and update project metadata for the 0.5.1 maintenance release.

Bug Fixes:
- Fix Quantity pytree reconstruction so that framework-supplied non-array leaves round-trip correctly without triggering user input guards.

Build:
- Raise the minimum supported Python version to 3.11 in packaging metadata.
- Bump the project version to 0.5.1.

Documentation:
- Add 0.5.1 release notes describing the Quantity pytree changes and updated Python support policy.

Tests:
- Add comprehensive pytree round-trip tests for Quantity covering placeholder leaves and common JAX transform paths.
- Add pytree reconstruction and JAX transform round-trip tests for CustomArray subclasses, including brainstate.State-backed arrays to guard against regressions.